### PR TITLE
enh: expose conduit dtype to hdf5 dtype helpers

### DIFF
--- a/src/libs/relay/conduit_relay_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_hdf5.cpp
@@ -199,15 +199,6 @@ private:
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-hid_t    conduit_dtype_to_hdf5_dtype(const DataType &dt,
-                                     const std::string &ref_path);
-
-//-----------------------------------------------------------------------------
-DataType hdf5_dtype_to_conduit_dtype(hid_t hdf5_dtype_id,
-                                     index_t num_elems,
-                                     const std::string &ref_path);
-
-//-----------------------------------------------------------------------------
 // helpers for checking if compatible 
 //-----------------------------------------------------------------------------
 
@@ -237,7 +228,7 @@ hid_t create_hdf5_dataset_for_conduit_leaf(const DataType &dt,
                                            hid_t hdf5_group_id,
                                            const std::string &hdf5_dset_name);
 
-//---------------------------------------------------------------------------//
+//-----------------------------------------------------------------------------
 void  write_conduit_leaf_to_hdf5_dataset(const Node &node,
                                          const std::string &ref_path,
                                          hid_t hdf5_dset_id);
@@ -292,7 +283,7 @@ join_ref_paths(const std::string &parent, const std::string &child)
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-// Data Type Helper methods that aren't part of public conduit::relay::io
+// Data Type Helper methods that are a part of public conduit::relay::io
 //
 //  conduit_dtype_to_hdf5_dtype
 //  hdf5_dtype_to_conduit_dtype
@@ -496,13 +487,6 @@ hdf5_dtype_to_conduit_dtype(hid_t hdf5_dtype_id,
     else if(H5Tequal(hdf5_dtype_id,H5T_C_S1))
     {
         res = DataType::char8_str(num_elems);
-    }
-    //-----------------------------------------------
-    // Empty
-    //-----------------------------------------------
-    else if(H5Tequal(hdf5_dtype_id,H5T_C_S1))
-    {
-        res = DataType::empty();
     }
     //-----------------------------------------------
     // Unsupported

--- a/src/libs/relay/conduit_relay_hdf5.hpp
+++ b/src/libs/relay/conduit_relay_hdf5.hpp
@@ -196,6 +196,35 @@ void CONDUIT_RELAY_API hdf5_read(hid_t hdf5_id,
 //-----------------------------------------------------------------------------
 void CONDUIT_RELAY_API hdf5_read(hid_t hdf5_id,
                                  Node &node);
+
+//-----------------------------------------------------------------------------
+/// Read from hdf5 id into the output node
+//-----------------------------------------------------------------------------
+void CONDUIT_RELAY_API hdf5_read(hid_t hdf5_id,
+                                 Node &node);
+
+//-----------------------------------------------------------------------------
+/// Helpers for converting between hdf5 dtypes and conduit dtypes
+/// 
+///  Throughout the relay hdf5 implementation, we use DataType::Empty when
+///  the hdf5 data space is H5S_NULL, regardless of what the hdf5 data type is.
+///  That isn't reflected in these helper functions,they handle
+///  mapping of endianness and leaf types other than empty.
+///
+///
+///  Note: In these functions, ref_path is used to provide context about the
+///  hdf5 tree when an error occurs. Using it is recommend but not required.
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+hid_t CONDUIT_RELAY_API    conduit_dtype_to_hdf5_dtype(const DataType &dt,
+                                                const std::string &ref_path="");
+
+//-----------------------------------------------------------------------------
+DataType CONDUIT_RELAY_API hdf5_dtype_to_conduit_dtype(hid_t hdf5_dtype_id,
+                                                       index_t num_elems,
+                                                const std::string &ref_path="");
+
 }
 //-----------------------------------------------------------------------------
 // -- end conduit::relay::io --


### PR DESCRIPTION
added conduit dtype to hdf5 dtype helpers to the relay hdf5 interface
removed unreachable empty case logic in hdf5_dtype_to_conduit_dtype

This will resolve #125  and #126 