### PR TITLE
bugfix: windows logic for warnings and long long

### DIFF
--- a/src/libs/conduit/CMake/BitwidthChecks.cmake
+++ b/src/libs/conduit/CMake/BitwidthChecks.cmake
@@ -1,45 +1,45 @@
 ###############################################################################
 # Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
-# 
+#
 # Produced at the Lawrence Livermore National Laboratory
-# 
+#
 # LLNL-CODE-666778
-# 
+#
 # All rights reserved.
-# 
-# This file is part of Conduit. 
-# 
+#
+# This file is part of Conduit.
+#
 # For details, see: http://software.llnl.gov/conduit/.
-# 
+#
 # Please also read conduit/LICENSE
-# 
-# Redistribution and use in source and binary forms, with or without 
+#
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
-# * Redistributions of source code must retain the above copyright notice, 
+#
+# * Redistributions of source code must retain the above copyright notice,
 #   this list of conditions and the disclaimer below.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the disclaimer (as noted below) in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the LLNS/LLNL nor the names of its contributors may
 #   be used to endorse or promote products derived from this software without
 #   specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 ###############################################################################
 
 
@@ -54,26 +54,26 @@ set(CONDUIT_EMPTY_ID  0)
 set(CONDUIT_OBJECT_ID 1)
 set(CONDUIT_LIST_ID   2)
 ################################################
-# signed integer types 
+# signed integer types
 ################################################
 set(CONDUIT_INT8_ID   3)
 set(CONDUIT_INT16_ID  4)
 set(CONDUIT_INT32_ID  5)
 set(CONDUIT_INT64_ID  6)
 ################################################
-# unsigned integer types 
+# unsigned integer types
 ################################################
 set(CONDUIT_UINT8_ID   7)
 set(CONDUIT_UINT16_ID  8)
 set(CONDUIT_UINT32_ID  9)
 set(CONDUIT_UINT64_ID  10)
 ################################################
-# floating point types 
+# floating point types
 ################################################
 set(CONDUIT_FLOAT32_ID 11)
 set(CONDUIT_FLOAT64_ID 12)
 ################################################
-#  string types 
+#  string types
 ################################################
 set(CONDUIT_CHAR8_STR_ID  13)
 
@@ -81,7 +81,7 @@ set(CONDUIT_CHAR8_STR_ID  13)
 #-----------------------------------------------------------------------------
 # Logic to provide bitwidth annotated style standard data types
 #-----------------------------------------------------------------------------
-# Derived from numpy (which provides very comprehensive support 
+# Derived from numpy (which provides very comprehensive support
 # for these types)
 #-----------------------------------------------------------------------------
 
@@ -116,70 +116,94 @@ if(${CONDUIT_BITSOF_LONG} EQUAL "8")
     ####
     # conduit to native
     ####
-    set(CONDUIT_INT8_TYPE   "conduit_long")
-    set(CONDUIT_UINT8_TYPE  "conduit_ulong")
-    #
-    set(CONDUIT_INT8_NATIVE_TYPE  "long")
-    set(CONDUIT_UINT8_NATIVE_TYPE "unsigned long")
+    # make sure we haven't already mapped this type
+    if(NOT CONDUIT_INT8_TYPE)
+        set(CONDUIT_INT8_TYPE   "conduit_long")
+        set(CONDUIT_UINT8_TYPE  "conduit_ulong")
+        #
+        set(CONDUIT_INT8_NATIVE_TYPE  "long")
+        set(CONDUIT_UINT8_NATIVE_TYPE "unsigned long")
+    endif()
     ####
     # native to conduit
     ####
-    set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT8_ID})
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT8_ID})
-    #
-    set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int8")
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint8")
+    # check to see if the native type map has been made
+    if(NOT CONDUIT_NATIVE_LONG_TYPE)
+        set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT8_ID})
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT8_ID})
+        #
+        set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int8")
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint8")
+    endif()
 elseif(${CONDUIT_BITSOF_LONG} EQUAL 16)
     ####
     # conduit to native
     ####
