### PR TITLE
enh: install headers to subdir include/conduit

### DIFF
--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -77,7 +77,8 @@ set(blueprint_sources
 add_compiled_library(NAME conduit_blueprint
                      EXPORT conduit
                      HEADERS ${blueprint_headers}
-                     SOURCES ${blueprint_sources})
+                     SOURCES ${blueprint_sources}
+                     HEADERS_DEST_DIR include/conduit)
 
 
 #

--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -117,7 +117,7 @@ add_compiled_library(NAME   conduit
                      EXPORT conduit
                      HEADERS ${conduit_headers} ${conduit_c_headers}
                      SOURCES ${conduit_sources} ${conduit_c_sources}
-                     )
+                     HEADERS_DEST_DIR include/conduit)
 
 #
 # libb64 is a private dep, its not exposed in / required by

--- a/src/libs/conduit/fortran/CMakeLists.txt
+++ b/src/libs/conduit/fortran/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 # Setup install to copy the fortran modules 
 install(FILES 
         ${conduit_fortran_modules}
-        DESTINATION include)
+        DESTINATION include/conduit)
 
 
 

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -107,7 +107,8 @@ endif()
 add_compiled_library(NAME conduit_relay
                      EXPORT conduit
                      HEADERS ${conduit_relay_headers}
-                     SOURCES ${conduit_relay_sources})
+                     SOURCES ${conduit_relay_sources}
+                     HEADERS_DEST_DIR include/conduit)
 
 #
 # Link with conduit 
@@ -167,7 +168,8 @@ include_directories(${MPI_CXX_INCLUDE_PATH})
 add_compiled_library(NAME conduit_relay_mpi 
                      EXPORT conduit
                      HEADERS ${conduit_relay_mpi_headers}
-                     SOURCES ${conduit_relay_mpi_sources} )
+                     SOURCES ${conduit_relay_mpi_sources}
+                     HEADERS_DEST_DIR include/conduit)
 
 
 #

--- a/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
+++ b/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
@@ -70,7 +70,8 @@ add_compiled_library(NAME   conduit_civetweb
                      INTERNAL
                      EXPORT conduit
                      HEADERS ${civetweb_headers}
-                     SOURCES ${civetweb_sources})
+                     SOURCES ${civetweb_sources}
+                     HEADERS_DEST_DIR include/conduit)
 
 ##################################
 # system dependencies for civetweb

--- a/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
+++ b/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
@@ -55,11 +55,19 @@ set(libb64_sources
     src/cencode.c
     )
 
+set(libb64_headers
+    include/b64/cdecode.h
+    include/b64/cencode.h
+    include/b64/decode.h
+    include/b64/encode.h)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 
 add_compiled_library(NAME conduit_b64
                      INTERNAL
                      EXPORT conduit
-                     SOURCES ${libb64_sources})
+                     SOURCES ${libb64_sources}
+                     HEADERS ${libb64_headers}
+                     HEADERS_DEST_DIR include/conduit)
 


### PR DESCRIPTION
to avoid potential conflicts during system installs

this resolves #24 