### PR TITLE
enh: use name instead of paths in several methods

### DIFF
--- a/src/libs/blueprint/blueprint_mcarray.cpp
+++ b/src/libs/blueprint/blueprint_mcarray.cpp
@@ -124,7 +124,7 @@ bool verify(const conduit::Node &n,
             if(chld.dtype().number_of_elements() != num_elems)
             {
                 std::ostringstream oss;
-                std::string chld_name = itr.path();
+                std::string chld_name = itr.name();
                 
                 if(chld_name.size() == 0)
                 {
@@ -146,7 +146,7 @@ bool verify(const conduit::Node &n,
         else
         {
             std::ostringstream oss;
-            std::string chld_name = itr.path();
+            std::string chld_name = itr.name();
 
             if(chld_name.size() == 0)
             {
@@ -187,7 +187,7 @@ to_contiguous(const conduit::Node &src,
         // get the next child
         const Node &chld = itr.next();
         // get the next child's name
-        std::string name = itr.path();
+        std::string name = itr.name();
         
         // use the child's data type to see our desired data type
         DataType curr_dt = chld.dtype();
@@ -236,7 +236,7 @@ to_interleaved(const conduit::Node &src,
         // get the next child
         const Node &chld = itr.next();
         // get the next child's name
-        std::string name = itr.path();
+        std::string name = itr.name();
         
         // use the child's data type to see our desired data type
         DataType curr_dt = chld.dtype();

--- a/src/libs/blueprint/blueprint_mesh.cpp
+++ b/src/libs/blueprint/blueprint_mesh.cpp
@@ -199,7 +199,7 @@ mesh::verify(const Node &n,
         while(itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if(!coordset::verify(chld,info["coordsets/" + chld_name]))
             {
@@ -230,7 +230,7 @@ mesh::verify(const Node &n,
         while(itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if(!topology::verify(chld,info["topologies"][chld_name]))
             {
@@ -273,7 +273,7 @@ mesh::verify(const Node &n,
         while(itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if(!field::verify(chld,info["fields/" + chld_name]))
             {
@@ -318,7 +318,7 @@ mesh::verify(const Node &n,
         while (itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if (chld.has_child("grid_function") &&
                 chld["grid_function"].dtype().is_string())
@@ -396,7 +396,7 @@ mesh::generate_index(const Node &mesh,
     while(itr.has_next())
     {
         const Node &coordset = itr.next();
-        std::string coordset_name = itr.path();
+        std::string coordset_name = itr.name();
         Node &idx_coordset = index_out["coordsets"][coordset_name];
         
         std::string coordset_type =   coordset["type"].as_string();
@@ -412,7 +412,7 @@ mesh::generate_index(const Node &mesh,
                 while(origin_itr.has_next())
                 {
                     origin_itr.next();
-                    idx_coordset["coord_system/axes"][origin_itr.path()];
+                    idx_coordset["coord_system/axes"][origin_itr.name()];
                 }
             }
             else if(coordset.has_child("spacing"))
@@ -421,7 +421,7 @@ mesh::generate_index(const Node &mesh,
                 while(spacing_itr.has_next())
                 {
                     spacing_itr.next();
-                    std::string axis_name = spacing_itr.path();
+                    std::string axis_name = spacing_itr.name();
                     // spacing names start with "d"
                     axis_name = axis_name.substr(1);
                     idx_coordset["coord_system/axes"][axis_name];
@@ -455,7 +455,7 @@ mesh::generate_index(const Node &mesh,
             while(values_itr.has_next())
             {
                 values_itr.next();
-                idx_coordset["coord_system/axes"][values_itr.path()];
+                idx_coordset["coord_system/axes"][values_itr.name()];
             }
         }
 
@@ -469,7 +469,7 @@ mesh::generate_index(const Node &mesh,
     while(itr.has_next())
     {
         const Node &topo = itr.next();
-        std::string topo_name = itr.path();
+        std::string topo_name = itr.name();
         Node &idx_topo = index_out["topologies"][topo_name];
         idx_topo["type"] = topo["type"].as_string();
         idx_topo["coordset"] = topo["coordset"].as_string();
@@ -489,7 +489,7 @@ mesh::generate_index(const Node &mesh,
         while(itr.has_next())
         {
             const Node &fld = itr.next();
-            std::string fld_name = itr.path();
+            std::string fld_name = itr.name();
             Node &idx_fld = index_out["fields"][fld_name];
             
             index_t ncomps = 1;
@@ -952,7 +952,7 @@ mesh::coordset::coord_system::verify(const Node &coord_sys,
                 bool axis_name_ok = true;
                 
                 itr.next();
-                std::string axis_name = itr.path();
+                std::string axis_name = itr.name();
                 if(coord_sys_str == "cartesian")
                 {
                     axis_name_ok = check_cart_coord_sys_axis_name(axis_name);
@@ -1241,7 +1241,7 @@ mesh::topology::unstructured::verify(const Node &topo,
             while(itr.has_next())
             {
                 const Node &cld  = itr.next();
-                std::string name = itr.path();
+                std::string name = itr.name();
                 
                 if(has_names)
                 {
@@ -1725,7 +1725,7 @@ mesh::index::verify(const Node &n,
         while(itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if(!coordset::index::verify(chld,info["coordsets/" + chld_name]))
             {
@@ -1756,7 +1756,7 @@ mesh::index::verify(const Node &n,
         while(itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if(!topology::index::verify(chld,info["topologies"][chld_name]))
             {
@@ -1799,7 +1799,7 @@ mesh::index::verify(const Node &n,
         while(itr.has_next())
         {
             const Node &chld = itr.next();
-            const std::string chld_name = itr.path();
+            const std::string chld_name = itr.name();
 
             if(!field::index::verify(chld,info["fields/" + chld_name]))
             {

--- a/src/libs/conduit/Node.cpp
+++ b/src/libs/conduit/Node.cpp
@@ -461,11 +461,10 @@ Node::set_node(const Node &node)
     if(node.dtype().id() == DataType::OBJECT_ID)
     {
         init(DataType::object());
-        std::vector<std::string> paths;
-        node.paths(paths);
+        const std::vector<std::string> &cld_names = node.child_names();
 
-        for (std::vector<std::string>::const_iterator itr = paths.begin();
-             itr < paths.end(); ++itr)
+        for (std::vector<std::string>::const_iterator itr = cld_names.begin();
+             itr < cld_names.end(); ++itr)
         {
             Schema *curr_schema = this->m_schema->fetch_ptr(*itr);
             size_t idx = (size_t) this->m_schema->child_index(*itr);
@@ -6975,11 +6974,10 @@ Node::update(const Node &n_src)
     index_t dtype_id = n_src.dtype().id();
     if( dtype_id == DataType::OBJECT_ID)
     {
-        std::vector<std::string> src_paths;
-        n_src.paths(src_paths);
+        const std::vector<std::string> &scld_names = n_src.child_names();
 
-        for (std::vector<std::string>::const_iterator itr = src_paths.begin();
-             itr < src_paths.end(); ++itr)
+        for (std::vector<std::string>::const_iterator itr = scld_names.begin();
+             itr < scld_names.end(); ++itr)
         {
             std::string ent_name = *itr;
             fetch(ent_name).update(n_src.fetch(ent_name));
@@ -7045,11 +7043,10 @@ Node::update_compatible(const Node &n_src)
     index_t dtype_id = n_src.dtype().id();
     if( dtype_id == DataType::OBJECT_ID)
     {
-        std::vector<std::string> src_paths;
-        n_src.paths(src_paths);
+        const std::vector<std::string> &scld_names = n_src.child_names();
 
-        for (std::vector<std::string>::const_iterator itr = src_paths.begin();
-             itr < src_paths.end(); ++itr)
+        for (std::vector<std::string>::const_iterator itr = scld_names.begin();
+             itr < scld_names.end(); ++itr)
         {
             std::string ent_name = *itr;
             if(has_path(ent_name))
@@ -7106,11 +7103,10 @@ Node::update_external(Node &n_src)
     index_t dtype_id = n_src.dtype().id();
     if( dtype_id == DataType::OBJECT_ID)
     {
-        std::vector<std::string> src_paths;
-        n_src.paths(src_paths);
+        const std::vector<std::string> &scld_names = n_src.child_names();
 
-        for (std::vector<std::string>::const_iterator itr = src_paths.begin();
-             itr < src_paths.end(); ++itr)
+        for (std::vector<std::string>::const_iterator itr = scld_names.begin();
+             itr < scld_names.end(); ++itr)
         {
             std::string ent_name = *itr;
             fetch(ent_name).update_external(n_src.fetch(ent_name));
@@ -11026,17 +11022,10 @@ Node::has_path(const std::string &path) const
 }
 
 //---------------------------------------------------------------------------//
-void
-Node::paths(std::vector<std::string> &paths) const
-{
-    m_schema->paths(paths);
-}
-
-//---------------------------------------------------------------------------//
 const std::vector<std::string>&
-Node::paths() const
+Node::child_names() const
 {
-    return m_schema->paths();
+    return m_schema->child_names();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/libs/conduit/Node.hpp
+++ b/src/libs/conduit/Node.hpp
@@ -3267,10 +3267,8 @@ public:
     bool        has_child(const std::string &name) const;
     /// checks if given path exists in the Node hierarchy 
     bool        has_path(const std::string &path) const;
-    /// returns the direct child paths for this node
-    void        paths(std::vector<std::string> &paths) const;
-    /// returns the direct child paths for this node
-    const std::vector<std::string> &paths() const;
+    /// returns the direct child names for this node
+    const std::vector<std::string> &child_names() const;
 
     /// adds an empty unnamed node to a list (list interface)
     /// TODO `append` is a strange name here, we want this interface

--- a/src/libs/conduit/NodeIterator.cpp
+++ b/src/libs/conduit/NodeIterator.cpp
@@ -120,7 +120,7 @@ NodeIterator::operator=(const NodeIterator &itr)
  
 //---------------------------------------------------------------------------//
 std::string
-NodeIterator::path() const
+NodeIterator::name() const
 {
     return m_node->m_schema->object_order()[(size_t)(m_index-1)];
 }
@@ -349,7 +349,7 @@ NodeConstIterator::operator=(const NodeIterator &itr)
  
 //---------------------------------------------------------------------------//
 std::string
-NodeConstIterator::path() const
+NodeConstIterator::name() const
 {
     return m_node->m_schema->object_order()[(size_t)(m_index-1)];
 }

--- a/src/libs/conduit/NodeIterator.hpp
+++ b/src/libs/conduit/NodeIterator.hpp
@@ -105,7 +105,7 @@ public:
 //-----------------------------------------------------------------------------
 /// Iterator value and property access.
 //-----------------------------------------------------------------------------
-    std::string path()  const;
+    std::string name()  const;
     index_t     index() const;
     Node       &node();
     void        to_front();
@@ -192,7 +192,7 @@ public:
 //-----------------------------------------------------------------------------
 /// Iterator value and property access.
 //-----------------------------------------------------------------------------
-    std::string path()  const;
+    std::string name()  const;
     index_t     index() const;
     const Node &node();
     void        to_front();

--- a/src/libs/conduit/Schema.cpp
+++ b/src/libs/conduit/Schema.cpp
@@ -68,6 +68,8 @@
 namespace conduit
 {
 
+std::vector<std::string> Schema::m_empty_child_names;
+
 //=============================================================================
 //-----------------------------------------------------------------------------
 //
@@ -978,18 +980,19 @@ Schema::has_path(const std::string &path) const
     }
 }
 
-//---------------------------------------------------------------------------//
-void
-Schema::paths(std::vector<std::string> &paths) const
-{
-    paths = object_order();
-}
 
 //---------------------------------------------------------------------------//
 const std::vector<std::string>&
-Schema::paths() const
+Schema::child_names() const
 {
-    return object_order();
+    if(m_dtype.is_object())
+    {
+        return object_order();
+    }
+    else
+    {
+        return m_empty_child_names;
+    }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/libs/conduit/Schema.cpp
+++ b/src/libs/conduit/Schema.cpp
@@ -652,7 +652,7 @@ Schema::remove(index_t idx)
     }
     
     std::vector<Schema*>  &chldrn = children();
-    if( (size_t)idx > chldrn.size())
+    if( (size_t)idx >= chldrn.size())
     {
         CONDUIT_ERROR("<Schema::remove> Invalid index:" 
                     << idx << ">" << chldrn.size() <<  "(list_size)");

--- a/src/libs/conduit/Schema.hpp
+++ b/src/libs/conduit/Schema.hpp
@@ -278,8 +278,7 @@ public:
     
     bool              has_child(const std::string &name) const;
     bool              has_path(const std::string &path) const;
-    void              paths(std::vector<std::string> &paths) const;
-    const std::vector<std::string> &paths() const;
+    const std::vector<std::string> &child_names() const;
     void              remove(const std::string &path);
     
 //-----------------------------------------------------------------------------
@@ -336,6 +335,10 @@ private:
         std::vector<std::string>        object_order;
         std::map<std::string, index_t>  object_map;
     };
+
+    // this is used to return a ref to an empty list of strings as 
+    // child names when the schema is not in the object role.
+    static std::vector<std::string>     m_empty_child_names;
 
 //-----------------------------------------------------------------------------
 //

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -2716,9 +2716,9 @@ PyConduit_NodeIterator_iternext(PyObject *self)
 
 //---------------------------------------------------------------------------//
 static PyObject *
-PyConduit_NodeIterator_path(PyConduit_NodeIterator *self)
+PyConduit_NodeIterator_name(PyConduit_NodeIterator *self)
 {
-    return (Py_BuildValue("s", self->itr.path().c_str()));
+    return (Py_BuildValue("s", self->itr.name().c_str()));
 }
 
 //---------------------------------------------------------------------------//
@@ -2859,8 +2859,8 @@ PyConduit_NodeIterator_info(PyConduit_NodeIterator *self)
 //----------------------------------------------------------------------------//
 static PyMethodDef PyConduit_NodeIterator_METHODS[] = {
     //-----------------------------------------------------------------------//
-    {"path",
-     (PyCFunction)PyConduit_NodeIterator_path, 
+    {"name",
+     (PyCFunction)PyConduit_NodeIterator_name, 
      METH_NOARGS,
      "{todo}"}, 
     //-----------------------------------------------------------------------//
@@ -3409,21 +3409,22 @@ PyConduit_Node_has_path(PyConduit_Node *self,
 
 //---------------------------------------------------------------------------//
 static PyObject * 
-PyConduit_Node_paths(PyConduit_Node *self)
+PyConduit_Node_child_names(PyConduit_Node *self)
 {
-    std::vector<std::string> paths;
-    self->node->paths(paths);
-    
     /// TODO: I think there is a faster way in the Python CAPI
     /// since we know the size of the list.
     PyObject *retval = PyList_New(0);
     
-    for (std::vector<std::string>::const_iterator itr = paths.begin();
-         itr < paths.end(); ++itr)
+    if(self->node->dtype().is_object())
     {
-        PyList_Append(retval, PyString_FromString( (*itr).c_str()));
-    };
+        const std::vector<std::string> cld_names = self->node->child_names();
+        for (std::vector<std::string>::const_iterator itr = cld_names.begin();
+             itr < cld_names.end(); ++itr)
+        {
+            PyList_Append(retval, PyString_FromString( (*itr).c_str()));
+        };
 
+    }
     return retval;
 }
 
@@ -3858,10 +3859,10 @@ static PyMethodDef PyConduit_Node_METHODS[] = {
      METH_VARARGS, 
      "Returns if this node has the given path"},
     //-----------------------------------------------------------------------//
-    {"paths",
-     (PyCFunction)PyConduit_Node_paths,
+    {"child_names",
+     (PyCFunction)PyConduit_Node_child_names,
      METH_NOARGS, 
-     "Returns a list with this node's child paths"},
+     "Returns a list with this node's child names"},
      //-----------------------------------------------------------------------//
      {"info",
       (PyCFunction)PyConduit_Node_info,

--- a/src/libs/relay/relay_hdf5.cpp
+++ b/src/libs/relay/relay_hdf5.cpp
@@ -621,10 +621,10 @@ check_if_conduit_object_is_compatible_with_hdf5_tree(const Node &node,
             // as the node's child
         
             hid_t h5_child_obj = H5Oopen(hdf5_id,
-                                        itr.path().c_str(),
+                                        itr.name().c_str(),
                                         H5P_DEFAULT);
         
-            std::string chld_ref_path = join_ref_paths(ref_path,itr.path());
+            std::string chld_ref_path = join_ref_paths(ref_path,itr.name());
             if( CONDUIT_HDF5_VALID_ID(h5_child_obj) )
             {
                 // if a child does exist, we need to make sure the child is 
@@ -983,7 +983,7 @@ write_conduit_object_to_hdf5_group(const Node &node,
             write_conduit_leaf_to_hdf5_group(child,
                                              ref_path,
                                              hdf5_group_id,
-                                             itr.path().c_str());
+                                             itr.name().c_str());
         }
         else if(dt.is_empty())
         {
@@ -991,7 +991,7 @@ write_conduit_object_to_hdf5_group(const Node &node,
             // a dataset with an null shape
             write_conduit_empty_to_hdf5_group(hdf5_group_id,
                                               ref_path,
-                                              itr.path().c_str());
+                                              itr.name().c_str());
         }
         else if(dt.is_object())
         {
@@ -999,7 +999,7 @@ write_conduit_object_to_hdf5_group(const Node &node,
             // as the node's child
             H5O_info_t h5_obj_info;
             herr_t h5_info_status =  H5Oget_info_by_name(hdf5_group_id,
-                                                         itr.path().c_str(),
+                                                         itr.name().c_str(),
                                                          &h5_obj_info,
                                                          H5P_DEFAULT);
             
@@ -1009,14 +1009,14 @@ write_conduit_object_to_hdf5_group(const Node &node,
             {
                 // if the hdf5 group exists, open it
                 h5_child_id = H5Gopen(hdf5_group_id,
-                                      itr.path().c_str(),
+                                      itr.name().c_str(),
                                       H5P_DEFAULT);
 
                 CONDUIT_CHECK_HDF5_ERROR_WITH_REF_PATH(h5_child_id,
                                                        ref_path,
                                              "Failed to open HDF5 Group "
                                              << " parent: " << hdf5_group_id
-                                             << " name: "   << itr.path());
+                                             << " name: "   << itr.name());
             }
             else
             {
@@ -1032,7 +1032,7 @@ write_conduit_object_to_hdf5_group(const Node &node,
                                  << " list");
 
                 h5_child_id = H5Gcreate(hdf5_group_id,
-                                        itr.path().c_str(),
+                                        itr.name().c_str(),
                                         H5P_DEFAULT,
                                         h5_gc_plist,
                                         H5P_DEFAULT);
@@ -1041,7 +1041,7 @@ write_conduit_object_to_hdf5_group(const Node &node,
                                                        ref_path,
                                       "Failed to create HDF5 Group "
                                       << " parent: " << hdf5_group_id
-                                      << " name: "   << itr.path());
+                                      << " name: "   << itr.name());
 
                 CONDUIT_CHECK_HDF5_ERROR_WITH_REF_PATH(H5Pclose(h5_gc_plist),
                                                        ref_path,

--- a/src/libs/relay/relay_silo.cpp
+++ b/src/libs/relay/relay_silo.cpp
@@ -1207,7 +1207,7 @@ silo_mesh_write(const Node &n,
     {
         const Node &n_topo = topo_itr.next();
         
-        std::string topo_name = topo_itr.path();
+        std::string topo_name = topo_itr.name();
     
         std::string topo_type = n_topo["type"].as_string();
 
@@ -1316,7 +1316,7 @@ silo_mesh_write(const Node &n,
         while(itr.has_next())
         {
             const Node &n_var = itr.next();
-            std::string var_name = itr.path();
+            std::string var_name = itr.name();
             silo_write_field(dbfile,
                              var_name,
                              n_var,

--- a/src/tests/blueprint/t_blueprint_mcarray_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mcarray_examples.cpp
@@ -392,7 +392,7 @@ TEST(conduit_blueprint_mcarray_examples, mcarray_xyz)
     {
         Node info;
         Node &mcarray = itr.next();
-        std::string name = itr.path();
+        std::string name = itr.name();
         // TODO: tests!
     }
 }

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -591,7 +591,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
     {
         Node info;
         const Node &mesh = itr.next();
-        std::string mesh_name = itr.path();
+        std::string mesh_name = itr.name();
         
         EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
         CONDUIT_INFO(info.to_json());
@@ -618,7 +618,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
         while(itr.has_next())
         {
             const Node &mesh = itr.next();
-            std::string name = itr.path();
+            std::string name = itr.name();
             CONDUIT_INFO("saving 2d example '" << name << "' to silo");
             // Skip output of silo mesh for mixed mesh of tris and quads for now.
             // The silo output is not yet defined and it throws an exception
@@ -653,7 +653,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
         {
 
             const Node &chld = idx_itr.next();
-            EXPECT_TRUE(blueprint::mesh::index::verify(chld,info[idx_itr.path()]));
+            EXPECT_TRUE(blueprint::mesh::index::verify(chld,info[idx_itr.name()]));
         }
 
         CONDUIT_INFO("blueprint::mesh::index verify info:");
@@ -748,7 +748,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_3d)
     {
         Node info;
         const Node &mesh = itr.next();
-        std::string mesh_name = itr.path();
+        std::string mesh_name = itr.name();
         
         EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
         CONDUIT_INFO(info.to_json());
@@ -776,7 +776,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_3d)
         {
             const Node &mesh = itr.next();
             //mesh.print();
-            std::string name = itr.path();
+            std::string name = itr.name();
             CONDUIT_INFO("saving 3d example '" << name << "' to silo")
 
             // Skip output of silo mesh for mixed mesh of hexs and tets for now.
@@ -808,7 +808,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_3d)
         {
 
             const Node &chld = idx_itr.next();
-            EXPECT_TRUE(blueprint::mesh::index::verify(chld,info[idx_itr.path()]));
+            EXPECT_TRUE(blueprint::mesh::index::verify(chld,info[idx_itr.name()]));
         }
         
         CONDUIT_INFO("blueprint::mesh::index verify info:");

--- a/src/tests/conduit/python/t_python_conduit_node.py
+++ b/src/tests/conduit/python/t_python_conduit_node.py
@@ -145,7 +145,7 @@ class Test_Conduit_Node(unittest.TestCase):
         n['c'] = 3
         for v in ['a','b','c']:
             self.assertTrue(n.has_path(v))
-        paths = n.paths()
+        paths = n.child_names()
         for v in ['a','b','c']:
             self.assertTrue(v in paths)
 
@@ -168,11 +168,11 @@ class Test_Conduit_Node(unittest.TestCase):
         self.assertEqual(n.number_of_children(),3)
         n.remove(path='c')
         self.assertEqual(n.number_of_children(),2)
-        paths = n.paths()
+        paths = n.child_names()
         for v in ['a','b']:
             self.assertTrue(v in paths)
         n.remove(index=0)
-        paths = n.paths()
+        paths = n.child_names()
         for v in ['b']:
             self.assertTrue(v in paths)
 

--- a/src/tests/conduit/python/t_python_conduit_node_iterator.py
+++ b/src/tests/conduit/python/t_python_conduit_node_iterator.py
@@ -74,7 +74,7 @@ class Test_Conduit_Node_Iterator(unittest.TestCase):
         self.assertTrue(itr.has_next())
         print(itr.has_next());
         for v in itr:
-            print(v.path(), v.node())
+            print(v.name(), v.node())
             idx = v.index()
             if idx == 0:
                 self.assertEqual(v.node().value(),a_val)

--- a/src/tests/conduit/t_conduit_node_iterator.cpp
+++ b/src/tests/conduit/t_conduit_node_iterator.cpp
@@ -84,13 +84,13 @@ TEST(conduit_node_iterator, simple_1)
         
         if(i == 0)
         {
-            EXPECT_EQ("a",itr.path());
+            EXPECT_EQ("a",itr.name());
             EXPECT_EQ(i,itr.index());
             EXPECT_EQ(a_val,n.as_uint32());
         }
         else if(i == 1)
         {
-            EXPECT_EQ("b",itr.path());
+            EXPECT_EQ("b",itr.name());
             EXPECT_EQ(i,itr.index());
             EXPECT_EQ(b_val,n.as_uint32());
         }
@@ -104,13 +104,13 @@ TEST(conduit_node_iterator, simple_1)
         
         if(i == 1)
         {
-            EXPECT_EQ("a",itr.path());
+            EXPECT_EQ("a",itr.name());
             EXPECT_EQ(i,itr.index());
             EXPECT_EQ(a_val,n.as_uint32());
         }
         else if(i == 2)
         {
-            EXPECT_EQ("b",itr.path());
+            EXPECT_EQ("b",itr.name());
             EXPECT_EQ(i,itr.index());
             EXPECT_EQ(b_val,n.as_uint32());
         }
@@ -209,18 +209,18 @@ TEST(conduit_node_iterator, move_cursor)
 
     EXPECT_TRUE(itr.has_next());
     EXPECT_EQ(itr.next().as_uint32(),a_val);
-    EXPECT_EQ(itr.path(),"a");
+    EXPECT_EQ(itr.name(),"a");
     
     EXPECT_TRUE(itr.has_next());
     EXPECT_EQ(itr.next().as_uint32(),b_val);
-    EXPECT_EQ(itr.path(),"b");
+    EXPECT_EQ(itr.name(),"b");
 
     //  create new iterator with current state of itr
     NodeIterator itr_2(itr);
     
     EXPECT_TRUE(itr.has_next());
     EXPECT_EQ(itr.next().as_string(),"myval");
-    EXPECT_EQ(itr.path(),"c");
+    EXPECT_EQ(itr.name(),"c");
     
     EXPECT_FALSE(itr.has_next());
     
@@ -228,7 +228,7 @@ TEST(conduit_node_iterator, move_cursor)
     
     EXPECT_TRUE(itr_2.has_next());
     EXPECT_EQ(itr_2.next().as_string(),"myval");
-    EXPECT_EQ(itr_2.path(),"c");
+    EXPECT_EQ(itr_2.name(),"c");
     
     EXPECT_FALSE(itr_2.has_next());
     
@@ -308,22 +308,22 @@ TEST(conduit_node_iterator, const_move_cursor)
 
     EXPECT_TRUE(itr.has_next());
     EXPECT_EQ(itr.next().as_uint32(),a_val);
-    EXPECT_EQ(itr.path(),"a");
+    EXPECT_EQ(itr.name(),"a");
     
     EXPECT_TRUE(itr.has_next());
     EXPECT_EQ(itr.next().as_uint32(),b_val);
-    EXPECT_EQ(itr.path(),"b");
+    EXPECT_EQ(itr.name(),"b");
 
     EXPECT_TRUE(itr.has_next());
     EXPECT_EQ(itr.next().as_string(),"myval");
-    EXPECT_EQ(itr.path(),"c");
+    EXPECT_EQ(itr.name(),"c");
     
     EXPECT_FALSE(itr.has_next());
 
 
     EXPECT_TRUE(itr.has_previous());
     EXPECT_EQ(itr.previous().as_uint32(),b_val);
-    EXPECT_EQ(itr.path(),"b");
+    EXPECT_EQ(itr.name(),"b");
     
     
     NodeConstIterator itr_2(itr);
@@ -331,7 +331,7 @@ TEST(conduit_node_iterator, const_move_cursor)
 
     EXPECT_TRUE(itr_2.has_next());
     EXPECT_EQ(itr_2.next().as_string(),"myval");
-    EXPECT_EQ(itr_2.path(),"c");
+    EXPECT_EQ(itr_2.name(),"c");
     
     EXPECT_FALSE(itr_2.has_next());
     
@@ -340,7 +340,7 @@ TEST(conduit_node_iterator, const_move_cursor)
     
     EXPECT_TRUE(itr_2.has_next());
     EXPECT_EQ(itr_2.next().as_string(),"myval");
-    EXPECT_EQ(itr_2.path(),"c");
+    EXPECT_EQ(itr_2.name(),"c");
     
     EXPECT_FALSE(itr_2.has_next());
     

--- a/src/tests/conduit/t_conduit_node_paths.cpp
+++ b/src/tests/conduit/t_conduit_node_paths.cpp
@@ -111,7 +111,7 @@ TEST(conduit_node_paths, simple_paths)
     Schema schema("{\"a\":\"uint32\",\"b\":\"uint32\",\"c\":\"float64\"}");
     Node n(schema,data,true);
     std::cout << n.schema().to_json() << std::endl; 
-    const std::vector<std::string>& npaths = n.paths();
+    const std::vector<std::string>& npaths = n.child_names();
     EXPECT_EQ(npaths.size(),3);
     EXPECT_EQ(npaths[0],"a");
     EXPECT_EQ(npaths[1],"b");
@@ -120,7 +120,7 @@ TEST(conduit_node_paths, simple_paths)
     Schema schema2("{\"g\": {\"a\":\"uint32\",\"b\":\"uint32\",\"c\":\"float64\"}}");
     Node n2(schema2,data,true);
     std::cout << n2.schema().to_json() << std::endl;
-    const std::vector<std::string>& n2paths = n2.paths();
+    const std::vector<std::string>& n2paths = n2.child_names();
     EXPECT_EQ(n2paths.size(),1);
     EXPECT_EQ(n2paths[0],"g");
 

--- a/src/tests/conduit/t_conduit_schema.cpp
+++ b/src/tests/conduit/t_conduit_schema.cpp
@@ -237,6 +237,10 @@ TEST(schema_basics, schema_fetch_child)
 
     const Schema &s_c = s["c"];
 
+    const Schema &s_c_idx = s[2];
+    
+    EXPECT_EQ(&s_c,&s_c_idx);
+
     EXPECT_THROW(s.fetch_child("bad"),conduit::Error);
     EXPECT_THROW(const Schema &s_bad = s_c.fetch_child("bad"),conduit::Error);
     
@@ -248,6 +252,54 @@ TEST(schema_basics, schema_fetch_child)
 
     EXPECT_TRUE(s_e.dtype().is_int64());
 
+}
+
+
+
+//-----------------------------------------------------------------------------
+TEST(schema_basics, schema_child_names)
+{
+    Schema s;
+    s["a"].set(DataType::int64());
+    s["b"].set(DataType::float64());
+    s["c"].set(DataType::float64());
+    s["d/e"].set(DataType::int64());
+    
+    const std::vector<std::string> &cld_names = s.child_names();
+    
+    const std::vector<std::string> &sde_names = s["d/e"].child_names();
+
+    EXPECT_EQ(cld_names[0],std::string("a"));
+    EXPECT_EQ(cld_names[1],std::string("b"));
+    EXPECT_EQ(cld_names[2],std::string("c"));
+    EXPECT_EQ(cld_names[3],std::string("d"));
+
+    EXPECT_EQ(sde_names.size(),0);
+
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(schema_basics, schema_errors)
+{
+    Schema s;
+    s["a"].set(DataType::int64());
+    s["b"].set(DataType::float64());
+    s["c"].set(DataType::float64());
+    
+    EXPECT_THROW(s.save("/dev/null/bad"),conduit::Error);
+    EXPECT_THROW(s.load("/dev/null/bad"),conduit::Error);
+
+    s.reset(); // can remove from empty
+    EXPECT_THROW(s.remove(0),conduit::Error);
+    s.append(); // now we have a list with one element
+    EXPECT_THROW(s.remove(1),conduit::Error);
+    
+    s.reset();
+    EXPECT_THROW(s.remove("a"),conduit::Error);
+    EXPECT_THROW(s.fetch_child("a"),conduit::Error);
+    s = DataType::object();
+    EXPECT_THROW(s.fetch_child(".."),conduit::Error);
 }
 
 


### PR DESCRIPTION
change Node::paths() to Node::child_names()
change Schema::paths() to Schema::child_names()

remove copy out variants of Node::paths and Schema::paths

return const ref to empty string vec for case where Node
is not in the object role (avoid exception)

change NodeIterator::path() to NodeIterator::name()