### PR TITLE
tests: add test cases for mcarray/mesh verify functions

### DIFF
--- a/src/libs/blueprint/blueprint_mesh.cpp
+++ b/src/libs/blueprint/blueprint_mesh.cpp
@@ -689,29 +689,26 @@ mesh::coordset::uniform::verify(const Node &coordset,
     }
     else
     {
-        const Node &dims = coordset["dims"];
-        
-        if(!mesh::logical_dims::verify(dims,info["dims"]))
-        {
-            res= false;
-        }
-    }
-    
-    if(!coordset.has_child("origin"))
-    {
-        log_optional(info,proto_name, "has origin");
-        
-        if(!mesh::coordset::uniform::origin::verify(coordset["dims"],
-                                                    info["dims"]))
+        if(!mesh::logical_dims::verify(coordset["dims"],info["dims"]))
         {
             res= false;
         }
     }
 
-    if(!coordset.has_child("spacing"))
+    if(coordset.has_child("origin"))
+    {
+        log_optional(info,proto_name, "has origin");
+
+        if(!mesh::coordset::uniform::origin::verify(coordset["origin"],
+                                                    info["origin"]))
+        {
+            res= false;
+        }
+    }
+
+    if(coordset.has_child("spacing"))
     {
         log_optional(info,proto_name, "has spacing");
-        
 
         if(!mesh::coordset::uniform::spacing::verify(coordset["spacing"],
                                                      info["spacing"]))

--- a/src/libs/blueprint/blueprint_mesh.cpp
+++ b/src/libs/blueprint/blueprint_mesh.cpp
@@ -890,12 +890,10 @@ check_cyln_coord_sys_axis_name(std::string &name)
 bool
 mesh::coordset::coord_system::verify(const Node &coord_sys,
                                      Node &info)
-{    
+{
     bool res = true;
 
-    
     std::string proto_name = "mesh::coordset::coord_system";
-
     std::string coord_sys_str = "unknown";
 
     if(!coord_sys.has_child("type"))
@@ -947,7 +945,7 @@ mesh::coordset::coord_system::verify(const Node &coord_sys,
             while(itr.has_next())
             {
                 bool axis_name_ok = true;
-                
+
                 itr.next();
                 std::string axis_name = itr.name();
                 if(coord_sys_str == "cartesian")

--- a/src/tests/blueprint/CMakeLists.txt
+++ b/src/tests/blueprint/CMakeLists.txt
@@ -50,6 +50,8 @@
 # blueprint lib Unit Tests
 ################################
 set(BLUEPRINT_TESTS t_blueprint_smoke 
+                    t_blueprint_mesh_verify
+                    t_blueprint_mcarray_verify
                     t_blueprint_mesh_examples
                     t_blueprint_mcarray_examples)
 

--- a/src/tests/blueprint/t_blueprint_mcarray_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mcarray_examples.cpp
@@ -58,102 +58,43 @@
 using namespace conduit;
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mcarray_examples, verify_mcarray)
+TEST(conduit_blueprint_mcarray_examples, mcarray_verify)
 {
-    ///
-    /// cases we expect to fail
-    ///
-    
-    
     Node n, info;
-    n["here/there"]     = 10;
-    n["here/everywhere"] = 10;
-    
-    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
 
     n.reset();
-    n["x"].set(DataType::float64(10));
-    n["y"].set(DataType::float64(5));
-    
-    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+    blueprint::mcarray::examples::xyz("separate",5,n);
+    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
 
-    ///
-    /// cases we expect to work
-    ///
-    
     n.reset();
-    n["x"].set(DataType::float64(10));
+    blueprint::mcarray::examples::xyz("interleaved",5,n);
     EXPECT_TRUE(blueprint::mcarray::verify(n,info));
 
-    n["y"].set(DataType::float64(10));
+    n.reset();
+    blueprint::mcarray::examples::xyz("contiguous",5,n);
     EXPECT_TRUE(blueprint::mcarray::verify(n,info));
-    
-    blueprint::mcarray::examples::xyz("separate",
-                                  5,
-                                  n);
-    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
-
-    blueprint::mcarray::examples::xyz("interleaved",
-                                  5,
-                                  n);
-    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
-
-    blueprint::mcarray::examples::xyz("contiguous",
-                                  5,
-                                  n);
-    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
-
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mcarray_examples, verify_mcarray_generic)
+TEST(conduit_blueprint_mcarray_examples, mcarray_verify_generic)
 {
-    ///
-    /// cases we expect to fail
-    ///
-    
-    
     Node n, info;
-    n["here/there"]     = 10;
-    n["here/everywhere"] = 10;
-    
-    EXPECT_FALSE(blueprint::verify("mcarray",n,info));
 
     n.reset();
-    n["x"].set(DataType::float64(10));
-    n["y"].set(DataType::float64(5));
-    
-    EXPECT_FALSE(blueprint::verify("mcarray",n,info));
+    blueprint::mcarray::examples::xyz("separate",5,n);
+    EXPECT_TRUE(blueprint::verify("mcarray",n,info));
 
-    ///
-    /// cases we expect to work
-    ///
-    
     n.reset();
-    n["x"].set(DataType::float64(10));
+    blueprint::mcarray::examples::xyz("interleaved",5,n);
     EXPECT_TRUE(blueprint::verify("mcarray",n,info));
 
-    n["y"].set(DataType::float64(10));
-    EXPECT_TRUE(blueprint::verify("mcarray",n,info));
-    
-    blueprint::mcarray::examples::xyz("separate",
-                                  5,
-                                  n);
-    EXPECT_TRUE(blueprint::verify("mcarray",n,info));
-
-    blueprint::mcarray::examples::xyz("interleaved",
-                                  5,
-                                  n);
-    EXPECT_TRUE(blueprint::verify("mcarray",n,info));
-
-    blueprint::mcarray::examples::xyz("contiguous",
-                                  5,
-                                  n);
+    n.reset();
+    blueprint::mcarray::examples::xyz("contiguous",5,n);
     EXPECT_TRUE(blueprint::verify("mcarray",n,info));
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mcarray_examples, mcarray_test_to_contig)
+TEST(conduit_blueprint_mcarray_examples, mcarray_to_contiguous)
 {
     
     Node n;
@@ -206,7 +147,7 @@ TEST(conduit_blueprint_mcarray_examples, mcarray_test_to_contig)
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mcarray_examples, mcarray_test_to_interleaved)
+TEST(conduit_blueprint_mcarray_examples, mcarray_to_interleaved)
 {
     
     Node n;

--- a/src/tests/blueprint/t_blueprint_mcarray_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mcarray_verify.cpp
@@ -156,3 +156,13 @@ TEST(conduit_blueprint_mcarray_verify, invalid_array_contents)
     n["m"].set(0.0f);
     EXPECT_FALSE(blueprint::mcarray::verify(n,info));
 }
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, verify_with_protocol)
+{
+    Node n, info;
+
+    EXPECT_FALSE(blueprint::mcarray::verify("protocol",n,info));
+    EXPECT_FALSE(blueprint::mcarray::verify("mcarray",n,info));
+}

--- a/src/tests/blueprint/t_blueprint_mcarray_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mcarray_verify.cpp
@@ -1,0 +1,158 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see https://lc.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_blueprint_mesh_verify.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+#include "blueprint.hpp"
+#include "relay.hpp"
+
+#include <iostream>
+#include "gtest/gtest.h"
+
+using namespace conduit;
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, valid_separate)
+{
+    Node n, info;
+
+    n["x"].set(DataType::float64(10));
+    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
+
+    n["y"].set(DataType::float64(10));
+    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
+
+    n["z"].set(DataType::float64(10));
+    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, valid_contiguous)
+{
+    Node n, info;
+
+    Schema s;
+    s["x"].set(DataType::float64(10));
+    s["y"].set(DataType::float64(10,10*sizeof(conduit::float64)));
+    s["z"].set(DataType::float64(10,20*sizeof(conduit::float64)));
+    n.set(s);
+
+    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, valid_interleaved)
+{
+    Node n, info;
+
+    Schema s;
+    s["x"].set(DataType::float64(10,0*sizeof(conduit::float64),3*sizeof(conduit::float64)));
+    s["y"].set(DataType::float64(10,1*sizeof(conduit::float64),3*sizeof(conduit::float64)));
+    s["z"].set(DataType::float64(10,2*sizeof(conduit::float64),3*sizeof(conduit::float64)));
+    n.set(s);
+
+    EXPECT_TRUE(blueprint::mcarray::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, invalid_node_type)
+{
+    Node n, info;
+
+    n.set(0.0f);
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+
+    n.set("test");
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, invalid_array_types)
+{
+    Node n, info;
+
+    n.reset();
+    n["x"].set(DataType::char8_str(10));
+    n["y"].set(DataType::char8_str(10));
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+
+    n.reset();
+    n["x"].set(DataType::float64(10));
+    n["y"].set(DataType::float64(10));
+    n["z"].set(DataType::char8_str(10));
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mcarray_verify, invalid_array_contents)
+{
+    Node n, info;
+
+    n.reset();
+    n["x"].set(DataType::float64(10));
+    n["y"].set(DataType::float64(9));
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+
+    n.reset();
+    n["x"].set(DataType::float64(10));
+    n["y"].set(DataType::float64(10));
+    n["z"].set(DataType::float64(11));
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+
+    n.reset();
+    n["x"].set(DataType::float64(10));
+    n["y"].set(DataType::float64(10));
+    n["m"].set(0.0f);
+    EXPECT_FALSE(blueprint::mcarray::verify(n,info));
+}

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -379,7 +379,6 @@ TEST(conduit_blueprint_mesh_verify, topology_rectilinear)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_structured)
 {
-    // FIXME: Use a base mesh for this.
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::topology::structured::verify(n,info));
 
@@ -408,7 +407,6 @@ TEST(conduit_blueprint_mesh_verify, topology_structured)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_unstructured)
 {
-    // FIXME: Use a base mesh for this.
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
 

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -118,7 +118,7 @@ const std::vector<std::string> CARTESIAN_COORDSYS = create_coordsys("x","y","z")
 const std::vector<std::string> SPHERICAL_COORDSYS = create_coordsys("r","theta","phi");
 const std::vector<std::string> CYLINDRICAL_COORDSYS = create_coordsys("r","z");
 
-const std::vector<std::string> COORDINATE_COORDSYSS[3] =
+const std::vector<std::string> COORDINATE_COORDSYSS[] =
     {CARTESIAN_COORDSYS, CYLINDRICAL_COORDSYS, SPHERICAL_COORDSYS};
 
 /// Mesh Coordinate Set Tests ///
@@ -288,7 +288,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_types)
 {
     Node n, info;
 
-    const std::string coordset_types[3] = {"uniform", "rectilinear", "explicit"};
+    const std::string coordset_types[] = {"uniform", "rectilinear", "explicit"};
     for(index_t ti = 0; ti < 3; ti++)
     {
         n.reset();
@@ -308,7 +308,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_coordsys)
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
 
-    const std::string coordsys_types[3] = {"cartesian", "cylindrical", "spherical"};
+    const std::string coordsys_types[] = {"cartesian", "cylindrical", "spherical"};
     for(index_t ci = 0; ci < 3; ci++)
     {
         n.reset();
@@ -409,7 +409,27 @@ TEST(conduit_blueprint_mesh_verify, topology_rectilinear)
 TEST(conduit_blueprint_mesh_verify, topology_structured)
 {
     Node n, info;
-    // TODO(JRC): Implement this test case and give it a name.
+    EXPECT_FALSE(blueprint::mesh::topology::structured::verify(n,info));
+
+    n["elements"].set(0);
+    EXPECT_FALSE(blueprint::mesh::topology::structured::verify(n,info));
+
+    n["elements"].reset();
+    n["elements"]["dims"].set(0);
+    EXPECT_FALSE(blueprint::mesh::topology::structured::verify(n,info));
+
+    n["elements"]["dims"].reset();
+    n["elements"]["dims"]["x"].set(5);
+    n["elements"]["dims"]["y"].set(10);
+    EXPECT_FALSE(blueprint::mesh::topology::structured::verify(n,info));
+
+    n["elements"]["dims"].reset();
+    n["elements"]["dims"]["i"].set(15);
+    n["elements"]["dims"]["j"].set(20);
+    EXPECT_TRUE(blueprint::mesh::topology::structured::verify(n,info));
+
+    n["elements"]["dims"]["k"].set(25);
+    EXPECT_TRUE(blueprint::mesh::topology::structured::verify(n,info));
 }
 
 
@@ -417,7 +437,7 @@ TEST(conduit_blueprint_mesh_verify, topology_structured)
 TEST(conduit_blueprint_mesh_verify, topology_unstructured)
 {
     Node n, info;
-    // TODO(JRC): Implement this test case and give it a name.
+    // TODO(JRC): Implement this test case.
 }
 
 
@@ -426,7 +446,7 @@ TEST(conduit_blueprint_mesh_verify, topology_types)
 {
     Node n, info;
 
-    const std::string topology_types[4] = {"uniform", "rectilinear", "structured", "unstructured"};
+    const std::string topology_types[] = {"uniform", "rectilinear", "structured", "unstructured"};
     for(index_t ti = 0; ti < 4; ti++)
     {
         n.reset();
@@ -436,21 +456,62 @@ TEST(conduit_blueprint_mesh_verify, topology_types)
 
     n.set("explicit");
     EXPECT_FALSE(blueprint::mesh::topology::type::verify(n,info));
-    n.reset();
 }
 
 
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_shape)
 {
-    // TODO(JRC): Implement this test case and give it a name.
+    Node n, info;
+    EXPECT_FALSE(blueprint::mesh::topology::shape::verify(n,info));
+
+    const std::string shape_types[] = {"point", "line", "tri", "quad", "tet", "hex"};
+    for(index_t ti = 0; ti < 6; ti++)
+    {
+        n.reset();
+        n.set(shape_types[ti]);
+        EXPECT_TRUE(blueprint::mesh::topology::shape::verify(n,info));
+    }
+
+    n.reset();
+    n.set(10);
+    EXPECT_FALSE(blueprint::mesh::topology::shape::verify(n,info));
+
+    n.reset();
+    n.set("poly");
+    EXPECT_FALSE(blueprint::mesh::topology::shape::verify(n,info));
 }
 
 
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_index)
 {
-    // TODO(JRC): Implement this test case and give it a name.
+    Node n, info;
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["type"].set("explicit");
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["type"].set("unstructured");
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["coordset"].set(0);
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["coordset"].set("path");
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["path"].set(5);
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["path"].set("path");
+    EXPECT_TRUE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["grid_function"].set(10);
+    EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
+
+    n["grid_function"].set("path");
+    EXPECT_TRUE(blueprint::mesh::topology::index::verify(n,info));
 }
 
 

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -1,0 +1,71 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see https://lc.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_blueprint_mesh_verify.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+#include "blueprint.hpp"
+#include "relay.hpp"
+
+#include <iostream>
+#include "gtest/gtest.h"
+
+using namespace conduit;
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, TODO1)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, TODO2)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -52,20 +52,175 @@
 #include "blueprint.hpp"
 #include "relay.hpp"
 
