### PR TITLE
enh: rename b64 and civetweb targets and libs

### DIFF
--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -123,7 +123,7 @@ add_compiled_library(NAME   conduit
 # libb64 is a private dep, its not exposed in / required by
 # conduit's header files
 #
-target_link_libraries(conduit PRIVATE libb64)
+target_link_libraries(conduit PRIVATE conduit_b64)
 
 ################################
 # Add python wrappers if python

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -118,7 +118,7 @@ target_link_libraries(conduit_relay PUBLIC conduit)
 # civetweb is a private dep, its not exposed in / required by
 # conduit relays' header files
 #
-target_link_libraries(conduit_relay PRIVATE civetweb)
+target_link_libraries(conduit_relay PRIVATE conduit_civetweb)
 
 
 #

--- a/src/tests/conduit/CMakeLists.txt
+++ b/src/tests/conduit/CMakeLists.txt
@@ -81,7 +81,7 @@ set(BASIC_TESTS t_conduit_smoke
 ################################
 message(STATUS "Adding conduit lib unit tests")
 foreach(TEST ${BASIC_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit libb64 )
+    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit)
 endforeach()
 
 ################################

--- a/src/tests/conduit/c/CMakeLists.txt
+++ b/src/tests/conduit/c/CMakeLists.txt
@@ -58,7 +58,7 @@ set(BASIC_C_TESTS
 ################################
 message(STATUS "Adding conduit lib c interface unit tests")
 foreach(TEST ${BASIC_C_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit libb64 )
+    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit )
 endforeach()
 
 

--- a/src/tests/docs/CMakeLists.txt
+++ b/src/tests/docs/CMakeLists.txt
@@ -57,7 +57,7 @@ set(DOCS_TESTS t_conduit_tutorial_examples)
 ################################
 message(STATUS "Adding docs related unit tests")
 foreach(TEST ${DOCS_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit libb64 )
+    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit )
 endforeach()
 
 

--- a/src/tests/thirdparty/CMakeLists.txt
+++ b/src/tests/thirdparty/CMakeLists.txt
@@ -50,9 +50,10 @@
 # Core (conduit lib) Unit Tests
 ################################
 set(TPL_TESTS t_gtest_smoke
-              t_rapidjson_smoke
-              t_libb64_smoke)
+              t_rapidjson_smoke)
 
+set(B64_TPL_TEST   t_libb64_smoke)
+set(CIVET_TPL_TEST t_civetweb_smoke)
 
 ################################
 # Optional Unit Tests
@@ -70,7 +71,17 @@ set(FORTRAN_TESTS t_fortran_smoke t_fruit_smoke)
 ################################
 message(STATUS "Adding thirdparty lib unit tests")
 foreach(TEST ${TPL_TESTS})
-    add_cpp_test(TEST ${TEST} DEPENDS_ON libb64 )
+    add_cpp_test(TEST ${TEST} DEPENDS_ON)
+endforeach()
+
+message(STATUS "Adding b64 unit test")
+foreach(TEST ${B64_TPL_TEST})
+    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit_b64 )
+endforeach()
+
+message(STATUS "Adding civetweb unit test")
+foreach(TEST ${CIVET_TPL_TEST})
+    add_cpp_test(TEST ${TEST} DEPENDS_ON conduit_civetweb )
 endforeach()
 
 

--- a/src/tests/thirdparty/t_civetweb_smoke.cpp
+++ b/src/tests/thirdparty/t_civetweb_smoke.cpp
@@ -44,39 +44,34 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: t_libb64_smoke.cpp
+/// file: t_civetweb_smoke.cpp
 ///
 //-----------------------------------------------------------------------------
 
-#include <iostream>
 #include "gtest/gtest.h"
-#define BUFFERSIZE 65536
-#include "b64/encode.h"
-#include "b64/decode.h"
 
-TEST(libb64_smoke, basic_use )
+//-----------------------------------------------------------------------------
+// civetweb includes
+//-----------------------------------------------------------------------------
+#include "civetweb.h"
+
+//-----------------------------------------------------------------------------
+//
+// Note: This just tests that we can compile and link with civetweb, it 
+// does not start a web server
+//
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+int
+dummy_civetweb_handler(struct mg_connection *conn, void *cbdata)
 {
-    std::string sin("test");
-    
-    std::istringstream iss(sin);
-    std::ostringstream oss;
+	mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n");
+    return 0;
+}
 
-    base64::encoder e;
-    e.encode(iss,oss);
-    
-    std::cout << oss.str() << std::endl;
-    std::string sout = oss.str();
-    
-    
-    
-    iss.str(sout);
-    iss.clear();
-    oss.str("");
-
-    base64::decoder d;
-
-    d.decode(iss,oss);
-    
-    EXPECT_EQ(oss.str(),sin);
+TEST(civetweb_smoke, basic_use )
+{
+    EXPECT_TRUE(true);
 }
 

--- a/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
+++ b/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
@@ -66,7 +66,7 @@ add_definitions(-DUSE_WEBSOCKET)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 
-add_compiled_library(NAME   civetweb
+add_compiled_library(NAME   conduit_civetweb
                      INTERNAL
                      EXPORT conduit
                      HEADERS ${civetweb_headers}

--- a/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
+++ b/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
@@ -79,7 +79,7 @@ add_compiled_library(NAME   conduit_civetweb
 if(UNIX AND NOT APPLE)
     # we need these on linux, we may need similar libs on windows 
     # (OSX appears ok without them)
-    target_link_libraries(civetweb dl rt)
+    target_link_libraries(conduit_civetweb dl rt)
 endif()
 
 

--- a/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
+++ b/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
@@ -58,7 +58,7 @@ set(libb64_sources
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 
-add_compiled_library(NAME   libb64
+add_compiled_library(NAME conduit_b64
                      INTERNAL
                      EXPORT conduit
                      SOURCES ${libb64_sources})


### PR DESCRIPTION
to avoid potential conflicts for system installs:

renamed b64 to conduit_b64
renamed civetweb to conduit_civetweb

These are only used internally, but are always installed -- due
to github issue #16 

This will resolve #18 