### PR TITLE
Reverted software.llnl.gov URLs to llnl.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ All rights reserved.
 
 This file is part of Conduit. 
 
-For details, see: http://software.llnl.gov/conduit/.
+For details, see: http://llnl.github.io/conduit/.
 
 Please also read conduit/LICENSE
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation
 
 To get started building and using Conduit, check out the full documentation:
 
-http://software.llnl.gov/conduit/
+http://llnl.github.io/conduit/
 
 
 Source Repo
@@ -32,7 +32,7 @@ License
 
 Conduit is released under a BSD-style license - for detailed license info, refer to:
 
-http://software.llnl.gov/conduit/licenses.html
+http://llnl.github.io/conduit/licenses.html
 
 or the following files in the Conduit source tree:
 - [LICENSE](/LICENSE)

--- a/config-build.sh
+++ b/config-build.sh
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/host-configs/Darwin.cmake
+++ b/host-configs/Darwin.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/host-configs/bgqos_0.cmake
+++ b/host-configs/bgqos_0.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/package.py
+++ b/package.py
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/generate_license_cpp_header.py
+++ b/scripts/generate_license_cpp_header.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py-breathe/package.py
+++ b/scripts/uberenv/packages/py-breathe/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py-numpy/package.py
+++ b/scripts/uberenv/packages/py-numpy/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py-sphinx/package.py
+++ b/scripts/uberenv/packages/py-sphinx/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py3-breathe/package.py
+++ b/scripts/uberenv/packages/py3-breathe/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py3-numpy/package.py
+++ b/scripts/uberenv/packages/py3-numpy/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/py3-sphinx/package.py
+++ b/scripts/uberenv/packages/py3-sphinx/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/python/package.py
+++ b/scripts/uberenv/packages/python/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/python3/package.py
+++ b/scripts/uberenv/packages/python3/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/scripts/uberenv/packages/uberenv-conduit/package.py
+++ b/scripts/uberenv/packages/uberenv-conduit/package.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 
@@ -57,7 +57,7 @@ def cmake_cache_entry(name,value):
 class UberenvConduit(Package):
     """Spack Based Uberenv Build for Conduit Thirdparty Libs """
 
-    homepage = "http://software.llnl.gov/conduit"
+    homepage = "http://llnl.github.io/conduit"
 
     version('0.2.0', '8d378ef62dedc2df5db447b029b71200')
 