-#include <iostream>
+#include <vector>
+#include <string>
 #include "gtest/gtest.h"
 
 using namespace conduit;
 
+/// Helper Functions ///
+
+std::vector<std::string> create_basis(const std::string& d1,
+                                      const std::string& d2,
+                                      const std::string& d3="")
+{
+    std::vector<std::string> dim_vector;
+
+    dim_vector.push_back(d1);
+    dim_vector.push_back(d2);
+
+    if(d3 != "")
+    {
+        dim_vector.push_back(d3);
+    }
+
+    return dim_vector;
+}
+
+
+bool is_valid_basis(bool (*basis_valid_fun)(const Node&, Node&),
+                    const std::vector<std::string>& basis)
+{
+    Node n, info;
+
+    bool is_valid = true;
+    for(index_t bi = 0; bi < basis.size(); bi++)
+    {
+        const std::string& basis_dim = basis[bi];
+
+        n[basis_dim].set("test");
+        is_valid &= !basis_valid_fun(n, info);
+
+        n[basis_dim].set(10);
+        is_valid &= basis_valid_fun(n, info);
+
+        // TODO(JRC): Determine whether or not the basis (i, k) should be
+        // valid for logical coordinates.
+        /*
+        if( bi > 0 )
+        {
+            const std::string& prev_dim = basis[bi-1];
+            n.remove(prev_dim);
+            is_valid &= !basis_valid_fun(n, info);
+            n[basis_dim].set(10);
+        }
+        */
+    }
+
+    return is_valid;
+}
+
+/// Mesh Coordinate Set Tests ///
+
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, TODO1)
+TEST(conduit_blueprint_mesh_verify, coordset_logical_dims)
+{
+    bool (*verify_coordset_logical)(const Node&, Node&) = blueprint::mesh::logical_dims::verify;
+
+    Node n, info;
+    EXPECT_FALSE(verify_coordset_logical(n, info));
+
+    EXPECT_TRUE(is_valid_basis(verify_coordset_logical,create_basis("i","j","k")));
+
+    EXPECT_FALSE(is_valid_basis(verify_coordset_logical,create_basis("x","y","z")));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_uniform_origin)
+{
+    bool (*verify_uniform_origin)(const Node&, Node&) = blueprint::mesh::coordset::uniform::origin::verify;
+
+    Node n, info;
+    EXPECT_FALSE(verify_uniform_origin(n, info));
+
+    EXPECT_TRUE(is_valid_basis(verify_uniform_origin,create_basis("x","y","z")));
+    EXPECT_TRUE(is_valid_basis(verify_uniform_origin,create_basis("r","theta","phi")));
+    EXPECT_TRUE(is_valid_basis(verify_uniform_origin,create_basis("r","z")));
+
+    const std::vector<std::string> logical_basis = create_basis("i","j","k");
+    EXPECT_FALSE(is_valid_basis(verify_uniform_origin,logical_basis));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_uniform_spacing)
+{
+    bool (*verify_uniform_spacing)(const Node&, Node&) = blueprint::mesh::coordset::uniform::spacing::verify;
+
+    Node n, info;
+    EXPECT_FALSE(verify_uniform_spacing(n, info));
+
+    EXPECT_TRUE(is_valid_basis(verify_uniform_spacing,create_basis("dx","dy","dz")));
+    EXPECT_TRUE(is_valid_basis(verify_uniform_spacing,create_basis("dr","dtheta","dphi")));
+    EXPECT_TRUE(is_valid_basis(verify_uniform_spacing,create_basis("dr","dz")));
+
+    EXPECT_FALSE(is_valid_basis(verify_uniform_spacing,create_basis("di","dj","dk")));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_types)
 {
     // TODO(JRC): Implement this test case and give it a name.
 }
 
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, TODO2)
+TEST(conduit_blueprint_mesh_verify, coordset_uniform)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_rectilinear)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_explicit)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_general)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+/// Mesh Topology Tests ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, TOPOLOGY)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+/// Mesh Field Tests ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, FIELD)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+/// Mesh Index Tests ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, INDEX)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+/// Mesh Integration Tests ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, INTEGRATION)
 {
     // TODO(JRC): Implement this test case and give it a name.
 }

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -505,7 +505,38 @@ TEST(conduit_blueprint_mesh_verify, topology_shape)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_general)
 {
-    // TODO(JRC): Implement this test case and give it a name.
+    Node mesh, info;
+    EXPECT_FALSE(blueprint::mesh::topology::verify(mesh,info));
+
+    blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+    Node& n = mesh["topologies"]["mesh"];
+
+    n.remove("type");
+    EXPECT_FALSE(blueprint::mesh::topology::verify(n,info));
+    n["type"].set("explicit");
+    EXPECT_FALSE(blueprint::mesh::topology::verify(n,info));
+
+    // FIXME: Remove the comments from the following line once the verify functions
+    // for uniform and rectilinear topologies have been implemented.
+    const std::string topology_types[] = {/*"uniform", "rectilinear", */"structured"};
+    for(index_t ti = 0; ti < 1; ti++)
+    {
+        n["type"].set(topology_types[ti]);
+        EXPECT_FALSE(blueprint::mesh::topology::verify(n,info));
+    }
+
+    n["type"].set("unstructured");
+    EXPECT_TRUE(blueprint::mesh::topology::verify(n,info));
+
+    n.remove("coordset");
+    EXPECT_FALSE(blueprint::mesh::topology::verify(n,info));
+    n["coordset"].set("coords");
+    EXPECT_TRUE(blueprint::mesh::topology::verify(n,info));
+
+    n["grid_function"].set(10);
+    EXPECT_FALSE(blueprint::mesh::topology::verify(n,info));
+    n["grid_function"].set("coords_gf");
+    EXPECT_TRUE(blueprint::mesh::topology::verify(n,info));
 }
 
 /// Mesh Field Tests ///
