### PR TITLE
bugfix: fix error making 2d braid uniform 3d

### DIFF
--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -78,7 +78,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
     blueprint::mesh::examples::braid("uniform",
                                       npts_x,
                                       npts_y,
-                                      npts_y,
+                                      npts_z,
                                       dsets["uniform"]);
 
     blueprint::mesh::examples::braid("rectilinear",
@@ -243,7 +243,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_3d)
     blueprint::mesh::examples::braid("uniform",
                                       npts_x,
                                       npts_y,
-                                      npts_y,
+                                      npts_z,
                                       dsets["uniform"]);
 
     blueprint::mesh::examples::braid("rectilinear",


### PR DESCRIPTION
fixes typo (passing y_npts as z_npts) that caused the 2d
uniform braid example to be 3d.