### PR TITLE
enh: add python module install path option

### DIFF
--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -108,6 +108,7 @@ Conduit's build system supports the following CMake options:
  The Conduit Python module will build for both Python 2 and Python 3. To select a specific Python, set the CMake variable **PYTHON_EXECUTABLE** to path of the desired python binary. The Conduit Python module requires Numpy. The selected Python instance must provide Numpy, or PYTHONPATH must be set to include a Numpy install compatible with the selected Python install. 
 
 * **ENABLE_MPI** - Controls if the conduit_relay_mpi library is built. *(default = OFF)*
+
  We are using CMake's standard FindMPI logic. To select a specific MPI set the CMake variables **MPI_C_COMPILER** and **MPI_CXX_COMPILER**, or the other FindMPI options for MPI include paths and MPI libraries.
 
  To run the mpi unit tests on LLNL's LC platforms, you may also need change the CMake variables **MPIEXEC** and **MPIEXEC_NUMPROC_FLAG**, so you can use srun and select a partition. (for an example see: src/host-configs/chaos_5_x86_64.cmake)
@@ -119,6 +120,17 @@ Conduit's build system supports the following CMake options:
  Controls if Silo I/O support is built into *conduit_relay*. When used, the following CMake variables must also be set:
  
  * **HDF5_DIR** - Path to a HDF5 install. (Silo support depends on HDF5) 
+
+Installation Path Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Conduit's build system provides an **install** target that installs the Conduit libraires, headers, python modules, and documentation. These CMake options allow you to control install destination paths:
+
+* **CMAKE_INSTALL_PREFIX** - Standard CMake install path option *(optional)*.
+
+* **PYTHON_MODULE_INSTALL_PREFIX** - Path to install Python modules into *(optional)*.
+
+ When present and **ENABLE_PYTHON** is ON, Conduit's Python modules will be installed to ``${PYTHON_MODULE_INSTALL_PREFIX}`` directory instead of ``${CMAKE_INSTALL_PREFIX}/python-modules``.
+
 
 Host Config Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/libs/conduit/python/CMakeLists.txt
+++ b/src/libs/conduit/python/CMakeLists.txt
@@ -63,4 +63,10 @@ PYTHON_ADD_HYBRID_MODULE(conduit_python
 target_link_libraries(conduit_python conduit)
 
 # install the capi header so other python modules can use it
-install(FILES ${conduit_py_headers} DESTINATION python-modules/conduit/)
+# support alt install dir for python module via PYTHON_MODULE_INSTALL_PREFIX
+if(PYTHON_MODULE_INSTALL_PREFIX)
+    install(FILES ${conduit_py_headers} DESTINATION ${PYTHON_MODULE_INSTALL_PREFIX}/conduit/)
+else()
+    install(FILES ${conduit_py_headers} DESTINATION python-modules/conduit/)
+endif()
+

--- a/src/libs/relay/python/CMakeLists.txt
+++ b/src/libs/relay/python/CMakeLists.txt
@@ -45,7 +45,9 @@
 
 # Setup our modules
 PYTHON_ADD_HYBRID_MODULE(relay_python
+                         # dest dir
                          python-modules
+                         # python module dir
                          conduit/relay
                          # python setup
                          setup.py
@@ -59,8 +61,10 @@ target_link_libraries(relay_python conduit conduit_relay ${PYTHON_LIBRARIES})
 
 # add relay io submodule
 PYTHON_ADD_COMPILED_MODULE(relay_io_python
-                           # dest 
-                           python-modules/conduit/relay/io
+                           # dest_dir 
+                           python-modules
+                           # python module dir
+                           conduit/relay/io
                            # c srcs
                            relay_io_python.cpp)
 
@@ -72,7 +76,9 @@ target_link_libraries(relay_io_python conduit conduit_relay)
 # add relay web submodule
 PYTHON_ADD_COMPILED_MODULE(relay_web_python
                            # dest 
-                           python-modules/conduit/relay/web
+                           python-modules
+                           # python module dir
+                           conduit/relay/web
                            # c srcs
                            relay_web_python.cpp)
 


### PR DESCRIPTION
Added PYTHON_MODULE_INSTALL_PREFIX CMake option for specifying
the destination path for the python modules.

This will resolve GitHub Issue #17 