@@ -604,12 +635,4 @@ TEST(conduit_blueprint_mesh_verify, index_field)
 TEST(conduit_blueprint_mesh_verify, index_general)
 {
     // TODO(JRC): Implement this test case.
-}
-
-/// Mesh Integration Tests ///
-
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, INTEGRATION)
-{
-    // TODO(JRC): Implement this test case and give it a name.
 }

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -463,7 +463,21 @@ TEST(conduit_blueprint_mesh_verify, topology_general)
 /// Mesh Field Tests ///
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, FIELD)
+TEST(conduit_blueprint_mesh_verify, field_association)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, field_basis)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, field_general)
 {
     // TODO(JRC): Implement this test case and give it a name.
 }
@@ -471,7 +485,7 @@ TEST(conduit_blueprint_mesh_verify, FIELD)
 /// Mesh Index Tests ///
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, coordset_index)
+TEST(conduit_blueprint_mesh_verify, index_coordset)
 {
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
@@ -500,7 +514,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_index)
 
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, topology_index)
+TEST(conduit_blueprint_mesh_verify, index_topology)
 {
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
@@ -528,6 +542,13 @@ TEST(conduit_blueprint_mesh_verify, topology_index)
 
     n["grid_function"].set("path");
     EXPECT_TRUE(blueprint::mesh::topology::index::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, index_field)
+{
+    // TODO(JRC): Implement this test case and give it a name.
 }
 
 

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -94,8 +94,9 @@ bool is_valid_basis(bool (*basis_valid_fun)(const Node&, Node&),
         n[basis_dim].set(10);
         is_valid &= basis_valid_fun(n, info);
 
-        // TODO(JRC): Determine whether or not the basis (i, k) should be
-        // valid for logical coordinates.
+        // FIXME: The basis checking functions shouldn't accept bases such as
+        // (y) or (x, z); all successive dimensions should require the existence
+        // of previous basis dimensions.
         /*
         if( bi > 0 )
         {
@@ -307,7 +308,21 @@ TEST(conduit_blueprint_mesh_verify, coordset_types)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, coordset_general)
 {
-    // TODO(JRC): Implement this test case and give it a name.
+    Node mesh, info;
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(mesh, info));
+
+    blueprint::mesh::examples::braid("uniform",10,10,10,mesh);
+    Node& n = mesh["coordsets"]["coords"];
+
+    n.remove("type");
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(n, info));
+    n["type"].set("structured");
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(n, info));
+    n["type"].set("rectilinear");
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(n, info));
+
+    n["type"].set("uniform");
+    EXPECT_TRUE(blueprint::mesh::coordset::verify(n, info));
 }
 
 /// Mesh Topology Tests ///

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -408,7 +408,55 @@ TEST(conduit_blueprint_mesh_verify, topology_structured)
 TEST(conduit_blueprint_mesh_verify, topology_unstructured)
 {
     Node n, info;
-    // TODO(JRC): Implement this test case.
+    EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+    n["elements"].set(0);
+    EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+    { // Single Shape Topology Tests //
+        n["elements"].reset();
+        n["elements"]["shape"].set("polygon");
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+        n["elements"]["shape"].set("quad");
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+        n["elements"]["connectivity"].set("quad");
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+        n["elements"]["connectivity"].set(DataType::float64(10));
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+        n["elements"]["connectivity"].set(DataType::int32(1));
+        EXPECT_TRUE(blueprint::mesh::topology::unstructured::verify(n,info));
+        n["elements"]["connectivity"].set(DataType::int32(10));
+        EXPECT_TRUE(blueprint::mesh::topology::unstructured::verify(n,info));
+    }
+
+    { // Mixed Shape Topology List Tests //
+        n["elements"].reset();
+
+        n["elements"]["a"]["shape"].set("quad");
+        n["elements"]["a"]["connectivity"].set(DataType::int32(5));
+        EXPECT_TRUE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+        n["elements"]["b"]["shape"].set("polygon");
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+        n["elements"]["b"]["shape"].set("quad");
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+        n["elements"]["b"]["connectivity"].set(DataType::float32(3));
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+        n["elements"]["b"]["connectivity"].set(DataType::int32(1));
+        EXPECT_TRUE(blueprint::mesh::topology::unstructured::verify(n,info));
+
+        n["elements"]["c"]["shape"].set("tri");
+        n["elements"]["c"]["connectivity"].set(DataType::int32(5));
+        EXPECT_TRUE(blueprint::mesh::topology::unstructured::verify(n,info));
+    }
+
+    { // Multiple Shape Topology Stream Tests //
+        // FIXME: Implement once multiple unstructured shape topologies are implemented.
+        n["elements"].reset();
+    }
 }
 
 

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -89,10 +89,10 @@ bool is_valid_coordsys(bool (*coordsys_valid_fun)(const Node&, Node&),
         const std::string& coordsys_dim = coordsys[ci];
 
         n[coordsys_dim].set("test");
-        is_valid &= !coordsys_valid_fun(n, info);
+        is_valid &= !coordsys_valid_fun(n,info);
 
         n[coordsys_dim].set(10);
-        is_valid &= coordsys_valid_fun(n, info);
+        is_valid &= coordsys_valid_fun(n,info);
 
         // FIXME: The coordinate system checking functions shouldn't accept
         // systems such as (y) or (x, z); all successive dimensions should
@@ -102,7 +102,7 @@ bool is_valid_coordsys(bool (*coordsys_valid_fun)(const Node&, Node&),
         {
             const std::string& prev_dim = coordsys[ci-1];
             n.remove(prev_dim);
-            is_valid &= !coordsys_valid_fun(n, info);
+            is_valid &= !coordsys_valid_fun(n,info);
             n[coordsys_dim].set(10);
         }
         */
@@ -130,7 +130,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_logical_dims)
         blueprint::mesh::logical_dims::verify;
 
     Node n, info;
-    EXPECT_FALSE(verify_coordset_logical(n, info));
+    EXPECT_FALSE(verify_coordset_logical(n,info));
 
     EXPECT_TRUE(is_valid_coordsys(verify_coordset_logical,LOGICAL_COORDSYS));
 
@@ -146,7 +146,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_uniform_origin)
 
     Node n, info;
     // FIXME: The origin verification function shouldn't accept an empty node.