-    set(CONDUIT_INT16_TYPE   "conduit_long")
-    set(CONDUIT_UINT16_TYPE  "conduit_ulong")
-    #
-    set(CONDUIT_INT16_NATIVE_TYPE  "long")
-    set(CONDUIT_UINT16_NATIVE_TYPE "unsigned long")
+    # make sure we haven't already mapped this type
+    if(NOT CONDUIT_INT16_TYPE)
+        set(CONDUIT_INT16_TYPE   "conduit_long")
+        set(CONDUIT_UINT16_TYPE  "conduit_ulong")
+        #
+        set(CONDUIT_INT16_NATIVE_TYPE  "long")
+        set(CONDUIT_UINT16_NATIVE_TYPE "unsigned long")
+    endif()
     ####
     # native to conduit
     ####
-    set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT16_ID})
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT16_ID})
-    #
-    set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int16")
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint16")
+    # check to see if the native type map has been made
+    if(NOT CONDUIT_NATIVE_LONG_TYPE)
+        set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT16_ID})
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT16_ID})
+        #
+        set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int16")
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint16")
+    endif()
 elseif(${CONDUIT_BITSOF_LONG} EQUAL 32)
     ####
     # conduit to native
     ####
-    set(CONDUIT_INT32_TYPE   "conduit_long")
-    set(CONDUIT_UINT32_TYPE  "conduit_ulong")
-    #
-    set(CONDUIT_INT32_NATIVE_TYPE  "long")
-    set(CONDUIT_UINT32_NATIVE_TYPE "unsigned long")
+    # make sure we haven't already mapped this type
+    if(NOT CONDUIT_INT32_TYPE)
+        set(CONDUIT_INT32_TYPE   "conduit_long")
+        set(CONDUIT_UINT32_TYPE  "conduit_ulong")
+        #
+        set(CONDUIT_INT32_NATIVE_TYPE  "long")
+        set(CONDUIT_UINT32_NATIVE_TYPE "unsigned long")
+    endif()
     ####
     # native to conduit
     ####
-    set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT32_ID})
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT32_ID})
-    #
-    set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int32")
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint32")
+    # check to see if the native type map has been made
+    if(NOT CONDUIT_NATIVE_LONG_TYPE)
+        set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT32_ID})
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT32_ID})
+        #
+        set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int32")
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint32")
+    endif()
 elseif(${CONDUIT_BITSOF_LONG} EQUAL 64)
     ####
     # conduit to native
     ####
-    set(CONDUIT_INT64_TYPE   "conduit_long")
-    set(CONDUIT_UINT64_TYPE  "conduit_ulong")
-    #
-    set(CONDUIT_INT64_NATIVE_TYPE  "long")
-    set(CONDUIT_UINT64_NATIVE_TYPE "unsigned long")
+    # make sure we haven't already mapped this type
+    if(NOT CONDUIT_INT64_TYPE)
+        set(CONDUIT_INT64_TYPE   "conduit_long")
+        set(CONDUIT_UINT64_TYPE  "conduit_ulong")
+        #
+        set(CONDUIT_INT64_NATIVE_TYPE  "long")
+        set(CONDUIT_UINT64_NATIVE_TYPE "unsigned long")
+    endif()
     ####
     # native to conduit
     ####
-    set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT64_ID})
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT64_ID})
-    #
-    set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int64")
-    set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint64")
+    # check to see if the native type map has been made
+    if(NOT CONDUIT_NATIVE_LONG_TYPE)
+        set(CONDUIT_NATIVE_LONG_ID          ${CONDUIT_INT64_ID})
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_ID ${CONDUIT_UINT64_ID})
+        #
+        set(CONDUIT_NATIVE_LONG_TYPE          "conduit_int64")
+        set(CONDUIT_NATIVE_UNSIGNED_LONG_TYPE "conduit_uint64")
+    endif()
 endif()
 
 #-----------------------------------------------------------------------------
@@ -780,5 +804,3 @@ message(STATUS " conduit::uint64 native type: ${CONDUIT_UINT64_NATIVE_TYPE}")
 #-----------------------------------------------------------------------------
 message(STATUS " conduit::float32 native type: ${CONDUIT_FLOAT32_NATIVE_TYPE}")
 message(STATUS " conduit::float64 native type: ${CONDUIT_FLOAT64_NATIVE_TYPE}")
-
-

