### PR TITLE
bugfix: fix parse cmd line arg for node viewer

### DIFF
--- a/src/libs/relay/relay_web_node_viewer.cpp
+++ b/src/libs/relay/relay_web_node_viewer.cpp
@@ -86,7 +86,7 @@ usage()
 void
 parse_args(int argc,
            char *argv[],
-           std::string address,
+           std::string &address,
            int &port,
            bool &entangle,
            std::string &data_file,


### PR DESCRIPTION
fix bug with handling of the --address command line argument
for the conduit node viewer.