-    // EXPECT_FALSE(verify_uniform_origin(n, info));
+    // EXPECT_FALSE(verify_uniform_origin(n,info));
 
     EXPECT_TRUE(is_valid_coordsys(verify_uniform_origin,CARTESIAN_COORDSYS));
     EXPECT_TRUE(is_valid_coordsys(verify_uniform_origin,SPHERICAL_COORDSYS));
@@ -164,7 +164,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_uniform_spacing)
 
     Node n, info;
     // FIXME: The spacing verification function shouldn't accept an empty node.
-    // EXPECT_FALSE(verify_uniform_spacing(n, info));
+    // EXPECT_FALSE(verify_uniform_spacing(n,info));
 
     EXPECT_TRUE(is_valid_coordsys(verify_uniform_spacing,create_coordsys("dx","dy","dz")));
     EXPECT_TRUE(is_valid_coordsys(verify_uniform_spacing,create_coordsys("dr","dtheta","dphi")));
@@ -178,40 +178,40 @@ TEST(conduit_blueprint_mesh_verify, coordset_uniform_spacing)
 TEST(conduit_blueprint_mesh_verify, coordset_uniform)
 {
     Node n, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     n["dims"]["i"].set(1);
     n["dims"]["j"].set(2);
-    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     n["dims"]["k"].set("test");
-    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n,info));
     n["dims"]["k"].set(3);
