### PR TITLE
enh: add lines topo examples to mesh bp

### DIFF
--- a/src/libs/blueprint/blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/blueprint_mesh_examples.cpp
@@ -163,17 +163,17 @@ void braid_init_example_point_vector_field(index_t npts_x,
     res["association"] = "point";
     res["type"] = "vector";
     res["topology"] = "mesh";
-    res["values/dx"].set(DataType::float64(npts));
-    res["values/dy"].set(DataType::float64(npts));
+    res["values/u"].set(DataType::float64(npts));
+    res["values/v"].set(DataType::float64(npts));
 
-    float64 *dx_vals = res["values/dx"].value();
-    float64 *dy_vals = res["values/dy"].value();
-    float64 *dz_vals = NULL;
+    float64 *u_vals = res["values/u"].value();
+    float64 *v_vals = res["values/v"].value();
+    float64 *w_vals = NULL;
     
     if(npts_z > 1)
     {
-        res["values/dz"].set(DataType::float64(npts));
-        dz_vals = res["values/dz"].value();
+        res["values/w"].set(DataType::float64(npts));
+        w_vals = res["values/w"].value();
     }
 
     // this logic is from the explicit coord set setup function
@@ -203,12 +203,12 @@ void braid_init_example_point_vector_field(index_t npts_x,
             {
                 float64 cx =  -10.0 + i * dx;
 
-                dx_vals[idx] = cx;
-                dy_vals[idx] = cy;
+                u_vals[idx] = cx;
+                v_vals[idx] = cy;
 
                 if(npts_z > 1)
                 {
-                    dz_vals[idx] = cz;
+                    w_vals[idx] = cz;
                 }
                 
                 idx++;
@@ -474,7 +474,7 @@ braid_uniform(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -517,7 +517,7 @@ braid_rectilinear(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -564,7 +564,7 @@ braid_structured(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -602,7 +602,7 @@ braid_points_explicit(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -661,7 +661,7 @@ braid_quads(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec"]);
+                                          fields["vel"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -780,7 +780,7 @@ braid_quads_and_tris(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
     // braid_init_example_element_scalar_field(nele_x,
     //                                         nele_y,
@@ -910,7 +910,7 @@ braid_quads_and_tris_offsets(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec"]);
+                                          fields["vel"]);
 }
 
 
@@ -981,7 +981,7 @@ braid_lines_2d(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -1046,7 +1046,7 @@ braid_tris(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -1122,7 +1122,7 @@ braid_hexs(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -1233,7 +1233,7 @@ braid_tets(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -1341,7 +1341,7 @@ braid_lines_3d(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 }
 
@@ -1532,7 +1532,7 @@ braid_hexs_and_tets(index_t npts_x,
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec"]);
+                                          fields["vel"]);
 
 //    // Omit for now -- the function assumes a uniform element type
 //    braid_init_example_element_scalar_field(nele_hexs_x,

--- a/src/libs/blueprint/blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/blueprint_mesh_examples.cpp
@@ -111,6 +111,7 @@ void braid_init_example_point_scalar_field(index_t npts_x,
     
     res["association"] = "point";
     res["type"] = "scalar";
+    res["topology"] = "mesh";
     res["values"].set(DataType::float64(npts));
     
     float64 *vals = res["values"].value();
@@ -161,6 +162,7 @@ void braid_init_example_point_vector_field(index_t npts_x,
     
     res["association"] = "point";
     res["type"] = "vector";
+    res["topology"] = "mesh";
     res["values/dx"].set(DataType::float64(npts));
     res["values/dy"].set(DataType::float64(npts));
 
@@ -233,6 +235,7 @@ void braid_init_example_element_scalar_field(index_t nele_x,
 
     res["association"] = "element";
     res["type"] = "scalar";
+    res["topology"] = "mesh";
     res["values"].set(DataType::float64(nele*prims_per_ele));
 
     float64 *vals = res["values"].value();
@@ -461,17 +464,17 @@ braid_uniform(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_x,
                                             nele_y,
                                             nele_z,
-                                            fields["radial_ec"]);
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -504,17 +507,17 @@ braid_rectilinear(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_x,
                                             nele_y,
                                             nele_z,
-                                            fields["radial_ec"]);
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -551,17 +554,17 @@ braid_structured(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
                                           
     braid_init_example_element_scalar_field(nele_x,
                                             nele_y, 
                                             nele_z,
-                                            fields["radial_ec"]);
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -589,17 +592,17 @@ braid_points_explicit(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
     
     braid_init_example_element_scalar_field(npts_x,
                                             npts_y, 
                                             npts_z,
-                                            fields["radial_ec"]);
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -648,17 +651,17 @@ braid_quads(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_x,
                                             nele_y,
                                             0,
-                                            fields["radial_ec"]);
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -772,17 +775,17 @@ braid_quads_and_tris(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
     // braid_init_example_element_scalar_field(nele_x,
     //                                         nele_y,
     //                                         0,
-    //                                         fields["radial_ec"]);
+    //                                         fields["radial"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -902,12 +905,12 @@ braid_quads_and_tris_offsets(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 }
 
 
@@ -968,17 +971,17 @@ braid_lines_2d(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_quads_x,
                                             nele_quads_y,
                                             0,
-                                            fields["radial_ec"],4);
+                                            fields["radial"],4);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -1033,17 +1036,17 @@ braid_tris(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_quads_x,
                                             nele_quads_y,
                                             0,
-                                            fields["radial_ec"],2);
+                                            fields["radial"],2);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           1,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -1109,17 +1112,17 @@ braid_hexs(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_x,
                                             nele_y,
                                             nele_z,
-                                            fields["radial_ec"]);
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 }
 
 //---------------------------------------------------------------------------//
@@ -1219,18 +1222,18 @@ braid_tets(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_hexs_x,
                                             nele_hexs_y,
                                             nele_hexs_z,
-                                            fields["radial_ec"],
+                                            fields["radial"],
                                             tets_per_hex);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -1327,18 +1330,18 @@ braid_lines_3d(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_hexs_x,
                                             nele_hexs_y,
                                             nele_hexs_z,
-                                            fields["radial_ec"],
+                                            fields["radial"],
                                             12);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 }
 
@@ -1524,18 +1527,18 @@ braid_hexs_and_tets(index_t npts_x,
     braid_init_example_point_scalar_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["braid_pc"]);
+                                          fields["braid"]);
 
     braid_init_example_point_vector_field(npts_x,
                                           npts_y,
                                           npts_z,
-                                          fields["vec_pc"]);
+                                          fields["vec"]);
 
 //    // Omit for now -- the function assumes a uniform element type
 //    braid_init_example_element_scalar_field(nele_hexs_x,
 //                                            nele_hexs_y,
 //                                            nele_hexs_z,
-//                                            fields["radial_ec"],
+//                                            fields["radial"],
 //                                            tets_per_hex);
 }
 

--- a/src/libs/relay/relay_silo.cpp
+++ b/src/libs/relay/relay_silo.cpp
@@ -660,6 +660,16 @@ silo_write_ucd_zonelist(DBfile *dbfile,
             shapecnt[i]    = num_elems;
             total_num_elems += num_elems;
         }
+        else  if( topo_shape == "lines")
+        {
+            // TODO: check for explicit # of elems
+            int num_elems  = n_mesh_conn.dtype().number_of_elements() / 2;
+            shapetype[i]   = DB_ZONETYPE_BEAM;
+            shapesize[i]   = 2;
+            shapecnt[i]    = num_elems;
+            total_num_elems += num_elems;
+        }
+        
     }
     
     // Final Compaction

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -158,6 +158,37 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             struct_idx["fields/vec_pc/topology"]    = "mesh";
             struct_idx["fields/vec_pc/path"]        = "struct/fields/vec_pc";
 
+    // lines (unstructured)
+        Node &lines_idx = index_root["lines"];
+        // state
+        lines_idx["state/cycle"] = 42;
+        lines_idx["state/time"]  = 3.1415;
+        lines_idx["state/number_of_domains"]  = 1;
+        // coords
+        lines_idx["coordsets/coords/type"]         = "explicit";
+        lines_idx["coordsets/coords/coord_system"] = "xy";
+        lines_idx["coordsets/coords/path"]         = "lines/coords";
+        // topology
+        lines_idx["topologies/mesh/type"]     = "unstructured";
+        lines_idx["topologies/mesh/coordset"] = "coords";
+        lines_idx["topologies/mesh/path"]     = "lines/topology";
+        // fields
+            // pc
+            lines_idx["fields/braid_pc/number_of_components"] = 1;
+            lines_idx["fields/braid_pc/association"] = "point";
+            lines_idx["fields/braid_pc/topology"]    = "mesh";
+            lines_idx["fields/braid_pc/path"]   = "lines/fields/braid_pc";
+            // ec
+            lines_idx["fields/radial_ec/number_of_components"] = 1;
+            lines_idx["fields/radial_ec/association"] = "element";
+            lines_idx["fields/radial_ec/topology"]    = "mesh";
+            lines_idx["fields/radial_ec/path"]        = "lines/fields/radial_ec";
+            // vec pc
+            lines_idx["fields/vec_pc/number_of_components"] = 2;
+            lines_idx["fields/vec_pc/association"] = "point";
+            lines_idx["fields/vec_pc/topology"]    = "mesh";
+            lines_idx["fields/vec_pc/path"]        = "lines/fields/vec_pc";
+
     
     // tris (unstructured)
     Node &tris_idx = index_root["tris"];
@@ -324,7 +355,38 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             struct_idx["fields/vec_pc/topology"]    = "mesh";
             struct_idx["fields/vec_pc/path"]        = "struct/fields/vec_pc";
 
-    
+
+    // lines (unstructured)
+        Node &lines_idx = index_root["lines"];
+        // state
+        lines_idx["state/cycle"] = 42;
+        lines_idx["state/time"]  = 3.1415;
+        lines_idx["state/number_of_domains"]  = 1;
+        // coords
+        lines_idx["coordsets/coords/type"]         = "explicit";
+        lines_idx["coordsets/coords/coord_system"] = "xyz";
+        lines_idx["coordsets/coords/path"]         = "lines/coords";
+        // topology
+        lines_idx["topologies/mesh/type"]     = "unstructured";
+        lines_idx["topologies/mesh/coordset"] = "coords";
+        lines_idx["topologies/mesh/path"]     = "lines/topology";
+        // fields
+            // pc
+            lines_idx["fields/braid_pc/number_of_components"] = 1;
+            lines_idx["fields/braid_pc/association"] = "point";
+            lines_idx["fields/braid_pc/topology"]    = "mesh";
+            lines_idx["fields/braid_pc/path"]   = "lines/fields/braid_pc";
+            // ec
+            lines_idx["fields/radial_ec/number_of_components"] = 1;
+            lines_idx["fields/radial_ec/association"] = "element";
+            lines_idx["fields/radial_ec/topology"]    = "mesh";
+            lines_idx["fields/radial_ec/path"]        = "lines/fields/radial_ec";
+            // vec pc
+            lines_idx["fields/vec_pc/number_of_components"] = 3;
+            lines_idx["fields/vec_pc/association"] = "point";
+            lines_idx["fields/vec_pc/topology"]    = "mesh";
+            lines_idx["fields/vec_pc/path"]        = "lines/fields/vec_pc";
+
     // tets (unstructured)
     Node &tets_idx = index_root["tets"];
     // state
@@ -424,6 +486,12 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
                                      npts_y,
                                      npts_z,
                                      dsets["struct"]);
+
+    blueprint::mesh::examples::braid("lines",
+                                     npts_x,
+                                     npts_y,
+                                     npts_z,
+                                     dsets["lines"]);
                                      
     blueprint::mesh::examples::braid("tris",
                                      npts_x,
@@ -449,11 +517,11 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
                                      npts_z,
                                      dsets["quads_and_tris_offsets"]);
 
-    blueprint::mesh::examples::braid("points_explicit",
+    blueprint::mesh::examples::braid("points",
                                      npts_x,
                                      npts_y,
                                      npts_z,
-                                     dsets["points_explicit"]);
+                                     dsets["points"]);
 
     Node expanded;
     
@@ -558,11 +626,17 @@ TEST(conduit_blueprint_mesh_examples, mesh_3d)
                                      npts_z,
                                      dsets["struct"]);
 
-    blueprint::mesh::examples::braid("points_explicit",
+    blueprint::mesh::examples::braid("points",
                                      npts_x,
                                      npts_y,
                                      npts_z,
-                                     dsets["points_explicit"]);
+                                     dsets["points"]);
+
+    blueprint::mesh::examples::braid("lines",
+                                     npts_x,
+                                     npts_y,
+                                     npts_z,
+                                     dsets["lines"]);
 
     blueprint::mesh::examples::braid("tets",
                                      npts_x,

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -78,20 +78,20 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         uni_idx["topologies/mesh/path"]     = "uniform/topology";
         // fields
             // pc
-            uni_idx["fields/braid_pc/number_of_components"] = 1;
-            uni_idx["fields/braid_pc/association"] = "point";
-            uni_idx["fields/braid_pc/topology"]    = "mesh";
-            uni_idx["fields/braid_pc/path"]        = "uniform/fields/braid_pc";
+            uni_idx["fields/braid/number_of_components"] = 1;
+            uni_idx["fields/braid/association"] = "point";
+            uni_idx["fields/braid/topology"]    = "mesh";
+            uni_idx["fields/braid/path"]        = "uniform/fields/braid";
             // ec
-            uni_idx["fields/radial_ec/number_of_components"] = 1;
-            uni_idx["fields/radial_ec/association"] = "element";
-            uni_idx["fields/radial_ec/topology"]    = "mesh";
-            uni_idx["fields/radial_ec/path"]        = "uniform/fields/radial_ec";
+            uni_idx["fields/radial/number_of_components"] = 1;
+            uni_idx["fields/radial/association"] = "element";
+            uni_idx["fields/radial/topology"]    = "mesh";
+            uni_idx["fields/radial/path"]        = "uniform/fields/radial";
             // vec pc
-            uni_idx["fields/vec_pc/number_of_components"] = 2;
-            uni_idx["fields/vec_pc/association"] = "point";
-            uni_idx["fields/vec_pc/topology"]    = "mesh";
-            uni_idx["fields/vec_pc/path"]        = "uniform/fields/vec_pc";
+            uni_idx["fields/vec/number_of_components"] = 2;
+            uni_idx["fields/vec/association"] = "point";
+            uni_idx["fields/vec/topology"]    = "mesh";
+            uni_idx["fields/vec/path"]        = "uniform/fields/vec";
 
 
     // rectilinear
@@ -110,20 +110,20 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         rect_idx["topologies/mesh/path"]     = "rect/topology";
         // fields
             // pc
-            rect_idx["fields/braid_pc/number_of_components"] = 1;
-            rect_idx["fields/braid_pc/association"] = "point";
-            rect_idx["fields/braid_pc/topology"]    = "mesh";
-            rect_idx["fields/braid_pc/path"]        = "rect/fields/braid_pc";
+            rect_idx["fields/braid/number_of_components"] = 1;
+            rect_idx["fields/braid/association"] = "point";
+            rect_idx["fields/braid/topology"]    = "mesh";
+            rect_idx["fields/braid/path"]        = "rect/fields/braid";
             // ec
-            rect_idx["fields/radial_ec/number_of_components"] = 1;
-            rect_idx["fields/radial_ec/association"] = "element";
-            rect_idx["fields/radial_ec/topology"]    = "mesh";
-            rect_idx["fields/radial_ec/path"]        = "rect/fields/radial_ec";
+            rect_idx["fields/radial/number_of_components"] = 1;
+            rect_idx["fields/radial/association"] = "element";
+            rect_idx["fields/radial/topology"]    = "mesh";
+            rect_idx["fields/radial/path"]        = "rect/fields/radial";
             // vec pc
-            rect_idx["fields/vec_pc/number_of_components"] = 2;
-            rect_idx["fields/vec_pc/association"] = "point";
-            rect_idx["fields/vec_pc/topology"]    = "mesh";
-            rect_idx["fields/vec_pc/path"]        = "rect/fields/vec_pc";
+            rect_idx["fields/vec/number_of_components"] = 2;
+            rect_idx["fields/vec/association"] = "point";
+            rect_idx["fields/vec/topology"]    = "mesh";
+            rect_idx["fields/vec/path"]        = "rect/fields/vec";
 
 
 
@@ -143,20 +143,20 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         struct_idx["topologies/mesh/path"]     = "struct/topology";
         // fields
             // pc
-            struct_idx["fields/braid_pc/number_of_components"] = 1;
-            struct_idx["fields/braid_pc/association"] = "point";
-            struct_idx["fields/braid_pc/topology"]    = "mesh";
-            struct_idx["fields/braid_pc/path"]        = "struct/fields/braid_pc";
+            struct_idx["fields/braid/number_of_components"] = 1;
+            struct_idx["fields/braid/association"] = "point";
+            struct_idx["fields/braid/topology"]    = "mesh";
+            struct_idx["fields/braid/path"]        = "struct/fields/braid";
             // ec
-            struct_idx["fields/radial_ec/number_of_components"] = 1;
-            struct_idx["fields/radial_ec/association"] = "element";
-            struct_idx["fields/radial_ec/topology"]    = "mesh";
-            struct_idx["fields/radial_ec/path"]        = "struct/fields/radial_ec";
+            struct_idx["fields/radial/number_of_components"] = 1;
+            struct_idx["fields/radial/association"] = "element";
+            struct_idx["fields/radial/topology"]    = "mesh";
+            struct_idx["fields/radial/path"]        = "struct/fields/radial";
             // vec pc
-            struct_idx["fields/vec_pc/number_of_components"] = 2;
-            struct_idx["fields/vec_pc/association"] = "point";
-            struct_idx["fields/vec_pc/topology"]    = "mesh";
-            struct_idx["fields/vec_pc/path"]        = "struct/fields/vec_pc";
+            struct_idx["fields/vec/number_of_components"] = 2;
+            struct_idx["fields/vec/association"] = "point";
+            struct_idx["fields/vec/topology"]    = "mesh";
+            struct_idx["fields/vec/path"]        = "struct/fields/vec";
 
     // lines (unstructured)
         Node &lines_idx = index_root["lines"];
@@ -174,20 +174,20 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         lines_idx["topologies/mesh/path"]     = "lines/topology";
         // fields
             // pc
-            lines_idx["fields/braid_pc/number_of_components"] = 1;
-            lines_idx["fields/braid_pc/association"] = "point";
-            lines_idx["fields/braid_pc/topology"]    = "mesh";
-            lines_idx["fields/braid_pc/path"]   = "lines/fields/braid_pc";
+            lines_idx["fields/braid/number_of_components"] = 1;
+            lines_idx["fields/braid/association"] = "point";
+            lines_idx["fields/braid/topology"]    = "mesh";
+            lines_idx["fields/braid/path"]   = "lines/fields/braid";
             // ec
-            lines_idx["fields/radial_ec/number_of_components"] = 1;
-            lines_idx["fields/radial_ec/association"] = "element";
-            lines_idx["fields/radial_ec/topology"]    = "mesh";
-            lines_idx["fields/radial_ec/path"]        = "lines/fields/radial_ec";
+            lines_idx["fields/radial/number_of_components"] = 1;
+            lines_idx["fields/radial/association"] = "element";
+            lines_idx["fields/radial/topology"]    = "mesh";
+            lines_idx["fields/radial/path"]        = "lines/fields/radial";
             // vec pc
-            lines_idx["fields/vec_pc/number_of_components"] = 2;
-            lines_idx["fields/vec_pc/association"] = "point";
-            lines_idx["fields/vec_pc/topology"]    = "mesh";
-            lines_idx["fields/vec_pc/path"]        = "lines/fields/vec_pc";
+            lines_idx["fields/vec/number_of_components"] = 2;
+            lines_idx["fields/vec/association"] = "point";
+            lines_idx["fields/vec/topology"]    = "mesh";
+            lines_idx["fields/vec/path"]        = "lines/fields/vec";
 
     
     // tris (unstructured)
@@ -206,20 +206,20 @@ create_blueprint_index_for_2d_examples(Node &index_root)
     tris_idx["topologies/mesh/path"]     = "tris/topology";
     // fields
         // pc
-        tris_idx["fields/braid_pc/number_of_components"] = 1;
-        tris_idx["fields/braid_pc/association"] = "point";
-        tris_idx["fields/braid_pc/topology"]    = "mesh";
-        tris_idx["fields/braid_pc/path"]   = "tris/fields/braid_pc";
+        tris_idx["fields/braid/number_of_components"] = 1;
+        tris_idx["fields/braid/association"] = "point";
+        tris_idx["fields/braid/topology"]    = "mesh";
+        tris_idx["fields/braid/path"]   = "tris/fields/braid";
         // ec
-        tris_idx["fields/radial_ec/number_of_components"] = 1;
-        tris_idx["fields/radial_ec/association"] = "element";
-        tris_idx["fields/radial_ec/topology"]    = "mesh";
-        tris_idx["fields/radial_ec/path"]        = "tris/fields/radial_ec";
+        tris_idx["fields/radial/number_of_components"] = 1;
+        tris_idx["fields/radial/association"] = "element";
+        tris_idx["fields/radial/topology"]    = "mesh";
+        tris_idx["fields/radial/path"]        = "tris/fields/radial";
         // vec pc
-        tris_idx["fields/vec_pc/number_of_components"] = 2;
-        tris_idx["fields/vec_pc/association"] = "point";
-        tris_idx["fields/vec_pc/topology"]    = "mesh";
-        tris_idx["fields/vec_pc/path"]   = "tris/fields/vec_pc";
+        tris_idx["fields/vec/number_of_components"] = 2;
+        tris_idx["fields/vec/association"] = "point";
+        tris_idx["fields/vec/topology"]    = "mesh";
+        tris_idx["fields/vec/path"]   = "tris/fields/vec";
 
     
     // quads (unstructured)
@@ -238,20 +238,20 @@ create_blueprint_index_for_2d_examples(Node &index_root)
     quads_idx["topologies/mesh/path"]     = "quads/topology";
     // fields
         // pc
-        quads_idx["fields/braid_pc/number_of_components"] = 1;
-        quads_idx["fields/braid_pc/association"] = "point";
-        quads_idx["fields/braid_pc/topology"]    = "mesh";
-        quads_idx["fields/braid_pc/path"]        = "quads/fields/braid_pc";
+        quads_idx["fields/braid/number_of_components"] = 1;
+        quads_idx["fields/braid/association"] = "point";
+        quads_idx["fields/braid/topology"]    = "mesh";
+        quads_idx["fields/braid/path"]        = "quads/fields/braid";
         // ec
-        quads_idx["fields/radial_ec/number_of_components"] = 1;
-        quads_idx["fields/radial_ec/association"] = "element";
-        quads_idx["fields/radial_ec/topology"]    = "mesh";
-        quads_idx["fields/radial_ec/path"]        = "quads/fields/radial_ec";
+        quads_idx["fields/radial/number_of_components"] = 1;
+        quads_idx["fields/radial/association"] = "element";
+        quads_idx["fields/radial/topology"]    = "mesh";
+        quads_idx["fields/radial/path"]        = "quads/fields/radial";
         // vec pc
-        quads_idx["fields/vec_pc/number_of_components"] = 2;
-        quads_idx["fields/vec_pc/association"] = "point";
-        quads_idx["fields/vec_pc/topology"]    = "mesh";
-        quads_idx["fields/vec_pc/path"]        = "quads/fields/vec_pc";
+        quads_idx["fields/vec/number_of_components"] = 2;
+        quads_idx["fields/vec/association"] = "point";
+        quads_idx["fields/vec/topology"]    = "mesh";
+        quads_idx["fields/vec/path"]        = "quads/fields/vec";
 
     
 }
@@ -276,20 +276,20 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         uni_idx["topologies/mesh/path"]     = "uniform/topology";
         // fields
             // pc
-            uni_idx["fields/braid_pc/number_of_components"] = 1;
-            uni_idx["fields/braid_pc/association"] = "point";
-            uni_idx["fields/braid_pc/topology"]    = "mesh";
-            uni_idx["fields/braid_pc/path"]        = "uniform/fields/braid_pc";
+            uni_idx["fields/braid/number_of_components"] = 1;
+            uni_idx["fields/braid/association"] = "point";
+            uni_idx["fields/braid/topology"]    = "mesh";
+            uni_idx["fields/braid/path"]        = "uniform/fields/braid";
             // ec
-            uni_idx["fields/radial_ec/number_of_components"] = 1;
-            uni_idx["fields/radial_ec/association"] = "element";
-            uni_idx["fields/radial_ec/topology"]    = "mesh";
-            uni_idx["fields/radial_ec/path"]        = "uniform/fields/radial_ec";
+            uni_idx["fields/radial/number_of_components"] = 1;
+            uni_idx["fields/radial/association"] = "element";
+            uni_idx["fields/radial/topology"]    = "mesh";
+            uni_idx["fields/radial/path"]        = "uniform/fields/radial";
             // vec pc
-            uni_idx["fields/vec_pc/number_of_components"] = 3;
-            uni_idx["fields/vec_pc/association"] = "point";
-            uni_idx["fields/vec_pc/topology"]    = "mesh";
-            uni_idx["fields/vec_pc/path"]        = "uniform/fields/vec_pc";
+            uni_idx["fields/vec/number_of_components"] = 3;
+            uni_idx["fields/vec/association"] = "point";
+            uni_idx["fields/vec/topology"]    = "mesh";
+            uni_idx["fields/vec/path"]        = "uniform/fields/vec";
 
 
     // rectilinear
@@ -308,20 +308,20 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         rect_idx["topologies/mesh/path"]     = "rect/topology";
         // fields
             // pc
-            rect_idx["fields/braid_pc/number_of_components"] = 1;
-            rect_idx["fields/braid_pc/association"] = "point";
-            rect_idx["fields/braid_pc/topology"]    = "mesh";
-            rect_idx["fields/braid_pc/path"]        = "rect/fields/braid_pc";
+            rect_idx["fields/braid/number_of_components"] = 1;
+            rect_idx["fields/braid/association"] = "point";
+            rect_idx["fields/braid/topology"]    = "mesh";
+            rect_idx["fields/braid/path"]        = "rect/fields/braid";
             // ec
-            rect_idx["fields/radial_ec/number_of_components"] = 1;
-            rect_idx["fields/radial_ec/association"] = "element";
-            rect_idx["fields/radial_ec/topology"]    = "mesh";
-            rect_idx["fields/radial_ec/path"]        = "rect/fields/radial_ec";
+            rect_idx["fields/radial/number_of_components"] = 1;
+            rect_idx["fields/radial/association"] = "element";
+            rect_idx["fields/radial/topology"]    = "mesh";
+            rect_idx["fields/radial/path"]        = "rect/fields/radial";
             // vec pc
-            rect_idx["fields/vec_pc/number_of_components"] = 3;
-            rect_idx["fields/vec_pc/association"] = "point";
-            rect_idx["fields/vec_pc/topology"]    = "mesh";
-            rect_idx["fields/vec_pc/path"]        = "rect/fields/vec_pc";
+            rect_idx["fields/vec/number_of_components"] = 3;
+            rect_idx["fields/vec/association"] = "point";
+            rect_idx["fields/vec/topology"]    = "mesh";
+            rect_idx["fields/vec/path"]        = "rect/fields/vec";
 
 
     // structured
@@ -340,20 +340,20 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         struct_idx["topologies/mesh/path"]     = "struct/topology";
         // fields
             // pc
-            struct_idx["fields/braid_pc/number_of_components"] = 1;
-            struct_idx["fields/braid_pc/association"] = "point";
-            struct_idx["fields/braid_pc/topology"]    = "mesh";
-            struct_idx["fields/braid_pc/path"]        = "struct/fields/braid_pc";
+            struct_idx["fields/braid/number_of_components"] = 1;
+            struct_idx["fields/braid/association"] = "point";
+            struct_idx["fields/braid/topology"]    = "mesh";
+            struct_idx["fields/braid/path"]        = "struct/fields/braid";
             // ec
-            struct_idx["fields/radial_ec/number_of_components"] = 1;
-            struct_idx["fields/radial_ec/association"] = "element";
-            struct_idx["fields/radial_ec/topology"]    = "mesh";
-            struct_idx["fields/radial_ec/path"]        = "struct/fields/radial_ec";
+            struct_idx["fields/radial/number_of_components"] = 1;
+            struct_idx["fields/radial/association"] = "element";
+            struct_idx["fields/radial/topology"]    = "mesh";
+            struct_idx["fields/radial/path"]        = "struct/fields/radial";
             // vec pc
-            struct_idx["fields/vec_pc/number_of_components"] = 3;
-            struct_idx["fields/vec_pc/association"] = "point";
-            struct_idx["fields/vec_pc/topology"]    = "mesh";
-            struct_idx["fields/vec_pc/path"]        = "struct/fields/vec_pc";
+            struct_idx["fields/vec/number_of_components"] = 3;
+            struct_idx["fields/vec/association"] = "point";
+            struct_idx["fields/vec/topology"]    = "mesh";
+            struct_idx["fields/vec/path"]        = "struct/fields/vec";
 
 
     // lines (unstructured)
@@ -372,20 +372,20 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         lines_idx["topologies/mesh/path"]     = "lines/topology";
         // fields
             // pc
-            lines_idx["fields/braid_pc/number_of_components"] = 1;
-            lines_idx["fields/braid_pc/association"] = "point";
-            lines_idx["fields/braid_pc/topology"]    = "mesh";
-            lines_idx["fields/braid_pc/path"]   = "lines/fields/braid_pc";
+            lines_idx["fields/braid/number_of_components"] = 1;
+            lines_idx["fields/braid/association"] = "point";
+            lines_idx["fields/braid/topology"]    = "mesh";
+            lines_idx["fields/braid/path"]   = "lines/fields/braid";
             // ec
-            lines_idx["fields/radial_ec/number_of_components"] = 1;
-            lines_idx["fields/radial_ec/association"] = "element";
-            lines_idx["fields/radial_ec/topology"]    = "mesh";
-            lines_idx["fields/radial_ec/path"]        = "lines/fields/radial_ec";
+            lines_idx["fields/radial/number_of_components"] = 1;
+            lines_idx["fields/radial/association"] = "element";
+            lines_idx["fields/radial/topology"]    = "mesh";
+            lines_idx["fields/radial/path"]        = "lines/fields/radial";
             // vec pc
-            lines_idx["fields/vec_pc/number_of_components"] = 3;
-            lines_idx["fields/vec_pc/association"] = "point";
-            lines_idx["fields/vec_pc/topology"]    = "mesh";
-            lines_idx["fields/vec_pc/path"]        = "lines/fields/vec_pc";
+            lines_idx["fields/vec/number_of_components"] = 3;
+            lines_idx["fields/vec/association"] = "point";
+            lines_idx["fields/vec/topology"]    = "mesh";
+            lines_idx["fields/vec/path"]        = "lines/fields/vec";
 
     // tets (unstructured)
     Node &tets_idx = index_root["tets"];
@@ -403,20 +403,20 @@ create_blueprint_index_for_3d_examples(Node &index_root)
     tets_idx["topologies/mesh/path"]     = "tets/topology";
     // fields
         // pc
-        tets_idx["fields/braid_pc/number_of_components"] = 1;
-        tets_idx["fields/braid_pc/association"] = "point";
-        tets_idx["fields/braid_pc/topology"]    = "mesh";
-        tets_idx["fields/braid_pc/path"]        = "tets/fields/braid_pc";
+        tets_idx["fields/braid/number_of_components"] = 1;
+        tets_idx["fields/braid/association"] = "point";
+        tets_idx["fields/braid/topology"]    = "mesh";
+        tets_idx["fields/braid/path"]        = "tets/fields/braid";
         // ec
-        tets_idx["fields/radial_ec/number_of_components"] = 1;
-        tets_idx["fields/radial_ec/association"] = "element";
-        tets_idx["fields/radial_ec/topology"]    = "mesh";
-        tets_idx["fields/radial_ec/path"]        = "tets/fields/radial_ec";
+        tets_idx["fields/radial/number_of_components"] = 1;
+        tets_idx["fields/radial/association"] = "element";
+        tets_idx["fields/radial/topology"]    = "mesh";
+        tets_idx["fields/radial/path"]        = "tets/fields/radial";
         // vec pc
-        tets_idx["fields/vec_pc/number_of_components"] = 3;
-        tets_idx["fields/vec_pc/association"] = "point";
-        tets_idx["fields/vec_pc/topology"]    = "mesh";
-        tets_idx["fields/vec_pc/path"]        = "tets/fields/vec_pc";
+        tets_idx["fields/vec/number_of_components"] = 3;
+        tets_idx["fields/vec/association"] = "point";
+        tets_idx["fields/vec/topology"]    = "mesh";
+        tets_idx["fields/vec/path"]        = "tets/fields/vec";
 
     
     // hexs (unstructured)
@@ -435,20 +435,20 @@ create_blueprint_index_for_3d_examples(Node &index_root)
     hexs_idx["topologies/mesh/path"]     = "hexs/topology";
     // fields
         // pc
-        hexs_idx["fields/braid_pc/number_of_components"] = 1;
-        hexs_idx["fields/braid_pc/association"] = "point";
-        hexs_idx["fields/braid_pc/topology"]    = "mesh";
-        hexs_idx["fields/braid_pc/path"]        = "hexs/fields/braid_pc";
+        hexs_idx["fields/braid/number_of_components"] = 1;
+        hexs_idx["fields/braid/association"] = "point";
+        hexs_idx["fields/braid/topology"]    = "mesh";
+        hexs_idx["fields/braid/path"]        = "hexs/fields/braid";
         // ec
-        hexs_idx["fields/radial_ec/number_of_components"] = 1;
-        hexs_idx["fields/radial_ec/association"] = "element";
-        hexs_idx["fields/radial_ec/topology"]    = "mesh";
-        hexs_idx["fields/radial_ec/path"]        = "hexs/fields/radial_ec";
+        hexs_idx["fields/radial/number_of_components"] = 1;
+        hexs_idx["fields/radial/association"] = "element";
+        hexs_idx["fields/radial/topology"]    = "mesh";
+        hexs_idx["fields/radial/path"]        = "hexs/fields/radial";
         // vec pc
-        hexs_idx["fields/vec_pc/number_of_components"] = 3;
-        hexs_idx["fields/vec_pc/association"] = "point";
-        hexs_idx["fields/vec_pc/topology"]    = "mesh";
-        hexs_idx["fields/vec_pc/path"]        = "hexs/fields/vec_pc";
+        hexs_idx["fields/vec/number_of_components"] = 3;
+        hexs_idx["fields/vec/association"] = "point";
+        hexs_idx["fields/vec/topology"]    = "mesh";
+        hexs_idx["fields/vec/path"]        = "hexs/fields/vec";
 
     
 }

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -87,11 +87,11 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             uni_idx["fields/radial/association"] = "element";
             uni_idx["fields/radial/topology"]    = "mesh";
             uni_idx["fields/radial/path"]        = "uniform/fields/radial";
-            // vec pc
-            uni_idx["fields/vec/number_of_components"] = 2;
-            uni_idx["fields/vec/association"] = "point";
-            uni_idx["fields/vec/topology"]    = "mesh";
-            uni_idx["fields/vec/path"]        = "uniform/fields/vec";
+            // vel pc
+            uni_idx["fields/vel/number_of_components"] = 2;
+            uni_idx["fields/vel/association"] = "point";
+            uni_idx["fields/vel/topology"]    = "mesh";
+            uni_idx["fields/vel/path"]        = "uniform/fields/vel";
 
 
     // rectilinear
@@ -119,11 +119,11 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             rect_idx["fields/radial/association"] = "element";
             rect_idx["fields/radial/topology"]    = "mesh";
             rect_idx["fields/radial/path"]        = "rect/fields/radial";
-            // vec pc
-            rect_idx["fields/vec/number_of_components"] = 2;
-            rect_idx["fields/vec/association"] = "point";
-            rect_idx["fields/vec/topology"]    = "mesh";
-            rect_idx["fields/vec/path"]        = "rect/fields/vec";
+            // vel pc
+            rect_idx["fields/vel/number_of_components"] = 2;
+            rect_idx["fields/vel/association"] = "point";
+            rect_idx["fields/vel/topology"]    = "mesh";
+            rect_idx["fields/vel/path"]        = "rect/fields/vel";
 
 
 
@@ -152,11 +152,11 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             struct_idx["fields/radial/association"] = "element";
             struct_idx["fields/radial/topology"]    = "mesh";
             struct_idx["fields/radial/path"]        = "struct/fields/radial";
-            // vec pc
-            struct_idx["fields/vec/number_of_components"] = 2;
-            struct_idx["fields/vec/association"] = "point";
-            struct_idx["fields/vec/topology"]    = "mesh";
-            struct_idx["fields/vec/path"]        = "struct/fields/vec";
+            // vel pc
+            struct_idx["fields/vel/number_of_components"] = 2;
+            struct_idx["fields/vel/association"] = "point";
+            struct_idx["fields/vel/topology"]    = "mesh";
+            struct_idx["fields/vel/path"]        = "struct/fields/vel";
 
     // lines (unstructured)
         Node &lines_idx = index_root["lines"];
@@ -183,11 +183,11 @@ create_blueprint_index_for_2d_examples(Node &index_root)
             lines_idx["fields/radial/association"] = "element";
             lines_idx["fields/radial/topology"]    = "mesh";
             lines_idx["fields/radial/path"]        = "lines/fields/radial";
-            // vec pc
-            lines_idx["fields/vec/number_of_components"] = 2;
-            lines_idx["fields/vec/association"] = "point";
-            lines_idx["fields/vec/topology"]    = "mesh";
-            lines_idx["fields/vec/path"]        = "lines/fields/vec";
+            // vel pc
+            lines_idx["fields/vel/number_of_components"] = 2;
+            lines_idx["fields/vel/association"] = "point";
+            lines_idx["fields/vel/topology"]    = "mesh";
+            lines_idx["fields/vel/path"]        = "lines/fields/vel";
 
     
     // tris (unstructured)
@@ -215,11 +215,11 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         tris_idx["fields/radial/association"] = "element";
         tris_idx["fields/radial/topology"]    = "mesh";
         tris_idx["fields/radial/path"]        = "tris/fields/radial";
-        // vec pc
-        tris_idx["fields/vec/number_of_components"] = 2;
-        tris_idx["fields/vec/association"] = "point";
-        tris_idx["fields/vec/topology"]    = "mesh";
-        tris_idx["fields/vec/path"]   = "tris/fields/vec";
+        // vel pc
+        tris_idx["fields/vel/number_of_components"] = 2;
+        tris_idx["fields/vel/association"] = "point";
+        tris_idx["fields/vel/topology"]    = "mesh";
+        tris_idx["fields/vel/path"]   = "tris/fields/vel";
 
     
     // quads (unstructured)
@@ -247,11 +247,11 @@ create_blueprint_index_for_2d_examples(Node &index_root)
         quads_idx["fields/radial/association"] = "element";
         quads_idx["fields/radial/topology"]    = "mesh";
         quads_idx["fields/radial/path"]        = "quads/fields/radial";
-        // vec pc
-        quads_idx["fields/vec/number_of_components"] = 2;
-        quads_idx["fields/vec/association"] = "point";
-        quads_idx["fields/vec/topology"]    = "mesh";
-        quads_idx["fields/vec/path"]        = "quads/fields/vec";
+        // vel pc
+        quads_idx["fields/vel/number_of_components"] = 2;
+        quads_idx["fields/vel/association"] = "point";
+        quads_idx["fields/vel/topology"]    = "mesh";
+        quads_idx["fields/vel/path"]        = "quads/fields/vel";
 
     
 }
@@ -285,11 +285,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             uni_idx["fields/radial/association"] = "element";
             uni_idx["fields/radial/topology"]    = "mesh";
             uni_idx["fields/radial/path"]        = "uniform/fields/radial";
-            // vec pc
-            uni_idx["fields/vec/number_of_components"] = 3;
-            uni_idx["fields/vec/association"] = "point";
-            uni_idx["fields/vec/topology"]    = "mesh";
-            uni_idx["fields/vec/path"]        = "uniform/fields/vec";
+            // vel pc
+            uni_idx["fields/vel/number_of_components"] = 3;
+            uni_idx["fields/vel/association"] = "point";
+            uni_idx["fields/vel/topology"]    = "mesh";
+            uni_idx["fields/vel/path"]        = "uniform/fields/vel";
 
 
     // rectilinear
@@ -317,11 +317,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             rect_idx["fields/radial/association"] = "element";
             rect_idx["fields/radial/topology"]    = "mesh";
             rect_idx["fields/radial/path"]        = "rect/fields/radial";
-            // vec pc
-            rect_idx["fields/vec/number_of_components"] = 3;
-            rect_idx["fields/vec/association"] = "point";
-            rect_idx["fields/vec/topology"]    = "mesh";
-            rect_idx["fields/vec/path"]        = "rect/fields/vec";
+            // vel pc
+            rect_idx["fields/vel/number_of_components"] = 3;
+            rect_idx["fields/vel/association"] = "point";
+            rect_idx["fields/vel/topology"]    = "mesh";
+            rect_idx["fields/vel/path"]        = "rect/fields/vel";
 
 
     // structured
@@ -349,11 +349,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             struct_idx["fields/radial/association"] = "element";
             struct_idx["fields/radial/topology"]    = "mesh";
             struct_idx["fields/radial/path"]        = "struct/fields/radial";
-            // vec pc
-            struct_idx["fields/vec/number_of_components"] = 3;
-            struct_idx["fields/vec/association"] = "point";
-            struct_idx["fields/vec/topology"]    = "mesh";
-            struct_idx["fields/vec/path"]        = "struct/fields/vec";
+            // vel pc
+            struct_idx["fields/vel/number_of_components"] = 3;
+            struct_idx["fields/vel/association"] = "point";
+            struct_idx["fields/vel/topology"]    = "mesh";
+            struct_idx["fields/vel/path"]        = "struct/fields/vel";
 
 
     // lines (unstructured)
@@ -381,11 +381,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
             lines_idx["fields/radial/association"] = "element";
             lines_idx["fields/radial/topology"]    = "mesh";
             lines_idx["fields/radial/path"]        = "lines/fields/radial";
-            // vec pc
-            lines_idx["fields/vec/number_of_components"] = 3;
-            lines_idx["fields/vec/association"] = "point";
-            lines_idx["fields/vec/topology"]    = "mesh";
-            lines_idx["fields/vec/path"]        = "lines/fields/vec";
+            // vel pc
+            lines_idx["fields/vel/number_of_components"] = 3;
+            lines_idx["fields/vel/association"] = "point";
+            lines_idx["fields/vel/topology"]    = "mesh";
+            lines_idx["fields/vel/path"]        = "lines/fields/vel";
 
     // tets (unstructured)
     Node &tets_idx = index_root["tets"];
@@ -412,11 +412,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         tets_idx["fields/radial/association"] = "element";
         tets_idx["fields/radial/topology"]    = "mesh";
         tets_idx["fields/radial/path"]        = "tets/fields/radial";
-        // vec pc
-        tets_idx["fields/vec/number_of_components"] = 3;
-        tets_idx["fields/vec/association"] = "point";
-        tets_idx["fields/vec/topology"]    = "mesh";
-        tets_idx["fields/vec/path"]        = "tets/fields/vec";
+        // vel pc
+        tets_idx["fields/vel/number_of_components"] = 3;
+        tets_idx["fields/vel/association"] = "point";
+        tets_idx["fields/vel/topology"]    = "mesh";
+        tets_idx["fields/vel/path"]        = "tets/fields/vel";
 
     
     // hexs (unstructured)
@@ -444,11 +444,11 @@ create_blueprint_index_for_3d_examples(Node &index_root)
         hexs_idx["fields/radial/association"] = "element";
         hexs_idx["fields/radial/topology"]    = "mesh";
         hexs_idx["fields/radial/path"]        = "hexs/fields/radial";
-        // vec pc
-        hexs_idx["fields/vec/number_of_components"] = 3;
-        hexs_idx["fields/vec/association"] = "point";
-        hexs_idx["fields/vec/topology"]    = "mesh";
-        hexs_idx["fields/vec/path"]        = "hexs/fields/vec";
+        // vel pc
+        hexs_idx["fields/vel/number_of_components"] = 3;
+        hexs_idx["fields/vel/association"] = "point";
+        hexs_idx["fields/vel/topology"]    = "mesh";
+        hexs_idx["fields/vel/path"]        = "hexs/fields/vel";
 
     
 }
@@ -585,7 +585,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
         
         CONDUIT_INFO("Creating ")
         CONDUIT_INFO("Creating: braid_2d_examples.hdf5.blueprint_root")
-        relay::io::save(root,"braid_2d_examples.hdf5.blueprint_root","hdf5");
+        relay::io::save(root,"braid_2d_examples.blueprint_root_hdf5","hdf5");
         CONDUIT_INFO("Creating: braid_2d_examples.hdf5")
         relay::io::save(dsets,"braid_2d_examples.hdf5");
     }
@@ -715,7 +715,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_3d)
         root["tree_pattern"] = "/";
 
         CONDUIT_INFO("Creating: braid_3d_examples.hdf5.blueprint_root")
-        relay::io::save(root,"braid_3d_examples.hdf5.blueprint_root","hdf5");
+        relay::io::save(root,"braid_3d_examples.blueprint_root_hdf5","hdf5");
         CONDUIT_INFO("Creating: braid_3d_examples.hdf5")
         relay::io::save(dsets,"braid_3d_examples.hdf5");
     }


### PR DESCRIPTION
adds a 2d and 3d example topologies that use lines.

these examples create meshes with lines elements that simply
represent the outline of the braid quads (2d), or hexs (3d) using
a naive approach.

With this approach there are lines that overlap spatially. This
was done so we could reuse the existing helper functions that
generate the values for the example element centered scalar field.
With more effort, we could create a better sample mesh.