### PR TITLE
enh: propagate ref_paths to all relay_hdf5 calls

### DIFF
--- a/src/tests/relay/CMakeLists.txt
+++ b/src/tests/relay/CMakeLists.txt
@@ -59,7 +59,7 @@ set(RELAY_TESTS t_relay_smoke
 ################################
 set(RELAY_MPI_TESTS      t_relay_mpi_smoke t_relay_mpi_test)
 set(RELAY_SILO_TESTS     t_relay_io_silo)
-set(RELAY_HDF5_TESTS     t_relay_io_hdf5)
+set(RELAY_HDF5_TESTS     t_relay_io_hdf5 t_relay_io_hdf5_read_and_print)
 
 
 ################################

--- a/src/tests/relay/t_relay_io_hdf5.cpp
+++ b/src/tests/relay/t_relay_io_hdf5.cpp
@@ -618,4 +618,45 @@ TEST(conduit_relay_io_hdf5, conduit_hdf5_write_read_childless_object)
 
 
 
+//-----------------------------------------------------------------------------
+TEST(conduit_relay_io_hdf5, conduit_hdf5_test_write_incompat)
+{
+    
+    Node n;
+    n["a/b/leaf"] = DataType::uint32(2);
+    n["a/b/grp/leaf"].set_uint32(10);
+    
+    uint32_array vals =  n["a/b/leaf"].value();
+    
+    vals[0] = 1;
+    vals[1] = 2;
+    
+    io::hdf5_write(n,"tout_hdf5_test_write_incompat.hdf5");
+
+    n.print();
+
+    Node n2;
+    n2["a/b/leaf/v"] = DataType::float64(2);
+    n2["a/b/grp/leaf/v"].set_float64(10.0);
+    
+    n2.print();
+
+    hid_t h5_file_id = H5Fopen("tout_hdf5_test_write_incompat.hdf5",
+                               H5F_ACC_RDWR,
+                               H5P_DEFAULT);
+
+    try
+    {
+        io::hdf5_write(n2,h5_file_id);
+    }
+    catch(Error &e)
+    {
+        CONDUIT_INFO(e.message());
+    }
+    
+    H5Fclose(h5_file_id);
+
+}
+
+
 

--- a/src/tests/relay/t_relay_io_hdf5_read_and_print.cpp
+++ b/src/tests/relay/t_relay_io_hdf5_read_and_print.cpp
@@ -1,0 +1,91 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_relay_io_hdf5_read_and_print.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "relay.hpp"
+#include "relay_hdf5.hpp"
+#include "hdf5.h"
+#include <iostream>
+#include "gtest/gtest.h"
+
+using namespace conduit;
+using namespace conduit::relay;
+
+std::string file_name;
+
+//-----------------------------------------------------------------------------
+TEST(conduit_relay_io_hdf5, conduit_hdf5_write_read_file_from_cmd_line)
+{
+    if(file_name.size() >0)
+    {
+        Node n;
+        io::hdf5_read(file_name,n);
+        n.print();
+    }
+}
+
+//-----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    int result = 0;
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    if(argc > 1)
+    {
+        file_name = std::string(argv[1]);
+    }
+
+    result = RUN_ALL_TESTS();
+    return result;
+}
+
+
+
+


### PR DESCRIPTION
adds references paths to all realy_hdf5 calls and leverage
these in compatibility and error checks.

Now the full path to where the error occurs is included
in the error message.

also added a helper that reads an hdf5 file using relay and prints
the resulting conduit hierarchy.

This resolves #19 