-    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     Node dims = n["dims"];
     n.remove("dims");
 
     n["origin"]["x"].set(10);
     n["origin"]["y"].set(20);
-    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     n["dims"].set(dims);
-    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     n["origin"]["z"].set("test");
-    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n,info));
     n["origin"]["z"].set(30);
-    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     n["spacing"]["dx"].set(0.1);
     n["spacing"]["dy"].set(0.2);
-    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n,info));
 
     n["spacing"]["dz"].set("test");
-    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::uniform::verify(n,info));
     n["spacing"]["dz"].set(0.3);
-    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::uniform::verify(n,info));
 }
 
 
@@ -219,10 +219,10 @@ TEST(conduit_blueprint_mesh_verify, coordset_uniform)
 TEST(conduit_blueprint_mesh_verify, coordset_rectilinear)
 {
     Node n, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::rectilinear::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::rectilinear::verify(n,info));
 
     n["values"].set("test");
-    EXPECT_FALSE(blueprint::mesh::coordset::rectilinear::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::rectilinear::verify(n,info));
 
     for(index_t ci = 0; ci < 3; ci++)
     {
@@ -232,7 +232,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_rectilinear)
         for(index_t ci = 0; ci < coord_coordsys.size(); ci++)
         {
             n["values"][coord_coordsys[ci]].set(DataType::float64(10));
-            EXPECT_TRUE(blueprint::mesh::coordset::rectilinear::verify(n, info));
+            EXPECT_TRUE(blueprint::mesh::coordset::rectilinear::verify(n,info));
         }
     }
 
@@ -243,7 +243,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_rectilinear)
     for(index_t ci = 0; ci < LOGICAL_COORDSYS.size(); ci++)
     {
         n["values"][LOGICAL_COORDSYS[ci]].set(DataType::float64(10));
-        EXPECT_FALSE(blueprint::mesh::coordset::rectilinear::verify(n, info));
+        EXPECT_FALSE(blueprint::mesh::coordset::rectilinear::verify(n,info));
     }
     */
 }
@@ -253,10 +253,10 @@ TEST(conduit_blueprint_mesh_verify, coordset_rectilinear)
 TEST(conduit_blueprint_mesh_verify, coordset_explicit)
 {
     Node n, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::_explicit::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::_explicit::verify(n,info));
 
     n["values"].set("test");
-    EXPECT_FALSE(blueprint::mesh::coordset::_explicit::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::_explicit::verify(n,info));
 
     for(index_t ci = 0; ci < 3; ci++)
     {
@@ -266,7 +266,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_explicit)
         for(index_t ci = 0; ci < coord_coordsys.size(); ci++)
         {
             n["values"][coord_coordsys[ci]].set(DataType::float64(10));
-            EXPECT_TRUE(blueprint::mesh::coordset::_explicit::verify(n, info));
+            EXPECT_TRUE(blueprint::mesh::coordset::_explicit::verify(n,info));
         }
     }
 
@@ -277,7 +277,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_explicit)
     for(index_t ci = 0; ci < LOGICAL_COORDSYS.size(); ci++)
     {
         n["values"][LOGICAL_COORDSYS[ci]].set(DataType::float64(10));
-        EXPECT_FALSE(blueprint::mesh::coordset::_explicit::verify(n, info));
+        EXPECT_FALSE(blueprint::mesh::coordset::_explicit::verify(n,info));
     }
     */
 }