--- a/src/libs/conduit/Node.cpp
+++ b/src/libs/conduit/Node.cpp
@@ -9276,6 +9276,18 @@ Node::as_unsigned_long_ptr()
 #ifdef CONDUIT_USE_LONG_LONG
 //---------------------------------------------------------------------------//
 //---------------------------------------------------------------------------//
+const unsigned long long *
+Node::as_unsigned_long_long_ptr() const
+{
+    CONDUIT_CHECK_DTYPE(this,
+        CONDUIT_NATIVE_UNSIGNED_LONG_LONG_ID,
+        "as_unsigned_long_long_ptr()",
+        NULL);
+    return (unsigned long long*)element_ptr(0);
+}
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
 unsigned long long *
 Node::as_unsigned_long_long_ptr()
 {
@@ -9286,6 +9298,7 @@ Node::as_unsigned_long_long_ptr()
     return (unsigned long long*)element_ptr(0);
 }
 //---------------------------------------------------------------------------//
+
 #endif
 //---------------------------------------------------------------------------//
 
@@ -9322,6 +9335,17 @@ Node::as_double_ptr()
 //---------------------------------------------------------------------------//
 long double *
 Node::as_long_double_ptr()
+{
+    CONDUIT_CHECK_DTYPE(this,
+        CONDUIT_NATIVE_LONG_DOUBLE_ID,
+        "as_long_double_ptr()",
+        NULL);
+    return (long double*)element_ptr(0);
+}
+
+//---------------------------------------------------------------------------//
+long double *
+Node::as_long_double_ptr() const
 {
     CONDUIT_CHECK_DTYPE(this,
                          CONDUIT_NATIVE_LONG_DOUBLE_ID,
@@ -9844,7 +9868,7 @@ Node::as_double_array() const
     return double_array(m_data,dtype());
 }
 //---------------------------------------------------------------------------//
-#ifdef CONDUIT_USE_LONG_LONG
+#ifdef CONDUIT_USE_LONG_DOUBLE
 //---------------------------------------------------------------------------//
 const long_double_array
 Node::as_long_double_array() const

--- a/src/libs/conduit/Node.hpp
+++ b/src/libs/conduit/Node.hpp
@@ -2605,18 +2605,21 @@ private:
 
     // signed integers via pointers
     #ifdef CONDUIT_USE_LONG_LONG
-    long long      *as_long_long_ptr() const;
+    long long       *as_long_long_ptr();
+    const long long *as_long_long_ptr() const;
     #endif
 
     // unsigned integers via pointers
     #ifdef CONDUIT_USE_LONG_LONG
-    unsigned long long  *as_unsigned_long_long_ptr() const;
+    unsigned long long        *as_unsigned_long_long_ptr();
+    const unsigned long long  *as_unsigned_long_long_ptr() const;
     #endif
 
 
     // floating point via pointers
     #ifdef CONDUIT_USE_LONG_DOUBLE
-    long double     *as_long_double_ptr();
+    long double         *as_long_double_ptr();
+    const long double   *as_long_double_ptr() const;
     #endif
 
     // signed integers via pointers (const variants)

--- a/src/libs/conduit/Utils.cpp
+++ b/src/libs/conduit/Utils.cpp
@@ -300,7 +300,7 @@ is_file(const std::string &path)
     bool res = false;
 #if defined(CONDUIT_PLATFORM_WINDOWS)
     // TODO
-    CONDUIT_WARNING("utils::is_directory not implemented on windows");
+    CONDUIT_WARN("utils::is_directory not implemented on windows");
 #else // unix, etc
     struct stat path_stat;
     stat(path.c_str(), &path_stat);
@@ -317,7 +317,7 @@ is_directory(const std::string &path)
     bool res = false;
 #if defined(CONDUIT_PLATFORM_WINDOWS)
     // TODO
-    CONDUIT_WARNING("utils::is_directory not implemented on windows");
+    CONDUIT_WARN("utils::is_directory not implemented on windows");
 #else // unix, etc
     DIR *dir = opendir(path.c_str());
     if(dir)


### PR DESCRIPTION
fix constness of private long long and long double methods

fix use of CONDUIT_WARNING instead of CONDUIT_WARN in a windows
only if def block

add extra checks to the  long case in bitwidth style checks so it can be

moved to after other types (if necessary)