### PR TITLE
bugfix: fix bug in mesh bp recti coord set verify

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -688,7 +688,6 @@ mesh::coordset::rectilinear::verify(const Node &coordset,
 
     std::string proto_name = "mesh::coordset::rectilinear";
 
-
     if(!coordset.has_child("values"))
     {
         log_error(info,proto_name, "missing child \"values\"");
@@ -696,9 +695,43 @@ mesh::coordset::rectilinear::verify(const Node &coordset,
     }
     else
     {
-        // values should be a mcarray
-        res = blueprint::mcarray::verify(coordset["values"],
-                                         info["values"]);
+        const Node &n_vals = coordset["values"];
+
+        if( ! (n_vals.dtype().is_object() || n_vals.dtype().is_list()) )
+        {
+            log_error(info,proto_name,"Node has no children");
+            res = false;
+        }
+        else
+        {
+            // each child should be a numeric array
+            NodeConstIterator itr = n_vals.children();
+
+            while(itr.has_next())
+            {
+                const Node &chld = itr.next();
+                // make sure every child is a numeric array
+                if(!chld.dtype().is_number())
+                {
+                    std::ostringstream oss;
+                    std::string chld_name = itr.name();
+
+                    if(chld_name.size() == 0)
+                    {
+                        oss << "child [" << itr.index() <<  "]";
+                    }
+                    else
+                    {
+                        oss << "child \"" << chld_name << "\"";
+                    }
+
+                    oss << " is not a numeric type.";
+
+                    log_error(info,proto_name,oss.str());
+                    res = false;
+                }
+            }
+        }
     }
 
     log_verify_result(info,res);

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -269,8 +269,26 @@ TEST(conduit_blueprint_mesh_verify, coordset_rectilinear)
         {
             n["values"][coord_coordsys[cj]].set(DataType::float64(10));
             EXPECT_TRUE(blueprint::mesh::coordset::rectilinear::verify(n,info));
+            info.print();
         }
     }
+
+    // check case where number of elements for each child doesn't match 
+    // (rectilinear coordsets use cross product of input coord arrays, they
+    //  don't need to be mcarrays)
+    for(size_t ci = 0; ci < 3; ci++)
+    {
+        const std::vector<std::string>& coord_coordsys = COORDINATE_COORDSYSS[ci];
+
+        n["values"].reset();
+        for(size_t cj = 0; cj < coord_coordsys.size(); cj++)
+        {
+            n["values"][coord_coordsys[cj]].set(DataType::float64(cj + 5));
+            EXPECT_TRUE(blueprint::mesh::coordset::rectilinear::verify(n,info));
+            info.print();
+        }
+    }
+
 
     // FIXME: The logical coordinate system shouldn't be an accepted value
     // for the rectilinear verify function.


### PR DESCRIPTION
The values for rectilinear coordsets aren't necessarily
mcarrays, since they use an implied cross product of
separate arrays to define the actual coordset.

This update changes verify for the rectilinear coordset
case  to check that "values" has numeric children, instead
of checking that "values" is an mcarray.