@@ -293,33 +293,12 @@ TEST(conduit_blueprint_mesh_verify, coordset_types)
     {
         n.reset();
         n.set(coordset_types[ti]);
-        EXPECT_TRUE(blueprint::mesh::coordset::type::verify(n, info));
+        EXPECT_TRUE(blueprint::mesh::coordset::type::verify(n,info));
     }
 
     n.set("unstructured");
-    EXPECT_FALSE(blueprint::mesh::coordset::type::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::type::verify(n,info));
     n.reset();
-}
-
-
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, coordset_general)
-{
-    Node mesh, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::verify(mesh, info));
-
-    blueprint::mesh::examples::braid("uniform",10,10,10,mesh);
-    Node& n = mesh["coordsets"]["coords"];
-
-    n.remove("type");
-    EXPECT_FALSE(blueprint::mesh::coordset::verify(n, info));
-    n["type"].set("structured");
-    EXPECT_FALSE(blueprint::mesh::coordset::verify(n, info));
-    n["type"].set("rectilinear");
-    EXPECT_FALSE(blueprint::mesh::coordset::verify(n, info));
-
-    n["type"].set("uniform");
-    EXPECT_TRUE(blueprint::mesh::coordset::verify(n, info));
 }
 
 
@@ -327,7 +306,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_general)
 TEST(conduit_blueprint_mesh_verify, coordset_coordsys)
 {
     Node n, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
 
     const std::string coordsys_types[3] = {"cartesian", "cylindrical", "spherical"};
     for(index_t ci = 0; ci < 3; ci++)
@@ -336,23 +315,23 @@ TEST(conduit_blueprint_mesh_verify, coordset_coordsys)
         info.reset();
 
         n["type"].set(coordsys_types[ci]);
-        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n, info));
+        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
 
         const std::vector<std::string>& coordsys = COORDINATE_COORDSYSS[ci];
         for(index_t ai = 0; ai < coordsys.size(); ai++)
         {
             n["axes"][coordsys[ai]].set(10);
-            EXPECT_TRUE(blueprint::mesh::coordset::coord_system::verify(n, info));
+            EXPECT_TRUE(blueprint::mesh::coordset::coord_system::verify(n,info));
         }
 
         n["type"].set(coordsys_types[(ci == 0) ? 2 : ci - 1]);
-        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n, info));
+        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
 
         n["type"].set("barycentric");
-        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n, info));
+        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
 
         n["type"].set(10);
-        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n, info));
+        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
     }
 }
 
@@ -361,35 +340,83 @@ TEST(conduit_blueprint_mesh_verify, coordset_coordsys)
 TEST(conduit_blueprint_mesh_verify, coordset_index)
 {
     Node n, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
     n["type"].set("unstructured");
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
     n["type"].set("uniform");
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
     n["coord_system"].set("invalid");
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
     n["coord_system"].reset();
     n["coord_system"]["type"].set("cartesian");
     n["coord_system"]["axes"]["x"].set(10);
     n["coord_system"]["axes"]["y"].set(10);
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
     n["path"].set(10);
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
     n["path"].set("path");
-    EXPECT_TRUE(blueprint::mesh::coordset::index::verify(n, info));
+    EXPECT_TRUE(blueprint::mesh::coordset::index::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_general)
+{
+    Node mesh, info;
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(mesh,info));
+
+    blueprint::mesh::examples::braid("uniform",10,10,10,mesh);
+    Node& n = mesh["coordsets"]["coords"];
+
+    n.remove("type");
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(n,info));
+    n["type"].set("structured");
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(n,info));
+    n["type"].set("rectilinear");
+    EXPECT_FALSE(blueprint::mesh::coordset::verify(n,info));
+
+    n["type"].set("uniform");
+    EXPECT_TRUE(blueprint::mesh::coordset::verify(n,info));
 }
 
 /// Mesh Topology Tests ///
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, TOPOLOGY)
+TEST(conduit_blueprint_mesh_verify, topology_uniform)
 {
+    // FIXME: Implement once 'mesh::topology::uniform::verify' is implemented.
+    Node n, info;
+    EXPECT_TRUE(blueprint::mesh::topology::uniform::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_rectilinear)
+{
+    // FIXME: Implement once 'mesh::topology::rectilinear::verify' is implemented.
+    Node n, info;
+    EXPECT_TRUE(blueprint::mesh::topology::rectilinear::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_structured)
+{
+    Node n, info;
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_unstructured)
+{
+    Node n, info;
     // TODO(JRC): Implement this test case and give it a name.
 }
 
@@ -404,12 +431,33 @@ TEST(conduit_blueprint_mesh_verify, topology_types)
     {
         n.reset();
         n.set(topology_types[ti]);
-        EXPECT_TRUE(blueprint::mesh::topology::type::verify(n, info));
+        EXPECT_TRUE(blueprint::mesh::topology::type::verify(n,info));
     }
 
     n.set("explicit");
-    EXPECT_FALSE(blueprint::mesh::topology::type::verify(n, info));
+    EXPECT_FALSE(blueprint::mesh::topology::type::verify(n,info));
     n.reset();
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_shape)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_index)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_general)
+{
+    // TODO(JRC): Implement this test case and give it a name.
 }
 
 /// Mesh Field Tests ///

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -332,9 +332,13 @@ TEST(conduit_blueprint_mesh_verify, coordset_types)
         EXPECT_TRUE(blueprint::mesh::coordset::type::verify(n,info));
     }
 
+    n.reset();
+    n.set(0);
+    EXPECT_FALSE(blueprint::mesh::coordset::type::verify(n,info));
+
+    n.reset();
     n.set("unstructured");
     EXPECT_FALSE(blueprint::mesh::coordset::type::verify(n,info));
-    n.reset();
 }
 
 
@@ -353,6 +357,10 @@ TEST(conduit_blueprint_mesh_verify, coordset_coordsys)
         n["type"].set(coordsys_types[ci]);
         EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
 
