### PR TITLE
Updated links from llnl.github.io -> software.llnl.gov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://scalability-llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ All rights reserved.
 
 This file is part of Conduit. 
 
-For details, see: http://llnl.github.io/conduit/.
+For details, see: http://software.llnl.gov/conduit/.
 
 Please also read conduit/LICENSE
 

--- a/config-build.sh
+++ b/config-build.sh
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/host-configs/Darwin.cmake
+++ b/host-configs/Darwin.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/host-configs/bgqos_0.cmake
+++ b/host-configs/bgqos_0.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/generate_license_cpp_header.py
+++ b/scripts/generate_license_cpp_header.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py-breathe/package.py
+++ b/scripts/uberenv/packages/py-breathe/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py-numpy/package.py
+++ b/scripts/uberenv/packages/py-numpy/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py-sphinx/package.py
+++ b/scripts/uberenv/packages/py-sphinx/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py3-breathe/package.py
+++ b/scripts/uberenv/packages/py3-breathe/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py3-numpy/package.py
+++ b/scripts/uberenv/packages/py3-numpy/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py3-sphinx/package.py
+++ b/scripts/uberenv/packages/py3-sphinx/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/python/package.py
+++ b/scripts/uberenv/packages/python/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/python3/package.py
+++ b/scripts/uberenv/packages/python3/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/uberenv-conduit/package.py
+++ b/scripts/uberenv/packages/uberenv-conduit/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/update_source_license_txt.py
+++ b/scripts/update_source_license_txt.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/BasicChecks.cmake
+++ b/src/CMake/BasicChecks.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/CMakeBasics.cmake
+++ b/src/CMake/CMakeBasics.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/Setup3rdParty.cmake
+++ b/src/CMake/Setup3rdParty.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupDocs.cmake
+++ b/src/CMake/SetupDocs.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupFortran.cmake
+++ b/src/CMake/SetupFortran.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupIncludes.cmake
+++ b/src/CMake/SetupIncludes.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupTests.cmake
+++ b/src/CMake/SetupTests.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/tests/fortran_test_obj_support.f
+++ b/src/CMake/tests/fortran_test_obj_support.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://cyrush.github.io/conduit.
+!* For details, see: http://software.llnl.gov/conduit.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/CMake/thirdparty/FindHDF5.cmake
+++ b/src/CMake/thirdparty/FindHDF5.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/FindNumPy.cmake
+++ b/src/CMake/thirdparty/FindNumPy.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/FindPython.cmake
+++ b/src/CMake/thirdparty/FindPython.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/FindRapidJSON.cmake
+++ b/src/CMake/thirdparty/FindRapidJSON.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/FindSilo.cmake
+++ b/src/CMake/thirdparty/FindSilo.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/FindSphinx.cmake
+++ b/src/CMake/thirdparty/FindSphinx.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/CMakeLists.txt
+++ b/src/docs/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/doxygen/CMakeLists.txt
+++ b/src/docs/doxygen/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/sphinx/CMakeLists.txt
+++ b/src/docs/sphinx/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/sphinx/blueprint.rst
+++ b/src/docs/sphinx/blueprint.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/blueprint_mcarray.rst
+++ b/src/docs/sphinx/blueprint_mcarray.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 
@@ -149,7 +149,7 @@ These files use standard CMake commands. CMake *set* commands need to specify th
 Bootstrapping Thirdparty Dependencies 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use *bootstrap-env.sh* (located at the root of the conduit repo) to help setup your development environment on OSX and Linux. This script uses *scripts/uberenv*, which leverages **Spack** (https://llnl.github.io/spack) to build external thirdparty libraries and tools used by Conduit.
+You can use *bootstrap-env.sh* (located at the root of the conduit repo) to help setup your development environment on OSX and Linux. This script uses *scripts/uberenv*, which leverages **Spack** (http://software.llnl.gov/spack) to build external thirdparty libraries and tools used by Conduit.
 It also writes a initial host-config file for you and adds the Spack built CMake binary to your PATH, so can directly call the *config-build.sh* helper script to configure a conduit build.
 
 .. code:: bash

--- a/src/docs/sphinx/conduit.rst
+++ b/src/docs/sphinx/conduit.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/conduit_api.rst
+++ b/src/docs/sphinx/conduit_api.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/conf.py.in
+++ b/src/docs/sphinx/conf.py.in
@@ -11,7 +11,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/sphinx/developer.rst
+++ b/src/docs/sphinx/developer.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/glossary.rst
+++ b/src/docs/sphinx/glossary.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/index.rst
+++ b/src/docs/sphinx/index.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 
@@ -87,7 +87,7 @@ Conduit Project Resources
 
 **Online Documentation**
 
-http://llnl.github.io/conduit/index.html
+http://software.llnl.gov/conduit/index.html
 
 **Github Source Repo**
 

--- a/src/docs/sphinx/licenses.rst
+++ b/src/docs/sphinx/licenses.rst
@@ -1,52 +1,52 @@
 .. ############################################################################
 .. # Copyright (c) 2014-2015, Lawrence Livermore National Security, LLC.
-.. # 
+.. #
 .. # Produced at the Lawrence Livermore National Laboratory
-.. # 
+.. #
 .. # LLNL-CODE-666778
-.. # 
+.. #
 .. # All rights reserved.
-.. # 
-.. # This file is part of Conduit. 
-.. # 
-.. # For details, see: http://llnl.github.io/conduit/.
-.. # 
+.. #
+.. # This file is part of Conduit.
+.. #
+.. # For details, see: http://software.llnl.gov/conduit/.
+.. #
 .. # Please also read conduit/LICENSE
-.. # 
-.. # Redistribution and use in source and binary forms, with or without 
+.. #
+.. # Redistribution and use in source and binary forms, with or without
 .. # modification, are permitted provided that the following conditions are met:
-.. # 
-.. # * Redistributions of source code must retain the above copyright notice, 
+.. #
+.. # * Redistributions of source code must retain the above copyright notice,
 .. #   this list of conditions and the disclaimer below.
-.. # 
+.. #
 .. # * Redistributions in binary form must reproduce the above copyright notice,
 .. #   this list of conditions and the disclaimer (as noted below) in the
 .. #   documentation and/or other materials provided with the distribution.
-.. # 
+.. #
 .. # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 .. #   be used to endorse or promote products derived from this software without
 .. #   specific prior written permission.
-.. # 
+.. #
 .. # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 .. # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 .. # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 .. # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 .. # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-.. # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+.. # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 .. # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 .. # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-.. # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+.. # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 .. # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-.. # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+.. # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .. # POSSIBILITY OF SUCH DAMAGE.
-.. # 
+.. #
 .. ############################################################################
 
 ================================
 License Info
 ================================
 
-Conduit License 
+Conduit License
 ----------------
 
 .. include:: ../../../LICENSE
@@ -54,9 +54,9 @@ Conduit License
 Third Party Builtin Libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here is a list of the software components used by conduit in source form and the location of their respective license files in our source repo. 
+Here is a list of the software components used by conduit in source form and the location of their respective license files in our source repo.
 
-C and C++ Libraries 
+C and C++ Libraries
 =====================
 - *gpreftools*: thirdparty_builtin/gperftools-2.2.1.tar.gz: gperftools-2.2.1/COPYING (BSD Style License)
 - *gtest*: thirdparty_builtin/gtest-1.7.0/LICENSE (BSD Style License)
@@ -78,7 +78,7 @@ Fortran Libraries
 Build System
 ~~~~~~~~~~~~~~~
 - *CMake*: http://www.cmake.org/licensing/ (BSD Style License)
-- *Spack*: https://llnl.github.io/spack (LGPL License)
+- *Spack*: http://software.llnl.gov/spack (LGPL License)
 
 
 Documentation

--- a/src/docs/sphinx/relay.rst
+++ b/src/docs/sphinx/relay.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_basics.rst
+++ b/src/docs/sphinx/tutorial_basics.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_json.rst
+++ b/src/docs/sphinx/tutorial_json.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_numeric.rst
+++ b/src/docs/sphinx/tutorial_numeric.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_ownership.rst
+++ b/src/docs/sphinx/tutorial_ownership.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_update.rst
+++ b/src/docs/sphinx/tutorial_update.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/user.rst
+++ b/src/docs/sphinx/user.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://llnl.github.io/conduit/.
+.. # For details, see: http://software.llnl.gov/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/blueprint/blueprint.cpp
+++ b/src/libs/blueprint/blueprint.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint.hpp
+++ b/src/libs/blueprint/blueprint.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_exports.hpp
+++ b/src/libs/blueprint/blueprint_exports.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mcarray.cpp
+++ b/src/libs/blueprint/blueprint_mcarray.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mcarray.hpp
+++ b/src/libs/blueprint/blueprint_mcarray.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mcarray_examples.cpp
+++ b/src/libs/blueprint/blueprint_mcarray_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mcarray_examples.hpp
+++ b/src/libs/blueprint/blueprint_mcarray_examples.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mesh.cpp
+++ b/src/libs/blueprint/blueprint_mesh.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mesh.hpp
+++ b/src/libs/blueprint/blueprint_mesh.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/blueprint_mesh_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/blueprint_mesh_examples.hpp
+++ b/src/libs/blueprint/blueprint_mesh_examples.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Bitwidth_Style_Types.h.in
+++ b/src/libs/conduit/Bitwidth_Style_Types.h.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/CMake/BitwidthChecks.cmake
+++ b/src/libs/conduit/CMake/BitwidthChecks.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/Conduit_Config.h.in
+++ b/src/libs/conduit/Conduit_Config.h.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Conduit_Exports.hpp
+++ b/src/libs/conduit/Conduit_Exports.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Core.cpp
+++ b/src/libs/conduit/Core.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Core.hpp
+++ b/src/libs/conduit/Core.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/DataArray.cpp
+++ b/src/libs/conduit/DataArray.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/DataArray.hpp
+++ b/src/libs/conduit/DataArray.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/DataType.cpp
+++ b/src/libs/conduit/DataType.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/DataType.hpp
+++ b/src/libs/conduit/DataType.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Endianness.cpp
+++ b/src/libs/conduit/Endianness.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Endianness.hpp
+++ b/src/libs/conduit/Endianness.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Endianness_Types.h
+++ b/src/libs/conduit/Endianness_Types.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Error.cpp
+++ b/src/libs/conduit/Error.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Error.hpp
+++ b/src/libs/conduit/Error.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Generator.cpp
+++ b/src/libs/conduit/Generator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Generator.hpp
+++ b/src/libs/conduit/Generator.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Node.cpp
+++ b/src/libs/conduit/Node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Node.hpp
+++ b/src/libs/conduit/Node.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/NodeIterator.cpp
+++ b/src/libs/conduit/NodeIterator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/NodeIterator.hpp
+++ b/src/libs/conduit/NodeIterator.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Schema.cpp
+++ b/src/libs/conduit/Schema.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Schema.hpp
+++ b/src/libs/conduit/Schema.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Utils.cpp
+++ b/src/libs/conduit/Utils.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/Utils.hpp
+++ b/src/libs/conduit/Utils.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit.h
+++ b/src/libs/conduit/conduit.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit.hpp
+++ b/src/libs/conduit/conduit.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_node.h
+++ b/src/libs/conduit/conduit_node.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/fortran/Bitwidth_Style_Types.inc.in
+++ b/src/libs/conduit/fortran/Bitwidth_Style_Types.inc.in
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/conduit/fortran/CMakeLists.txt
+++ b/src/libs/conduit/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/fortran/conduit_fortran.F
+++ b/src/libs/conduit/fortran/conduit_fortran.F
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/conduit/fortran/conduit_fortran_obj.f
+++ b/src/libs/conduit/fortran/conduit_fortran_obj.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/conduit/python/CMakeLists.txt
+++ b/src/libs/conduit/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/python/Conduit_Python_Exports.hpp
+++ b/src/libs/conduit/python/Conduit_Python_Exports.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/python/py_src/__init__.py
+++ b/src/libs/conduit/python/py_src/__init__.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/relay.cpp
+++ b/src/libs/relay/relay.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay.hpp
+++ b/src/libs/relay/relay.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_config.hpp.in
+++ b/src/libs/relay/relay_config.hpp.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_exports.hpp
+++ b/src/libs/relay/relay_exports.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_hdf5.cpp
+++ b/src/libs/relay/relay_hdf5.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_hdf5.hpp
+++ b/src/libs/relay/relay_hdf5.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_io.cpp
+++ b/src/libs/relay/relay_io.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_io.hpp
+++ b/src/libs/relay/relay_io.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_mpi.cpp
+++ b/src/libs/relay/relay_mpi.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_mpi.hpp
+++ b/src/libs/relay/relay_mpi.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_silo.cpp
+++ b/src/libs/relay/relay_silo.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_silo.hpp
+++ b/src/libs/relay/relay_silo.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_web.cpp
+++ b/src/libs/relay/relay_web.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_web.hpp
+++ b/src/libs/relay/relay_web.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_web_visualizer.cpp
+++ b/src/libs/relay/relay_web_visualizer.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/relay_web_visualizer.hpp
+++ b/src/libs/relay/relay_web_visualizer.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/web_clients/rest_client/index.html
+++ b/src/libs/relay/web_clients/rest_client/index.html
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/launcher.js
+++ b/src/libs/relay/web_clients/rest_client/resources/launcher.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/search-table.js
+++ b/src/libs/relay/web_clients/rest_client/resources/search-table.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/tree.js
+++ b/src/libs/relay/web_clients/rest_client/resources/tree.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/treemap.js
+++ b/src/libs/relay/web_clients/rest_client/resources/treemap.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/value-table.js
+++ b/src/libs/relay/web_clients/rest_client/resources/value-table.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/visualizer-utils.js
+++ b/src/libs/relay/web_clients/rest_client/resources/visualizer-utils.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/resources/visualizer.js
+++ b/src/libs/relay/web_clients/rest_client/resources/visualizer.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/rest_client/visualizer.css
+++ b/src/libs/relay/web_clients/rest_client/visualizer.css
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/wsock_test/index.html
+++ b/src/libs/relay/web_clients/wsock_test/index.html
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/wsock_test/resources/wsock_test.js
+++ b/src/libs/relay/web_clients/wsock_test/resources/wsock_test.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/blueprint/CMakeLists.txt
+++ b/src/tests/blueprint/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/CMakeLists.txt
+++ b/src/tests/conduit/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/c/CMakeLists.txt
+++ b/src/tests/conduit/c/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/c/t_c_conduit_node.cpp
+++ b/src/tests/conduit/c/t_c_conduit_node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/c/t_c_conduit_node_set.cpp
+++ b/src/tests/conduit/c/t_c_conduit_node_set.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/fortran/CMakeLists.txt
+++ b/src/tests/conduit/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/fortran/t_f_conduit_node.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_conduit_node_obj.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node_obj.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_type_sizes.f
+++ b/src/tests/conduit/fortran/t_f_type_sizes.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/python/CMakeLists.txt
+++ b/src/tests/conduit/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_datatype.py
+++ b/src/tests/conduit/python/t_python_conduit_datatype.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_generator.py
+++ b/src/tests/conduit/python/t_python_conduit_generator.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_node.py
+++ b/src/tests/conduit/python/t_python_conduit_node.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_node_iterator.py
+++ b/src/tests/conduit/python/t_python_conduit_node_iterator.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_schema.py
+++ b/src/tests/conduit/python/t_python_conduit_schema.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_smoke.py
+++ b/src/tests/conduit/python/t_python_conduit_smoke.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/t_conduit_array.cpp
+++ b/src/tests/conduit/t_conduit_array.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_char8_str.cpp
+++ b/src/tests/conduit/t_conduit_char8_str.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_datatype_tests.cpp
+++ b/src/tests/conduit/t_conduit_datatype_tests.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_endianness.cpp
+++ b/src/tests/conduit/t_conduit_endianness.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_generator.cpp
+++ b/src/tests/conduit/t_conduit_generator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_json_sanitize.cpp
+++ b/src/tests/conduit/t_conduit_json_sanitize.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_list_of.cpp
+++ b/src/tests/conduit/t_conduit_list_of.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node.cpp
+++ b/src/tests/conduit/t_conduit_node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_binary_io.cpp
+++ b/src/tests/conduit/t_conduit_node_binary_io.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_compact.cpp
+++ b/src/tests/conduit/t_conduit_node_compact.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_convert.cpp
+++ b/src/tests/conduit/t_conduit_node_convert.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_info.cpp
+++ b/src/tests/conduit/t_conduit_node_info.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_iterator.cpp
+++ b/src/tests/conduit/t_conduit_node_iterator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_parent.cpp
+++ b/src/tests/conduit/t_conduit_node_parent.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_paths.cpp
+++ b/src/tests/conduit/t_conduit_node_paths.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_save_load.cpp
+++ b/src/tests/conduit/t_conduit_node_save_load.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_set.cpp
+++ b/src/tests/conduit/t_conduit_node_set.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_to_value.cpp
+++ b/src/tests/conduit/t_conduit_node_to_value.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_update.cpp
+++ b/src/tests/conduit/t_conduit_node_update.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_serialize.cpp
+++ b/src/tests/conduit/t_conduit_serialize.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_smoke.cpp
+++ b/src/tests/conduit/t_conduit_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_to_string.cpp
+++ b/src/tests/conduit/t_conduit_to_string.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_utils.cpp
+++ b/src/tests/conduit/t_conduit_utils.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/docs/CMakeLists.txt
+++ b/src/tests/docs/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/docs/t_conduit_tutorial_examples.cpp
+++ b/src/tests/docs/t_conduit_tutorial_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/CMakeLists.txt
+++ b/src/tests/relay/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/t_relay_io_basic.cpp
+++ b/src/tests/relay/t_relay_io_basic.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_io_hdf5.cpp
+++ b/src/tests/relay/t_relay_io_hdf5.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_mpi_smoke.cpp
+++ b/src/tests/relay/t_relay_mpi_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_rest.cpp
+++ b/src/tests/relay/t_relay_rest.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_smoke.cpp
+++ b/src/tests/relay/t_relay_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_websocket.cpp
+++ b/src/tests/relay/t_relay_websocket.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/t_config.hpp.in
+++ b/src/tests/t_config.hpp.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/CMakeLists.txt
+++ b/src/tests/thirdparty/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/thirdparty/t_fortran_smoke.f
+++ b/src/tests/thirdparty/t_fortran_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/thirdparty/t_fruit_smoke.f
+++ b/src/tests/thirdparty/t_fruit_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://llnl.github.io/conduit/.
+!* For details, see: http://software.llnl.gov/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/thirdparty/t_gpref_smoke.cpp
+++ b/src/tests/thirdparty/t_gpref_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_gtest_smoke.cpp
+++ b/src/tests/thirdparty/t_gtest_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_hdf5_smoke.cpp
+++ b/src/tests/thirdparty/t_hdf5_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_libb64_smoke.cpp
+++ b/src/tests/thirdparty/t_libb64_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_mpi_smoke.cpp
+++ b/src/tests/thirdparty/t_mpi_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_numpy_smoke.cpp
+++ b/src/tests/thirdparty/t_numpy_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_rapidjson_smoke.cpp
+++ b/src/tests/thirdparty/t_rapidjson_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_silo_smoke.cpp
+++ b/src/tests/thirdparty/t_silo_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/thirdparty_builtin/civetweb/CMakeLists.txt
+++ b/src/thirdparty_builtin/civetweb/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/thirdparty_builtin/fruit-3.3.9/CMakeLists.txt
+++ b/src/thirdparty_builtin/fruit-3.3.9/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/thirdparty_builtin/fruit-3.3.9/gtest_fortran_driver.cpp
+++ b/src/thirdparty_builtin/fruit-3.3.9/gtest_fortran_driver.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://llnl.github.io/conduit/.
+// For details, see: http://software.llnl.gov/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/thirdparty_builtin/gperftools-2.2.1/CMakeLists.txt
+++ b/src/thirdparty_builtin/gperftools-2.2.1/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
+++ b/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://llnl.github.io/conduit/.
+# For details, see: http://software.llnl.gov/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 


### PR DESCRIPTION
Updated `<LLNL related>.github.io` -> `software.llnl.gov`