### PR TITLE
enh: added examples of using installed conduit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build-release-xcode/
 install-debug/
 install-release/
 .DS_Store
+src/examples/using-with-cmake/build
+src/examples/using-with-make/example
 temp.cpp
 temp.exe
 *.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ script:
   # using with make example
   - cd ${TRAVIS_BUILD_DIR}/src/examples/using-with-make
   - env CXX=${CONDUIT_CXX} CONDUIT_DIR=${TRAVIS_BUILD_DIR}/travis-debug-install make
-  - ./example
+  - env LD_LIBRARY_PATH=${TRAVIS_BUILD_DIR}/travis-debug-install/lib/ ./example
   
 after_success:
   - coveralls --gcov /usr/bin/gcov-4.8 --include src/libs/conduit  --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR --build-root $TRAVIS_BUILD_DIR/travis-debug-build;

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,19 @@ script:
   - make
   - make test
   - make install
+  # test our examples that demo using an installed conduit
+  # using with cmake example
+  - cd ${TRAVIS_BUILD_DIR}/src/examples/using-with-cmake
+  - mkdir build
+  - cd build
+  - cmake -DCONDUIT_DIR=${TRAVIS_BUILD_DIR}/travis-debug-install ../
+  - make
+  - ./example
+  # using with make example
+  - cd ${TRAVIS_BUILD_DIR}/src/examples/using-with-make
+  - env CXX=${CONDUIT_CXX} CONDUIT_DIR=${TRAVIS_BUILD_DIR}/travis-debug-install make
+  - ./example
+  
 after_success:
   - coveralls --gcov /usr/bin/gcov-4.8 --include src/libs/conduit  --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR --build-root $TRAVIS_BUILD_DIR/travis-debug-build;
 notifications:

--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -114,9 +114,11 @@ Conduit's build system supports the following CMake options:
  To run the mpi unit tests on LLNL's LC platforms, you may also need change the CMake variables **MPIEXEC** and **MPIEXEC_NUMPROC_FLAG**, so you can use srun and select a partition. (for an example see: src/host-configs/chaos_5_x86_64.cmake)
 
 * **HDF5_DIR** - Path to a HDF5 install *(optional)*. 
+
  Controls if HDF5 I/O support is built into *conduit_relay*.
 
 * **SILO_DIR** - Path to a Silo install *(optional)*. 
+
  Controls if Silo I/O support is built into *conduit_relay*. When used, the following CMake variables must also be set:
  
  * **HDF5_DIR** - Path to a HDF5 install. (Silo support depends on HDF5) 
@@ -203,5 +205,16 @@ Building with Spack
   For example, we build independent installs of Python 2 and Python 3 to make it easy 
   to check Python C-API compatibility during development. In the near future, we plan to 
   provide a Spack package to simplify deployment.
+
+
+
+Using Conduit in Another Project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Under ``src/examples``, you can find examples demonstrating how to use Conduit in a CMake-based build system (``using-with-cmake``) and via a Makefile (``using-with-make``).
+
+
+
+
 
 

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -1,0 +1,78 @@
+###############################################################################
+# Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+# 
+# Produced at the Lawrence Livermore National Laboratory
+# 
+# LLNL-CODE-666778
+# 
+# All rights reserved.
+# 
+# This file is part of Conduit. 
+# 
+# For details, see https://lc.llnl.gov/conduit/.
+# 
+# Please also read conduit/LICENSE
+# 
+# Redistribution and use in source and binary forms, with or without 
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, 
+#   this list of conditions and the disclaimer below.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the
+#   documentation and/or other materials provided with the distribution.
+# 
+# * Neither the name of the LLNS/LLNL nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+# LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# POSSIBILITY OF SUCH DAMAGE.
+# 
+###############################################################################
+#
+# Example that shows how to use an installed instance of Conduit in another
+# CMake-based build system.
+#
+# To build:
+#  mkdir build
+#  cd build
+#  cmake -DCONDUIT_DIR={conduit install path} ../
+#  make
+#  ./example
+#
+#
+# Note:
+#  If you use features that leverage external third party libraries 
+#  (ex: relay hdf5 features), the imported CMake targets will handle linking 
+#  these libraries, however you may need to add additional include
+#  include directories to use their headers. 
+# 
+###############################################################################
+
+cmake_minimum_required(VERSION 3.0)
+
+project(using_with_cmake)
+
+include("FindConduit.cmake")
+
+# setup the conduit include path
+include_directories(${CONDUIT_INCLUDE_DIRS})
+
+# create our example 
+add_executable(example example.cpp)
+
+# link to conduit targets
+target_link_libraries(example conduit conduit_relay conduit_blueprint)
+