+        n["axes"].set(0);
+        EXPECT_FALSE(blueprint::mesh::coordset::coord_system::verify(n,info));
+
+        n["axes"].reset();
         const std::vector<std::string>& coordsys = COORDINATE_COORDSYSS[ci];
         for(index_t ai = 0; ai < coordsys.size(); ai++)
         {
@@ -480,6 +488,9 @@ TEST(conduit_blueprint_mesh_verify, topology_unstructured)
     { // Mixed Shape Topology List Tests //
         n["elements"].reset();
 
+        n["elements"]["a"].set(0);
+        EXPECT_FALSE(blueprint::mesh::topology::unstructured::verify(n,info));
+
         n["elements"]["a"]["shape"].set("quad");
         n["elements"]["a"]["connectivity"].set(DataType::int32(5));
         EXPECT_TRUE(blueprint::mesh::topology::unstructured::verify(n,info));
@@ -518,6 +529,11 @@ TEST(conduit_blueprint_mesh_verify, topology_types)
         EXPECT_TRUE(blueprint::mesh::topology::type::verify(n,info));
     }
 
+    n.reset();
+    n.set(0);
+    EXPECT_FALSE(blueprint::mesh::topology::type::verify(n,info));
+
+    n.reset();
     n.set("explicit");
     EXPECT_FALSE(blueprint::mesh::topology::type::verify(n,info));
 }
@@ -586,6 +602,10 @@ TEST(conduit_blueprint_mesh_verify, topology_general)
         { // Coordset Field Tests //
             n.remove("coordset");
             EXPECT_FALSE(verify_topology(n,info));
+
+            n["coordset"].set(0);
+            EXPECT_FALSE(verify_topology(n,info));
+
             n["coordset"].set("coords");
             EXPECT_TRUE(verify_topology(n,info));
         }

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -379,6 +379,7 @@ TEST(conduit_blueprint_mesh_verify, topology_rectilinear)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_structured)
 {
+    // FIXME: Use a base mesh for this.
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::topology::structured::verify(n,info));
 
@@ -656,6 +657,7 @@ TEST(conduit_blueprint_mesh_verify, field_general)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, index_coordset)
 {
+    // FIXME: Use a base mesh for this.
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
 
@@ -685,6 +687,7 @@ TEST(conduit_blueprint_mesh_verify, index_coordset)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, index_topology)
 {
+    // FIXME: Use a base mesh for this.
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::topology::index::verify(n,info));
 
