### PR TITLE
enh: add vector field to blueprint example meshes

### DIFF
--- a/src/libs/blueprint/blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/blueprint_mesh_examples.cpp
@@ -152,6 +152,72 @@ void braid_init_example_point_scalar_field(index_t npts_x,
 }
 
 //---------------------------------------------------------------------------//
+void braid_init_example_point_vector_field(index_t npts_x,
+                                           index_t npts_y,
+                                           index_t npts_z,
+                                           Node &res)
+{
+    index_t npts = npts_x * npts_y * npts_z;
+    
+    res["association"] = "point";
+    res["type"] = "vector";
+    res["values/dx"].set(DataType::float64(npts));
+    res["values/dy"].set(DataType::float64(npts));
+
+    float64 *dx_vals = res["values/dx"].value();
+    float64 *dy_vals = res["values/dy"].value();
+    float64 *dz_vals = NULL;
+    
+    if(npts_z > 1)
+    {
+        res["values/dz"].set(DataType::float64(npts));
+        dz_vals = res["values/dz"].value();
+    }
+
+    // this logic is from the explicit coord set setup function
+    // we are using the coords (distance from origin)
+    // to create an example vector field
+    
+    float dx = 20.0 / float64(npts_x-1);
+    float dy = 20.0 / float64(npts_y-1);
+
+    float dz = 0.0;
+
+    if(npts_z > 1)
+    {
+        dz = 20.0 / float64(npts_z-1);
+    }
+
+    index_t idx = 0;
+    for(index_t k = 0; k < npts_z ; k++)
+    {
+        float64 cz = -10.0 + k * dz;
+        
+        for(index_t j = 0; j < npts_y ; j++)
+        {
+            float64 cy =  -10.0 + j * dy;
+            
+            for(index_t i = 0; i < npts_x ; i++)
+            {
+                float64 cx =  -10.0 + i * dx;
+
+                dx_vals[idx] = cx;
+                dy_vals[idx] = cy;
+
+                if(npts_z > 1)
+                {
+                    dz_vals[idx] = cz;
+                }
+                
+                idx++;
+            }
+        
+        }
+    }
+}
+
+
+//---------------------------------------------------------------------------//
 void braid_init_example_element_scalar_field(index_t nele_x,
                                              index_t nele_y,
                                              index_t nele_z,
@@ -401,6 +467,12 @@ braid_uniform(index_t npts_x,
                                             nele_y,
                                             nele_z,
                                             fields["radial_ec"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
+
 }
 
 
@@ -438,6 +510,12 @@ braid_rectilinear(index_t npts_x,
                                             nele_y,
                                             nele_z,
                                             fields["radial_ec"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
+
 }
 
 //---------------------------------------------------------------------------//
@@ -479,6 +557,12 @@ braid_structured(index_t npts_x,
                                             nele_y, 
                                             nele_z,
                                             fields["radial_ec"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
+
 }
 
 
@@ -511,7 +595,13 @@ braid_points_explicit(index_t npts_x,
                                             npts_y, 
                                             npts_z,
                                             fields["radial_ec"]);
- }
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
+
+}
 
 
 //---------------------------------------------------------------------------//
@@ -564,6 +654,11 @@ braid_quads(index_t npts_x,
                                             nele_y,
                                             0,
                                             fields["radial_ec"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          1,
+                                          fields["vec_pc"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -678,6 +773,11 @@ braid_quads_and_tris(index_t npts_x,
                                           npts_y,
                                           1,
                                           fields["braid_pc"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          1,
+                                          fields["vec_pc"]);
 
     // braid_init_example_element_scalar_field(nele_x,
     //                                         nele_y,
@@ -803,6 +903,11 @@ braid_quads_and_tris_offsets(index_t npts_x,
                                           npts_y,
                                           1,
                                           fields["braid_pc"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          1,
+                                          fields["vec_pc"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -862,6 +967,12 @@ braid_tris(index_t npts_x,
                                             nele_quads_y,
                                             0,
                                             fields["radial_ec"],2);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          1,
+                                          fields["vec_pc"]);
+
 }
 
 
@@ -932,6 +1043,11 @@ braid_hexs(index_t npts_x,
                                             nele_y,
                                             nele_z,
                                             fields["radial_ec"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -1038,6 +1154,12 @@ braid_tets(index_t npts_x,
                                             nele_hexs_z,
                                             fields["radial_ec"],
                                             tets_per_hex);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
+
 }
 
 //---------------------------------------------------------------------------//
@@ -1221,6 +1343,11 @@ braid_hexs_and_tets(index_t npts_x,
                                           npts_y,
                                           npts_z,
                                           fields["braid_pc"]);
+
+    braid_init_example_point_vector_field(npts_x,
+                                          npts_y,
+                                          npts_z,
+                                          fields["vec_pc"]);
 
 //    // Omit for now -- the function assumes a uniform element type
 //    braid_init_example_element_scalar_field(nele_hexs_x,

--- a/src/libs/relay/relay_silo.cpp
+++ b/src/libs/relay/relay_silo.cpp
@@ -386,10 +386,12 @@ silo_write_field(DBfile *dbfile,
         }
         else
         {
-            CONDUIT_ERROR( "field " 
-                            << var_name 
-                            << "'s type not implemented, found " 
-                            << dtype.name());
+            // skip the field if we don't support its type
+            CONDUIT_INFO( "skipping field " 
+                           << var_name 
+                           << ", since its type is not implemented, found " 
+                           << dtype.name() );
+            continue;
         }
 
         int silo_error = 0;

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -87,6 +87,12 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             uni_idx["fields/radial_ec/association"] = "element";
             uni_idx["fields/radial_ec/topology"]    = "mesh";
             uni_idx["fields/radial_ec/path"]        = "uniform/fields/radial_ec";
+            // vec pc
+            uni_idx["fields/vec_pc/number_of_components"] = 2;
+            uni_idx["fields/vec_pc/association"] = "point";
+            uni_idx["fields/vec_pc/topology"]    = "mesh";
+            uni_idx["fields/vec_pc/path"]        = "uniform/fields/vec_pc";
+
 
     // rectilinear
         Node &rect_idx = index_root["rect"];
@@ -113,6 +119,12 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             rect_idx["fields/radial_ec/association"] = "element";
             rect_idx["fields/radial_ec/topology"]    = "mesh";
             rect_idx["fields/radial_ec/path"]        = "rect/fields/radial_ec";
+            // vec pc
+            rect_idx["fields/vec_pc/number_of_components"] = 2;
+            rect_idx["fields/vec_pc/association"] = "point";
+            rect_idx["fields/vec_pc/topology"]    = "mesh";
+            rect_idx["fields/vec_pc/path"]        = "rect/fields/vec_pc";
+
 
 
     // structured
@@ -140,6 +152,12 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             struct_idx["fields/radial_ec/association"] = "element";
             struct_idx["fields/radial_ec/topology"]    = "mesh";
             struct_idx["fields/radial_ec/path"]        = "struct/fields/radial_ec";
+            // vec pc
+            struct_idx["fields/vec_pc/number_of_components"] = 2;
+            struct_idx["fields/vec_pc/association"] = "point";
+            struct_idx["fields/vec_pc/topology"]    = "mesh";
+            struct_idx["fields/vec_pc/path"]        = "struct/fields/vec_pc";
+
     
     // tris (unstructured)
     Node &tris_idx = index_root["tris"];
@@ -157,15 +175,21 @@ create_blueprint_index_for_2d_examples(Node &index_root)
     tris_idx["topologies/mesh/path"]     = "tris/topology";
     // fields
         // pc
+        tris_idx["fields/braid_pc/number_of_components"] = 1;
         tris_idx["fields/braid_pc/association"] = "point";
         tris_idx["fields/braid_pc/topology"]    = "mesh";
-        tris_idx["fields/braid_pc/number_of_components"] = 1;
         tris_idx["fields/braid_pc/path"]   = "tris/fields/braid_pc";
         // ec
         tris_idx["fields/radial_ec/number_of_components"] = 1;
         tris_idx["fields/radial_ec/association"] = "element";
         tris_idx["fields/radial_ec/topology"]    = "mesh";
         tris_idx["fields/radial_ec/path"]        = "tris/fields/radial_ec";
+        // vec pc
+        tris_idx["fields/vec_pc/number_of_components"] = 2;
+        tris_idx["fields/vec_pc/association"] = "point";
+        tris_idx["fields/vec_pc/topology"]    = "mesh";
+        tris_idx["fields/vec_pc/path"]   = "tris/fields/vec_pc";
+
     
     // quads (unstructured)
     Node &quads_idx = index_root["quads"];
@@ -192,6 +216,12 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         quads_idx["fields/radial_ec/association"] = "element";
         quads_idx["fields/radial_ec/topology"]    = "mesh";
         quads_idx["fields/radial_ec/path"]        = "quads/fields/radial_ec";
+        // vec pc
+        quads_idx["fields/vec_pc/number_of_components"] = 2;
+        quads_idx["fields/vec_pc/association"] = "point";
+        quads_idx["fields/vec_pc/topology"]    = "mesh";
+        quads_idx["fields/vec_pc/path"]        = "quads/fields/vec_pc";
+
     
 }
 
@@ -224,6 +254,12 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             uni_idx["fields/radial_ec/association"] = "element";
             uni_idx["fields/radial_ec/topology"]    = "mesh";
             uni_idx["fields/radial_ec/path"]        = "uniform/fields/radial_ec";
+            // vec pc
+            uni_idx["fields/vec_pc/number_of_components"] = 3;
+            uni_idx["fields/vec_pc/association"] = "point";
+            uni_idx["fields/vec_pc/topology"]    = "mesh";
+            uni_idx["fields/vec_pc/path"]        = "uniform/fields/vec_pc";
+
 
     // rectilinear
         Node &rect_idx = index_root["rect"];
@@ -250,6 +286,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             rect_idx["fields/radial_ec/association"] = "element";
             rect_idx["fields/radial_ec/topology"]    = "mesh";
             rect_idx["fields/radial_ec/path"]        = "rect/fields/radial_ec";
+            // vec pc
+            rect_idx["fields/vec_pc/number_of_components"] = 3;
+            rect_idx["fields/vec_pc/association"] = "point";
+            rect_idx["fields/vec_pc/topology"]    = "mesh";
+            rect_idx["fields/vec_pc/path"]        = "rect/fields/vec_pc";
 
 
     // structured
@@ -277,6 +318,12 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             struct_idx["fields/radial_ec/association"] = "element";
             struct_idx["fields/radial_ec/topology"]    = "mesh";
             struct_idx["fields/radial_ec/path"]        = "struct/fields/radial_ec";
+            // vec pc
+            struct_idx["fields/vec_pc/number_of_components"] = 3;
+            struct_idx["fields/vec_pc/association"] = "point";
+            struct_idx["fields/vec_pc/topology"]    = "mesh";
+            struct_idx["fields/vec_pc/path"]        = "struct/fields/vec_pc";
+
     
     // tets (unstructured)
     Node &tets_idx = index_root["tets"];
@@ -303,6 +350,12 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         tets_idx["fields/radial_ec/association"] = "element";
         tets_idx["fields/radial_ec/topology"]    = "mesh";
         tets_idx["fields/radial_ec/path"]        = "tets/fields/radial_ec";
+        // vec pc
+        tets_idx["fields/vec_pc/number_of_components"] = 3;
+        tets_idx["fields/vec_pc/association"] = "point";
+        tets_idx["fields/vec_pc/topology"]    = "mesh";
+        tets_idx["fields/vec_pc/path"]        = "tets/fields/vec_pc";
+
     
     // hexs (unstructured)
     Node &hexs_idx = index_root["hexs"];
@@ -329,6 +382,12 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         hexs_idx["fields/radial_ec/association"] = "element";
         hexs_idx["fields/radial_ec/topology"]    = "mesh";
         hexs_idx["fields/radial_ec/path"]        = "hexs/fields/radial_ec";
+        // vec pc
+        hexs_idx["fields/vec_pc/number_of_components"] = 3;
+        hexs_idx["fields/vec_pc/association"] = "point";
+        hexs_idx["fields/vec_pc/topology"]    = "mesh";
+        hexs_idx["fields/vec_pc/path"]        = "hexs/fields/vec_pc";
+
     
 }
 


### PR DESCRIPTION
adds a point-centered vector field to the 2d and 3d braid example
meshes, and hdf5 output.