--- a/scripts/update_source_license_txt.py
+++ b/scripts/update_source_license_txt.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/BasicTypeChecks.cmake
+++ b/src/CMake/BasicTypeChecks.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/CMakeBasics.cmake
+++ b/src/CMake/CMakeBasics.cmake
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/CMake/Setup3rdParty.cmake
+++ b/src/CMake/Setup3rdParty.cmake
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/CMake/SetupDocs.cmake
+++ b/src/CMake/SetupDocs.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupFortran.cmake
+++ b/src/CMake/SetupFortran.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupIncludes.cmake
+++ b/src/CMake/SetupIncludes.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/SetupTests.cmake
+++ b/src/CMake/SetupTests.cmake
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/CMake/tests/fortran_test_obj_support.f
+++ b/src/CMake/tests/fortran_test_obj_support.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit.
+!* For details, see: http://llnl.github.io/conduit.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/CMake/thirdparty/FindNumPy.cmake
+++ b/src/CMake/thirdparty/FindNumPy.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/FindSphinx.cmake
+++ b/src/CMake/thirdparty/FindSphinx.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/SetupHDF5.cmake
+++ b/src/CMake/thirdparty/SetupHDF5.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/SetupPython.cmake
+++ b/src/CMake/thirdparty/SetupPython.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/SetupRapidJSON.cmake
+++ b/src/CMake/thirdparty/SetupRapidJSON.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMake/thirdparty/SetupSilo.cmake
+++ b/src/CMake/thirdparty/SetupSilo.cmake
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/docs/CMakeLists.txt
+++ b/src/docs/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/doxygen/CMakeLists.txt
+++ b/src/docs/doxygen/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/sphinx/CMakeLists.txt
+++ b/src/docs/sphinx/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/docs/sphinx/blueprint.rst
+++ b/src/docs/sphinx/blueprint.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/blueprint_mcarray.rst
+++ b/src/docs/sphinx/blueprint_mcarray.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 
@@ -164,7 +164,7 @@ These files use standard CMake commands. CMake *set* commands need to specify th
 
 Bootstrapping Third Party Dependencies 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-We use **Spack** (http://software.llnl.gov/spack) automate builds of third party dependencies on OSX and Linux. Conduit builds on Windows as well, but there is no automated process to build dependencies necessary to support Conduit's optional features.
+We use **Spack** (http://llnl.github.io/spack) automate builds of third party dependencies on OSX and Linux. Conduit builds on Windows as well, but there is no automated process to build dependencies necessary to support Conduit's optional features.
 
 On OSX and Linux, you can use ``bootstrap-env.sh`` (located at the root of the conduit repo) to help setup your development environment. This script uses ``scripts/uberenv/uberenv.py``, which leverages **Spack** to build all of the external third party libraries and tools used by Conduit. Fortran support is optional and all dependencies should build without a fortran compiler. After building these libraries and tools, it writes an initial *host-config* file and adds the Spack built CMake binary to your PATH so can immediately call the ``config-build.sh`` helper script to configure a conduit build.
 

--- a/src/docs/sphinx/conduit.rst
+++ b/src/docs/sphinx/conduit.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/conduit_api.rst
+++ b/src/docs/sphinx/conduit_api.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/conf.py.in
+++ b/src/docs/sphinx/conf.py.in
@@ -11,7 +11,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/docs/sphinx/developer.rst
+++ b/src/docs/sphinx/developer.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/glossary.rst
+++ b/src/docs/sphinx/glossary.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/index.rst
+++ b/src/docs/sphinx/index.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 
@@ -86,7 +86,7 @@ Conduit Project Resources
 
 **Online Documentation**
 
-http://software.llnl.gov/conduit/
+http://llnl.github.io/conduit/
 
 **Github Source Repo**
 

--- a/src/docs/sphinx/licenses.rst
+++ b/src/docs/sphinx/licenses.rst
@@ -9,7 +9,7 @@
 .. #
 .. # This file is part of Conduit.
 .. #
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. #
 .. # Please also read conduit/LICENSE
 .. #
@@ -77,7 +77,7 @@ Fortran Libraries
 Build System
 ~~~~~~~~~~~~~~~
 - *CMake*: http://www.cmake.org/licensing/ (BSD Style License)
-- *Spack*: http://software.llnl.gov/spack (LGPL License)
+- *Spack*: http://llnl.github.io/spack (LGPL License)
 
 
 Documentation

--- a/src/docs/sphinx/presentations.rst
+++ b/src/docs/sphinx/presentations.rst
@@ -9,7 +9,7 @@
 .. #
 .. # This file is part of Conduit.
 .. #
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. #
 .. # Please also read conduit/LICENSE
 .. #

--- a/src/docs/sphinx/relay.rst
+++ b/src/docs/sphinx/relay.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/releases.rst
+++ b/src/docs/sphinx/releases.rst
@@ -9,7 +9,7 @@
 .. #
 .. # This file is part of Conduit.
 .. #
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. #
 .. # Please also read conduit/LICENSE
 .. #
@@ -54,7 +54,7 @@ v0.2.0
 -----------------
 
 * `Source Tarball <https://github.com/LLNL/conduit/archive/v0.2.0.tar.gz>`_
-* `Docs <http://software.llnl.gov/conduit/v0.2.0>`_
+* `Docs <http://llnl.github.io/conduit/v0.2.0>`_
     
 Highlights 
 +++++++++++++

--- a/src/docs/sphinx/tutorial_basics.rst
+++ b/src/docs/sphinx/tutorial_basics.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_json.rst
+++ b/src/docs/sphinx/tutorial_json.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_numeric.rst
+++ b/src/docs/sphinx/tutorial_numeric.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_ownership.rst
+++ b/src/docs/sphinx/tutorial_ownership.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/tutorial_update.rst
+++ b/src/docs/sphinx/tutorial_update.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/docs/sphinx/user.rst
+++ b/src/docs/sphinx/user.rst
@@ -9,7 +9,7 @@
 .. # 
 .. # This file is part of Conduit. 
 .. # 
-.. # For details, see: http://software.llnl.gov/conduit/.
+.. # For details, see: http://llnl.github.io/conduit/.
 .. # 
 .. # Please also read conduit/LICENSE
 .. # 

--- a/src/examples/using-with-cmake/example.cpp
+++ b/src/examples/using-with-cmake/example.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/examples/using-with-make/example.cpp
+++ b/src/examples/using-with-make/example.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/blueprint/c/conduit_blueprint.h
+++ b/src/libs/blueprint/c/conduit_blueprint.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/c/conduit_blueprint_c.cpp
+++ b/src/libs/blueprint/c/conduit_blueprint_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/c/conduit_blueprint_mcarray.h
+++ b/src/libs/blueprint/c/conduit_blueprint_mcarray.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/c/conduit_blueprint_mcarray_c.cpp
+++ b/src/libs/blueprint/c/conduit_blueprint_mcarray_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/c/conduit_blueprint_mesh.h
+++ b/src/libs/blueprint/c/conduit_blueprint_mesh.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/c/conduit_blueprint_mesh_c.cpp
+++ b/src/libs/blueprint/c/conduit_blueprint_mesh_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint.cpp
+++ b/src/libs/blueprint/conduit_blueprint.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint.hpp
+++ b/src/libs/blueprint/conduit_blueprint.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_exports.h
+++ b/src/libs/blueprint/conduit_blueprint_exports.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mcarray.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mcarray.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mcarray.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mcarray.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mcarray_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mcarray_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mcarray_examples.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mcarray_examples.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_utils.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_utils.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/conduit_blueprint_verify_exe.cpp
+++ b/src/libs/blueprint/conduit_blueprint_verify_exe.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/fortran/CMakeLists.txt
+++ b/src/libs/blueprint/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/blueprint/fortran/conduit_blueprint_fortran.f
+++ b/src/libs/blueprint/fortran/conduit_blueprint_fortran.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/blueprint/fortran/conduit_blueprint_mcarray_fortran.f
+++ b/src/libs/blueprint/fortran/conduit_blueprint_mcarray_fortran.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/blueprint/fortran/conduit_blueprint_mesh_fortran.f
+++ b/src/libs/blueprint/fortran/conduit_blueprint_mesh_fortran.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/blueprint/python/CMakeLists.txt
+++ b/src/libs/blueprint/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/blueprint/python/conduit_blueprint_python.cpp
+++ b/src/libs/blueprint/python/conduit_blueprint_python.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/python/conduit_blueprint_python_exports.hpp
+++ b/src/libs/blueprint/python/conduit_blueprint_python_exports.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/blueprint/python/py_src/__init__.py
+++ b/src/libs/blueprint/python/py_src/__init__.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/CMake/BitwidthChecks.cmake
+++ b/src/libs/conduit/CMake/BitwidthChecks.cmake
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/libs/conduit/c/conduit.h
+++ b/src/libs/conduit/c/conduit.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/c/conduit_c.cpp
+++ b/src/libs/conduit/c/conduit_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/c/conduit_cpp_to_c.cpp
+++ b/src/libs/conduit/c/conduit_cpp_to_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/c/conduit_cpp_to_c.hpp
+++ b/src/libs/conduit/c/conduit_cpp_to_c.hpp
@@ -9,7 +9,7 @@
 //
 // This file is part of Conduit.
 //
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 //
 // Please also read conduit/LICENSE
 //

--- a/src/libs/conduit/c/conduit_node.h
+++ b/src/libs/conduit/c/conduit_node.h
@@ -9,7 +9,7 @@
 //
 // This file is part of Conduit.
 //
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 //
 // Please also read conduit/LICENSE
 //

--- a/src/libs/conduit/c/conduit_node_c.cpp
+++ b/src/libs/conduit/c/conduit_node_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit.hpp
+++ b/src/libs/conduit/conduit.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_bitwidth_style_types.h.in
+++ b/src/libs/conduit/conduit_bitwidth_style_types.h.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_config.h.in
+++ b/src/libs/conduit/conduit_config.h.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_core.cpp
+++ b/src/libs/conduit/conduit_core.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_core.hpp
+++ b/src/libs/conduit/conduit_core.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_data_array.cpp
+++ b/src/libs/conduit/conduit_data_array.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_data_array.hpp
+++ b/src/libs/conduit/conduit_data_array.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_data_type.cpp
+++ b/src/libs/conduit/conduit_data_type.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_endianness.cpp
+++ b/src/libs/conduit/conduit_endianness.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_endianness.hpp
+++ b/src/libs/conduit/conduit_endianness.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_endianness_types.h
+++ b/src/libs/conduit/conduit_endianness_types.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_error.cpp
+++ b/src/libs/conduit/conduit_error.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_error.hpp
+++ b/src/libs/conduit/conduit_error.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_exports.h
+++ b/src/libs/conduit/conduit_exports.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_generator.cpp
+++ b/src/libs/conduit/conduit_generator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_generator.hpp
+++ b/src/libs/conduit/conduit_generator.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_node_iterator.cpp
+++ b/src/libs/conduit/conduit_node_iterator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_node_iterator.hpp
+++ b/src/libs/conduit/conduit_node_iterator.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_schema.cpp
+++ b/src/libs/conduit/conduit_schema.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_schema.hpp
+++ b/src/libs/conduit/conduit_schema.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_utils.cpp
+++ b/src/libs/conduit/conduit_utils.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/fortran/CMakeLists.txt
+++ b/src/libs/conduit/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/fortran/conduit_fortran.F
+++ b/src/libs/conduit/fortran/conduit_fortran.F
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/conduit/fortran/conduit_fortran_bitwidth_style_types.inc.in
+++ b/src/libs/conduit/fortran/conduit_fortran_bitwidth_style_types.inc.in
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/conduit/fortran/conduit_fortran_obj.f
+++ b/src/libs/conduit/fortran/conduit_fortran_obj.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/conduit/python/CMakeLists.txt
+++ b/src/libs/conduit/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/python/conduit_python.hpp
+++ b/src/libs/conduit/python/conduit_python.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/python/conduit_python_exports.hpp
+++ b/src/libs/conduit/python/conduit_python_exports.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/conduit/python/py_src/__init__.py
+++ b/src/libs/conduit/python/py_src/__init__.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/libs/relay/c/conduit_relay.h
+++ b/src/libs/relay/c/conduit_relay.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/c/conduit_relay_c.cpp
+++ b/src/libs/relay/c/conduit_relay_c.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay.cpp
+++ b/src/libs/relay/conduit_relay.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay.hpp
+++ b/src/libs/relay/conduit_relay.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_config.h.in
+++ b/src/libs/relay/conduit_relay_config.h.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_exports.h
+++ b/src/libs/relay/conduit_relay_exports.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_hdf5.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_hdf5.hpp
+++ b/src/libs/relay/conduit_relay_hdf5.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_io.cpp
+++ b/src/libs/relay/conduit_relay_io.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_io.hpp
+++ b/src/libs/relay/conduit_relay_io.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_mpi.hpp
+++ b/src/libs/relay/conduit_relay_mpi.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_silo.cpp
+++ b/src/libs/relay/conduit_relay_silo.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_silo.hpp
+++ b/src/libs/relay/conduit_relay_silo.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_web.cpp
+++ b/src/libs/relay/conduit_relay_web.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_web.hpp
+++ b/src/libs/relay/conduit_relay_web.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_web_node_viewer_exe.cpp
+++ b/src/libs/relay/conduit_relay_web_node_viewer_exe.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_web_node_viewer_server.cpp
+++ b/src/libs/relay/conduit_relay_web_node_viewer_server.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/conduit_relay_web_node_viewer_server.hpp
+++ b/src/libs/relay/conduit_relay_web_node_viewer_server.hpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/fortran/CMakeLists.txt
+++ b/src/libs/relay/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/fortran/conduit_relay_fortran.f
+++ b/src/libs/relay/fortran/conduit_relay_fortran.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/libs/relay/python/CMakeLists.txt
+++ b/src/libs/relay/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/python/conduit_relay_io_python.cpp
+++ b/src/libs/relay/python/conduit_relay_io_python.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/python/conduit_relay_python.cpp
+++ b/src/libs/relay/python/conduit_relay_python.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/python/conduit_relay_python_exports.h
+++ b/src/libs/relay/python/conduit_relay_python_exports.h
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/python/conduit_relay_web_python.cpp
+++ b/src/libs/relay/python/conduit_relay_web_python.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/libs/relay/python/py_src/__init__.py
+++ b/src/libs/relay/python/py_src/__init__.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/python/py_src/io/__init__.py
+++ b/src/libs/relay/python/py_src/io/__init__.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/python/py_src/web/__init__.py
+++ b/src/libs/relay/python/py_src/web/__init__.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/scripts/conduit_relay_entangle.py
+++ b/src/libs/relay/scripts/conduit_relay_entangle.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/index.html
+++ b/src/libs/relay/web_clients/node_viewer/index.html
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/launcher.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/launcher.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/search-table.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/search-table.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/tree.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/tree.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/treemap.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/treemap.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/value-table.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/value-table.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/visualizer-utils.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/visualizer-utils.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/resources/visualizer.js
+++ b/src/libs/relay/web_clients/node_viewer/resources/visualizer.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/node_viewer/visualizer.css
+++ b/src/libs/relay/web_clients/node_viewer/visualizer.css
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/wsock_test/index.html
+++ b/src/libs/relay/web_clients/wsock_test/index.html
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/libs/relay/web_clients/wsock_test/resources/wsock_test.js
+++ b/src/libs/relay/web_clients/wsock_test/resources/wsock_test.js
@@ -10,7 +10,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/blueprint/CMakeLists.txt
+++ b/src/tests/blueprint/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/blueprint/c/CMakeLists.txt
+++ b/src/tests/blueprint/c/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/blueprint/c/t_c_blueprint_mcarray.cpp
+++ b/src/tests/blueprint/c/t_c_blueprint_mcarray.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/blueprint/c/t_c_blueprint_mesh.cpp
+++ b/src/tests/blueprint/c/t_c_blueprint_mesh.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/blueprint/c/t_c_blueprint_smoke.cpp
+++ b/src/tests/blueprint/c/t_c_blueprint_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/blueprint/fortran/CMakeLists.txt
+++ b/src/tests/blueprint/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/blueprint/fortran/t_f_blueprint_mcarray.f
+++ b/src/tests/blueprint/fortran/t_f_blueprint_mcarray.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/blueprint/fortran/t_f_blueprint_mesh.f
+++ b/src/tests/blueprint/fortran/t_f_blueprint_mesh.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/blueprint/fortran/t_f_blueprint_smoke.f
+++ b/src/tests/blueprint/fortran/t_f_blueprint_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/blueprint/python/CMakeLists.txt
+++ b/src/tests/blueprint/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/blueprint/python/t_python_blueprint_smoke.py
+++ b/src/tests/blueprint/python/t_python_blueprint_smoke.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/CMakeLists.txt
+++ b/src/tests/conduit/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/c/CMakeLists.txt
+++ b/src/tests/conduit/c/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/c/t_c_conduit_node.cpp
+++ b/src/tests/conduit/c/t_c_conduit_node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/c/t_c_conduit_node_set.cpp
+++ b/src/tests/conduit/c/t_c_conduit_node_set.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/c/t_c_conduit_smoke.cpp
+++ b/src/tests/conduit/c/t_c_conduit_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/fortran/CMakeLists.txt
+++ b/src/tests/conduit/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/fortran/t_f_conduit_node.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_conduit_node_char8_str.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node_char8_str.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_conduit_node_float.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node_float.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_conduit_node_int.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node_int.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_conduit_node_obj.f
+++ b/src/tests/conduit/fortran/t_f_conduit_node_obj.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_conduit_smoke.f
+++ b/src/tests/conduit/fortran/t_f_conduit_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/fortran/t_f_type_sizes.f
+++ b/src/tests/conduit/fortran/t_f_type_sizes.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/conduit/python/CMakeLists.txt
+++ b/src/tests/conduit/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_datatype.py
+++ b/src/tests/conduit/python/t_python_conduit_datatype.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_generator.py
+++ b/src/tests/conduit/python/t_python_conduit_generator.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_node.py
+++ b/src/tests/conduit/python/t_python_conduit_node.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_node_iterator.py
+++ b/src/tests/conduit/python/t_python_conduit_node_iterator.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_schema.py
+++ b/src/tests/conduit/python/t_python_conduit_schema.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/python/t_python_conduit_smoke.py
+++ b/src/tests/conduit/python/t_python_conduit_smoke.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/conduit/t_conduit_array.cpp
+++ b/src/tests/conduit/t_conduit_array.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_char8_str.cpp
+++ b/src/tests/conduit/t_conduit_char8_str.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_datatype_tests.cpp
+++ b/src/tests/conduit/t_conduit_datatype_tests.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_endianness.cpp
+++ b/src/tests/conduit/t_conduit_endianness.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_generator.cpp
+++ b/src/tests/conduit/t_conduit_generator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_json_sanitize.cpp
+++ b/src/tests/conduit/t_conduit_json_sanitize.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_list_of.cpp
+++ b/src/tests/conduit/t_conduit_list_of.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node.cpp
+++ b/src/tests/conduit/t_conduit_node.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_binary_io.cpp
+++ b/src/tests/conduit/t_conduit_node_binary_io.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_compact.cpp
+++ b/src/tests/conduit/t_conduit_node_compact.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_convert.cpp
+++ b/src/tests/conduit/t_conduit_node_convert.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_info.cpp
+++ b/src/tests/conduit/t_conduit_node_info.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_iterator.cpp
+++ b/src/tests/conduit/t_conduit_node_iterator.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_parent.cpp
+++ b/src/tests/conduit/t_conduit_node_parent.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_paths.cpp
+++ b/src/tests/conduit/t_conduit_node_paths.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_save_load.cpp
+++ b/src/tests/conduit/t_conduit_node_save_load.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_set.cpp
+++ b/src/tests/conduit/t_conduit_node_set.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_to_value.cpp
+++ b/src/tests/conduit/t_conduit_node_to_value.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_node_update.cpp
+++ b/src/tests/conduit/t_conduit_node_update.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_serialize.cpp
+++ b/src/tests/conduit/t_conduit_serialize.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_smoke.cpp
+++ b/src/tests/conduit/t_conduit_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_to_string.cpp
+++ b/src/tests/conduit/t_conduit_to_string.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/conduit/t_conduit_utils.cpp
+++ b/src/tests/conduit/t_conduit_utils.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/docs/CMakeLists.txt
+++ b/src/tests/docs/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/docs/t_conduit_docs_blueprint_examples.cpp
+++ b/src/tests/docs/t_conduit_docs_blueprint_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/docs/t_conduit_docs_tutorial_examples.cpp
+++ b/src/tests/docs/t_conduit_docs_tutorial_examples.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/CMakeLists.txt
+++ b/src/tests/relay/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/c/CMakeLists.txt
+++ b/src/tests/relay/c/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/c/t_c_relay_smoke.cpp
+++ b/src/tests/relay/c/t_c_relay_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/fortran/CMakeLists.txt
+++ b/src/tests/relay/fortran/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/fortran/t_f_relay_smoke.f
+++ b/src/tests/relay/fortran/t_f_relay_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/relay/python/CMakeLists.txt
+++ b/src/tests/relay/python/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/python/t_python_relay_io.py
+++ b/src/tests/relay/python/t_python_relay_io.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/python/t_python_relay_smoke.py
+++ b/src/tests/relay/python/t_python_relay_smoke.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/python/t_python_relay_web.py
+++ b/src/tests/relay/python/t_python_relay_web.py
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/tests/relay/t_relay_io_basic.cpp
+++ b/src/tests/relay/t_relay_io_basic.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_io_hdf5.cpp
+++ b/src/tests/relay/t_relay_io_hdf5.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_io_hdf5_read_and_print.cpp
+++ b/src/tests/relay/t_relay_io_hdf5_read_and_print.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_mpi_smoke.cpp
+++ b/src/tests/relay/t_relay_mpi_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_node_viewer.cpp
+++ b/src/tests/relay/t_relay_node_viewer.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_smoke.cpp
+++ b/src/tests/relay/t_relay_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/relay/t_relay_websocket.cpp
+++ b/src/tests/relay/t_relay_websocket.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/t_config.hpp.in
+++ b/src/tests/t_config.hpp.in
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/CMakeLists.txt
+++ b/src/tests/thirdparty/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/tests/thirdparty/t_civetweb_smoke.cpp
+++ b/src/tests/thirdparty/t_civetweb_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_fortran_smoke.f
+++ b/src/tests/thirdparty/t_fortran_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/thirdparty/t_fruit_smoke.f
+++ b/src/tests/thirdparty/t_fruit_smoke.f
@@ -9,7 +9,7 @@
 !* 
 !* This file is part of Conduit. 
 !* 
-!* For details, see: http://software.llnl.gov/conduit/.
+!* For details, see: http://llnl.github.io/conduit/.
 !* 
 !* Please also read conduit/LICENSE
 !* 

--- a/src/tests/thirdparty/t_gtest_smoke.cpp
+++ b/src/tests/thirdparty/t_gtest_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_hdf5_smoke.cpp
+++ b/src/tests/thirdparty/t_hdf5_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_libb64_smoke.cpp
+++ b/src/tests/thirdparty/t_libb64_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_mpi_smoke.cpp
+++ b/src/tests/thirdparty/t_mpi_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_numpy_smoke.cpp
+++ b/src/tests/thirdparty/t_numpy_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_rapidjson_smoke.cpp
+++ b/src/tests/thirdparty/t_rapidjson_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/tests/thirdparty/t_silo_smoke.cpp
+++ b/src/tests/thirdparty/t_silo_smoke.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
+++ b/src/thirdparty_builtin/civetweb-1.8/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/src/thirdparty_builtin/fruit-3.3.9/CMakeLists.txt
+++ b/src/thirdparty_builtin/fruit-3.3.9/CMakeLists.txt
@@ -9,7 +9,7 @@
 # 
 # This file is part of Conduit. 
 # 
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 # 
 # Please also read conduit/LICENSE
 # 

--- a/src/thirdparty_builtin/fruit-3.3.9/gtest_fortran_driver.cpp
+++ b/src/thirdparty_builtin/fruit-3.3.9/gtest_fortran_driver.cpp
@@ -9,7 +9,7 @@
 // 
 // This file is part of Conduit. 
 // 
-// For details, see: http://software.llnl.gov/conduit/.
+// For details, see: http://llnl.github.io/conduit/.
 // 
 // Please also read conduit/LICENSE
 // 

--- a/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
+++ b/src/thirdparty_builtin/libb64-1.2.1/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 # This file is part of Conduit.
 #
-# For details, see: http://software.llnl.gov/conduit/.
+# For details, see: http://llnl.github.io/conduit/.
 #
 # Please also read conduit/LICENSE
 #

--- a/thirdparty_licenses.md
+++ b/thirdparty_licenses.md
@@ -4,5 +4,5 @@ Third Party Licenses
 For a list of software components used in Conduit and their respective licenses
 refer to:
 
-* [The live documentation](http://software.llnl.gov/conduit/licenses.html#third-party-builtin-libraries)
+* [The live documentation](http://llnl.github.io/conduit/licenses.html#third-party-builtin-libraries)
 * [The source code](/src/docs/sphinx/licenses.rst )


### PR DESCRIPTION
This is a "workaround" to the break that happened last week when we enabled HTTPS on the software.llnl.gov site.