### PR TITLE
uberenv: defensive tweaks to mpich and py packages

### DIFF
--- a/scripts/uberenv/packages/mpich/package.py
+++ b/scripts/uberenv/packages/mpich/package.py
@@ -33,12 +33,16 @@ class Mpich(Package):
     list_url   = "http://www.mpich.org/static/downloads/"
     list_depth = 2
 
-    version('3.2',   'f414cfa77099cd1fa1a5ae4e22db508a')
-    version('3.1.4', '2ab544607986486562e076b83937bba2')
-    version('3.1.3', '93cb17f91ac758cbf9174ecb03563778')
-    version('3.1.2', '7fbf4b81dcb74b07ae85939d1ceee7f1')
-    version('3.1.1', '40dc408b1e03cc36d80209baaa2d32b7')
-    version('3.1',   '5643dd176499bfb7d25079aaff25f2ec')
+    #
+    # Rolled back to mpich 3.0.4 b/c on 7/29/2015 the other
+    # mpich source tarballs disappeared from the mpich website 
+    #
+    #version('3.2',   'f414cfa77099cd1fa1a5ae4e22db508a')
+    #version('3.1.4', '2ab544607986486562e076b83937bba2')
+    #version('3.1.3', '93cb17f91ac758cbf9174ecb03563778')
+    #version('3.1.2', '7fbf4b81dcb74b07ae85939d1ceee7f1')
+    #version('3.1.1', '40dc408b1e03cc36d80209baaa2d32b7')
+    #version('3.1',   '5643dd176499bfb7d25079aaff25f2ec')
     version('3.0.4', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
 
     variant('verbs', default=False, description='Build support for OpenFabrics verbs.')

--- a/scripts/uberenv/packages/python/package.py
+++ b/scripts/uberenv/packages/python/package.py
@@ -90,7 +90,7 @@ class Python(Package):
         if spec.satisfies('@3:'):
             configure_args.append('--without-ensurepip')
         configure(*configure_args)
-        make()
+        make(parallel=False)
         make("install")
 
         # Modify compiler paths in configuration files. This is necessary for

--- a/scripts/uberenv/packages/python3/package.py
+++ b/scripts/uberenv/packages/python3/package.py
@@ -85,7 +85,7 @@ class Python3(Package):
         if spec.satisfies('@3:'):
             configure_args.append('--without-ensurepip')
         configure(*configure_args)
-        make()
+        make(parallel=False)
         make("install")
 
         # Modify compiler paths in configuration files. This is necessary for


### PR DESCRIPTION
* roll back to earlier mpich version

The 3.2 version source disappeared from mpich's website,
though it's back online we don't have any pressing need
for the newer version.

* avoid make -j builds by spack for  python2 and python3