### PR TITLE
enh: add Schema::child_name(idx)

### DIFF
--- a/src/libs/conduit/Schema.cpp
+++ b/src/libs/conduit/Schema.cpp
@@ -783,6 +783,24 @@ Schema::child_index(const std::string &path) const
 }
 
 //---------------------------------------------------------------------------//
+std::string
+Schema::child_name(index_t idx) const
+{
+    std::string res = "";
+
+    if(m_dtype.id() == DataType::OBJECT_ID)
+    {
+        const std::vector<std::string> &obj_order = object_order();
+        if( idx < obj_order.size())
+        {
+            res = obj_order[idx];
+        }
+    }
+
+    return res;
+}
+
+//---------------------------------------------------------------------------//
 Schema &
 Schema::fetch(const std::string &path)
 {

--- a/src/libs/conduit/Schema.hpp
+++ b/src/libs/conduit/Schema.hpp
@@ -256,6 +256,11 @@ public:
     /// path to index map
     index_t          child_index(const std::string &path) const;
 
+    /// index to path map
+    /// returns an empty string when passed index is invalid, or 
+    /// this schema does not describe an object.
+    std::string      child_name(index_t idx) const;
+
     /// this uses the fetch method
     Schema           &operator[](const std::string &path);
     /// the const variant uses the "fetch_child" method

--- a/src/tests/conduit/t_conduit_schema.cpp
+++ b/src/tests/conduit/t_conduit_schema.cpp
@@ -183,6 +183,29 @@ TEST(schema_basics, schema_alloc)
 }
 
 //-----------------------------------------------------------------------------
+TEST(schema_basics, schema_name_by_index)
+{
+    Schema s1;
+    s1["a"].set(DataType::int64());
+    s1["b"].set(DataType::float64());
+    s1["c"].set(DataType::float64());
+    
+    // standard case
+    EXPECT_EQ(s1.child_name(0),"a");
+    EXPECT_EQ(s1.child_name(1),"b");
+    EXPECT_EQ(s1.child_name(2),"c");
+
+    // these are out of bounds, should be empty
+    EXPECT_EQ(s1.child_name(100),"");
+    EXPECT_EQ(s1["a"].child_name(100),"");
+    
+    Schema s2;
+    // check empty schema
+    EXPECT_EQ(s2.child_name(100),"");
+}
+
+
+//-----------------------------------------------------------------------------
 ///
 /// commented out b/c spanned_bytes is now private, 
 /// keeping if useful in future


### PR DESCRIPTION
if the Schema represents an object, this method
allows you to get a child's name by index.

if the Schema is not an object, or the index is bad
it returns an empty string.

This commit resolves #13.