@@ -717,6 +720,7 @@ TEST(conduit_blueprint_mesh_verify, index_topology)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, index_field)
 {
+    // FIXME: Use a base mesh for this.
     Node n, info;
     EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
 
@@ -757,32 +761,87 @@ TEST(conduit_blueprint_mesh_verify, index_general)
     Node mesh, index, info;
     EXPECT_FALSE(blueprint::mesh::index::verify(mesh,info));
 
-    // FIXME: How does this even work?
-    /*
     blueprint::mesh::examples::braid("quads",10,10,1,mesh);
-    blueprint::mesh::generate_index(mesh,"fields/braid",1,index);
+    blueprint::mesh::generate_index(mesh,"quads",1,index);
     EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
 
     { // Topology Field Tests //
-        Node topology = index["topology"];
-        index.remove("topology");
+        info.reset();
+        Node coords = index["coordsets"];
+        index.remove("coordsets");
+
         EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
-        index["topology"].set(10);
+        index["coordsets"].set("coords");
         EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
-        index["topology"].set(topology);
+
+        index["coordsets"].reset();
+        index["coordsets"]["coords1"].set("coords");
+        index["coordsets"]["coords2"].set("coords");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["coordsets"].reset();
+        index["coordsets"].set(coords);
         EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
     }
 
     { // Components Field Tests //
-        
+        info.reset();
+        Node topos = index["topologies"];
+        index.remove("topologies");
+
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+        index["topologies"].set("topo");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["topologies"].reset();
+        index["topologies"]["topo1"].set("topo");
+        index["topologies"]["topo2"].set("topo");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["topologies"].reset();
+        index["topologies"]["mesh"]["type"].set("unstructured");
+        index["topologies"]["mesh"]["path"].set("quads/topologies/mesh");
+        index["topologies"]["mesh"]["coordset"].set("nonexitent");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["topologies"]["mesh"]["coordset"].set("coords");
+        index["coordsets"]["coords"]["type"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+        index["coordsets"]["coords"]["type"].set("explicit");
+
+        index["topologies"].reset();
+        index["topologies"].set(topos);
+        EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
     }
 
-    { // Path Field Tests //
-        
-    }
+    { // Fields Field Tests //
+        info.reset();
+        Node fields = index["fields"];
+        index.remove("fields");
+        EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
 
-    { // Association/Basis Field Tests //
-        
+        index["fields"].set("field");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["fields"].reset();
+        index["fields"]["field1"].set("field1");
+        index["fields"]["field1"].set("field2");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["fields"].reset();
+        index["fields"]["field"]["number_of_components"].set(1);
+        index["fields"]["field"]["association"].set("point");
+        index["fields"]["field"]["path"].set("quads/fields/braid");
+        index["fields"]["field"]["topology"].set("nonexitent");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+
+        index["fields"]["field"]["topology"].set("mesh");
+        index["topologies"]["mesh"]["type"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+        index["topologies"]["mesh"]["type"].set("unstructured");
+
+        index["fields"].reset();
+        index["fields"].set(fields);
+        EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
     }
-    */
 }

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -337,35 +337,6 @@ TEST(conduit_blueprint_mesh_verify, coordset_coordsys)
 
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, coordset_index)
-{
-    Node n, info;
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
-
-    n["type"].set("unstructured");
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
-
-    n["type"].set("uniform");
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
-
-    n["coord_system"].set("invalid");
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
-
-    n["coord_system"].reset();
-    n["coord_system"]["type"].set("cartesian");
-    n["coord_system"]["axes"]["x"].set(10);
-    n["coord_system"]["axes"]["y"].set(10);
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
-
-    n["path"].set(10);
-    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
-
-    n["path"].set("path");
-    EXPECT_TRUE(blueprint::mesh::coordset::index::verify(n,info));
-}
-
-
-//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, coordset_general)
 {
     Node mesh, info;
@@ -484,6 +455,51 @@ TEST(conduit_blueprint_mesh_verify, topology_shape)
 
 
 //-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, topology_general)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+/// Mesh Field Tests ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, FIELD)
+{
+    // TODO(JRC): Implement this test case and give it a name.
+}
+
+/// Mesh Index Tests ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, coordset_index)
+{
+    Node n, info;
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
+
+    n["type"].set("unstructured");
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
+
+    n["type"].set("uniform");
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
+
+    n["coord_system"].set("invalid");
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
+
+    n["coord_system"].reset();
+    n["coord_system"]["type"].set("cartesian");
+    n["coord_system"]["axes"]["x"].set(10);
+    n["coord_system"]["axes"]["y"].set(10);
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
+
+    n["path"].set(10);
+    EXPECT_FALSE(blueprint::mesh::coordset::index::verify(n,info));
+
+    n["path"].set("path");
+    EXPECT_TRUE(blueprint::mesh::coordset::index::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, topology_index)
 {
     Node n, info;
@@ -516,25 +532,9 @@ TEST(conduit_blueprint_mesh_verify, topology_index)
 
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, topology_general)
+TEST(conduit_blueprint_mesh_verify, index_general)
 {
-    // TODO(JRC): Implement this test case and give it a name.
-}
-
-/// Mesh Field Tests ///
-
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, FIELD)
-{
-    // TODO(JRC): Implement this test case and give it a name.
-}
-
-/// Mesh Index Tests ///
-
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_verify, INDEX)
-{
-    // TODO(JRC): Implement this test case and give it a name.
+    // TODO(JRC): Implement this test case.
 }
 
 /// Mesh Integration Tests ///

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -1050,5 +1050,114 @@ TEST(conduit_blueprint_mesh_verify, index_general)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, mesh_general)
 {
-    // TODO: Implement this function.
+    Node mesh, info;
+    EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+    blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+    EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+
+    { // Coordsets Field Tests //
+        Node coordsets = mesh["coordsets"];
+        mesh.remove("coordsets");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["coordsets"].set("path");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["coordsets"].reset();
+        mesh["coordsets"]["coords"]["type"].set("invalid");
+        mesh["coordsets"]["coords"]["values"]["x"].set(DataType::float64(10));
+        mesh["coordsets"]["coords"]["values"]["y"].set(DataType::float64(10));
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["coordsets"]["coords"]["type"].set("explicit");
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+        mesh["coordsets"]["coords2"]["type"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["coordsets"].reset();
+        mesh["coordsets"].set(coordsets);
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+    }
+
+    { // Topologies Field Tests //
+        Node topologies = mesh["topologies"];
+        mesh.remove("topologies");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["topologies"].set("path");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["topologies"].reset();
+        mesh["topologies"]["mesh"]["type"].set("invalid");
+        mesh["topologies"]["mesh"]["coordset"].set("coords");
+        mesh["topologies"]["mesh"]["elements"]["shape"].set("quad");
+        mesh["topologies"]["mesh"]["elements"]["connectivity"].set(DataType::int32(10));
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["topologies"]["mesh"]["type"].set("unstructured");
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+
+        mesh["coordsets"]["coords"]["type"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+        mesh["coordsets"]["coords"]["type"].set("explicit");
+
+        mesh["topologies"]["grid"]["type"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["topologies"].reset();
+        mesh["topologies"].set(topologies);
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+    }
+
+    { // Fields Field Tests //
+        Node fields = mesh["fields"];
+        mesh.remove("fields");
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+
+        mesh["fields"].set("path");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["fields"].reset();
+        mesh["fields"]["temp"]["association"].set("invalid");
+        mesh["fields"]["temp"]["topology"].set("mesh");
+        mesh["fields"]["temp"]["values"].set(DataType::float64(10));
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["fields"]["temp"]["association"].set("point");
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+
+        mesh["topologies"]["mesh"]["type"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+        mesh["topologies"]["mesh"]["type"].set("unstructured");
+
+        mesh["fields"]["accel"]["association"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["fields"].reset();
+        mesh["fields"].set(fields);
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+    }
+
+    { // Grid Function Field Tests //
+        Node topologies = mesh["topologies"];
+        Node fields = mesh["fields"];
+        mesh.remove("fields");
+
+        mesh["topologies"]["mesh"]["grid_function"].set("braid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+
+        mesh["fields"].set(fields);
+        mesh["topologies"]["mesh"]["grid_function"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+        mesh["topologies"]["mesh"]["grid_function"].set("braid");
+        EXPECT_TRUE(blueprint::mesh::verify(mesh,info));
+
+        mesh["fields"]["braid"]["association"].set("invalid");
+        EXPECT_FALSE(blueprint::mesh::verify(mesh,info));
+        mesh["fields"]["braid"]["association"].set("point");
+
+        mesh["topologies"].reset();
+        mesh["topologies"].set(topologies);
+    }
 }

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -717,12 +717,72 @@ TEST(conduit_blueprint_mesh_verify, index_topology)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, index_field)
 {
-    // TODO(JRC): Implement this test case and give it a name.
+    Node n, info;
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["topology"].set(0);
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["topology"].set("path");
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["number_of_components"].set("three");
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["number_of_components"].set(3);
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["path"].set(5);
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["path"].set("path");
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+
+    n["association"].set("zone");
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+    n["association"].set("point");
+    EXPECT_TRUE(blueprint::mesh::field::index::verify(n,info));
+
+    n.remove("association");
+    n["basis"].set(0);
+    EXPECT_FALSE(blueprint::mesh::field::index::verify(n,info));
+    n["basis"].set("basis");
+    EXPECT_TRUE(blueprint::mesh::field::index::verify(n,info));
 }
 
 
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, index_general)
 {
-    // TODO(JRC): Implement this test case.
+    Node mesh, index, info;
+    EXPECT_FALSE(blueprint::mesh::index::verify(mesh,info));
+
+    // FIXME: How does this even work?
+    /*
+    blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+    blueprint::mesh::generate_index(mesh,"fields/braid",1,index);
+    EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
+
+    { // Topology Field Tests //
+        Node topology = index["topology"];
+        index.remove("topology");
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+        index["topology"].set(10);
+        EXPECT_FALSE(blueprint::mesh::index::verify(index,info));
+        index["topology"].set(topology);
+        EXPECT_TRUE(blueprint::mesh::index::verify(index,info));
+    }
+
+    { // Components Field Tests //
+        
+    }
+
+    { // Path Field Tests //
+        
+    }
+
+    { // Association/Basis Field Tests //
+        
+    }
+    */
 }


### PR DESCRIPTION
The changes in this pull request will add test cases to verify the correctness of the `conduit::blueprint::mcarray::verify` and `conduit::blueprint::mesh::verify` functions in simple cases not covered by the existing example tests (see  #55 for more information).