--- a/src/examples/using-with-cmake/FindConduit.cmake
+++ b/src/examples/using-with-cmake/FindConduit.cmake
@@ -1,0 +1,90 @@
+###############################################################################
+# Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+# 
+# Produced at the Lawrence Livermore National Laboratory
+# 
+# LLNL-CODE-666778
+# 
+# All rights reserved.
+# 
+# This file is part of Conduit. 
+# 
+# For details, see https://lc.llnl.gov/conduit/.
+# 
+# Please also read conduit/LICENSE
+# 
+# Redistribution and use in source and binary forms, with or without 
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, 
+#   this list of conditions and the disclaimer below.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the
+#   documentation and/or other materials provided with the distribution.
+# 
+# * Neither the name of the LLNS/LLNL nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+# LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# POSSIBILITY OF SUCH DAMAGE.
+# 
+###############################################################################
+#
+# Setup Conduit
+#
+###############################################################################
+#
+#  Expects CONDUIT_DIR to point to a Conduit installations.
+#
+# This file defines the following CMake variables:
+#  CONDUIT_FOUND - If Conduit was found
+#  CONDUIT_INCLUDE_DIRS - The Conduit include directories
+#
+#  If found, the conduit CMake targets will also be imported.
+#  The main conduit library targets are:
+#   conduit
+#   conduit_relay
+#   conduit_relay_mpi (if conduit was built with mpi support)
+#   conduit_blueprint
+#
+###############################################################################
+
+###############################################################################
+# Check for CONDUIT_DIR
+###############################################################################
+if(NOT CONDUIT_DIR)
+    MESSAGE(FATAL_ERROR "Could not find Conduit. Conduit requires explicit CONDUIT_DIR.")
+endif()
+
+if(NOT EXISTS ${CONDUIT_DIR}/lib/cmake/conduit.cmake)
+    MESSAGE(FATAL_ERROR "Could not find Conduit CMake include file (${CONDUIT_DIR}/lib/cmake/conduit.cmake)")
+endif()
+
+###############################################################################
+# Import Conduit's CMake targets
+###############################################################################
+include(${CONDUIT_DIR}/lib/cmake/conduit.cmake)
+
+###############################################################################
+# Set remaning CMake variables 
+###############################################################################
+# we found Conduit
+set(CONDUIT_FOUND TRUE)
+# provide location of the headers in CONDUIT_INCLUDE_DIRS
+set(CONDUIT_INCLUDE_DIRS ${CONDUIT_DIR}/include/conduit)
+
+
+
+

--- a/src/examples/using-with-cmake/example.cpp
+++ b/src/examples/using-with-cmake/example.cpp
@@ -1,0 +1,65 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: example.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include <iostream>
+
+#include "conduit.hpp"
+#include "relay.hpp"
+#include "blueprint.hpp"
+
+
+int main(int argc, char **argv)
+{
+    std::cout << conduit::about() << std::endl
+              << conduit::relay::about() << std::endl
+              << conduit::blueprint::about() << std::endl;
+}
+
+

--- a/src/examples/using-with-make/Makefile
+++ b/src/examples/using-with-make/Makefile
@@ -62,6 +62,6 @@ INC_FLAGS=-I$(CONDUIT_DIR)/include/conduit
 LINK_FLAGS=-L$(CONDUIT_DIR)/lib/ -lconduit -lconduit_relay -lconduit_blueprint
 
 main:
-	$(CXX) $(INC_FLAGS) $(LINK_FLAGS) example.cpp  -o example
+	$(CXX) $(INC_FLAGS) example.cpp $(LINK_FLAGS) -o example
 
 

--- a/src/examples/using-with-make/Makefile
+++ b/src/examples/using-with-make/Makefile
@@ -1,0 +1,67 @@
+###############################################################################
+# Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+# 
+# Produced at the Lawrence Livermore National Laboratory
+# 
+# LLNL-CODE-666778
+# 
+# All rights reserved.
+# 
+# This file is part of Conduit. 
+# 
+# For details, see https://lc.llnl.gov/conduit/.
+# 
+# Please also read conduit/LICENSE
+# 
+# Redistribution and use in source and binary forms, with or without 
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright notice, 
+#   this list of conditions and the disclaimer below.
+# 
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the disclaimer (as noted below) in the
+#   documentation and/or other materials provided with the distribution.
+# 
+# * Neither the name of the LLNS/LLNL nor the names of its contributors may
+#   be used to endorse or promote products derived from this software without
+#   specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+# LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# POSSIBILITY OF SUCH DAMAGE.
+# 
+###############################################################################
+#
+# Example that shows how to use an installed instance of Conduit in Makefile
+# based build system.
+#
+# To build:
+#  env CONDUIT_DIR={conduit install path} make
+#  ./example
+#
+# Note:
+#  If you use features that leverage external third party libraries 
+#  (ex: relay hdf5 features), you may need to pass additional include 
+#   and linking flags. 
+# 
+#
+###############################################################################
+
+
+INC_FLAGS=-I$(CONDUIT_DIR)include/conduit
+LINK_FLAGS=-L$(CONDUIT_DIR)lib/ -lconduit -lconduit_relay -lconduit_blueprint
+
+main:
+	$(CXX) $(INC_FLAGS) $(LINK_FLAGS) example.cpp  -o example
+
+

--- a/src/examples/using-with-make/Makefile
+++ b/src/examples/using-with-make/Makefile
@@ -58,8 +58,8 @@
 ###############################################################################
 
 
-INC_FLAGS=-I$(CONDUIT_DIR)include/conduit
-LINK_FLAGS=-L$(CONDUIT_DIR)lib/ -lconduit -lconduit_relay -lconduit_blueprint
+INC_FLAGS=-I$(CONDUIT_DIR)/include/conduit
+LINK_FLAGS=-L$(CONDUIT_DIR)/lib/ -lconduit -lconduit_relay -lconduit_blueprint
 
 main:
 	$(CXX) $(INC_FLAGS) $(LINK_FLAGS) example.cpp  -o example

--- a/src/examples/using-with-make/example.cpp
+++ b/src/examples/using-with-make/example.cpp
@@ -1,0 +1,64 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: example.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include <iostream>
+
+#include "conduit.hpp"
+#include "relay.hpp"
+#include "blueprint.hpp"
+
+
+int main(int argc, char **argv)
+{
+    std::cout << conduit::about() << std::endl
+              << conduit::relay::about() << std::endl
+              << conduit::blueprint::about() << std::endl;
+}
+


### PR DESCRIPTION
Added simple examples that demonstrate how to include conduit
in CMake-based project, and via a Makefile.