### PR TITLE
Task/2017 01 uberenv ssl opts

### DIFF
--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -209,7 +209,7 @@ Uberenv Options for Building Third Party Dependencies
   --spec             Spack spec                           linux: **%gcc**
                                                           osx: **%clang**
   --compilers-yaml   Spack compilers settings file        ``scripts/uberenv/compilers.yaml``
-  -k                 Ignore SSL Errors                    False
+  -k                 Ignore SSL Errors                    **False**
  ================== ==================================== ======================================
 
 The ``-k`` option exists for sites where SSL certificate interception undermines fetching

--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -209,7 +209,18 @@ Uberenv Options for Building Third Party Dependencies
   --spec             Spack spec                           linux: **%gcc**
                                                           osx: **%clang**
   --compilers-yaml   Spack compilers settings file        ``scripts/uberenv/compilers.yaml``
+  -k                 Ignore SSL Errors                    False
  ================== ==================================== ======================================
+
+The ``-k`` option exists for sites where SSL certificate interception undermines fetching
+from github and https hosted source tarballs. When enabled, ``uberenv.py`` clones spack using:
+
+.. code:: bash
+
+    git -c http.sslVerify=false clone https://github.com/llnl/spack.git
+
+And passes ``-k`` to any spack commands that may fetch via https.
+
 
 Default invocation on Linux:
 

--- a/src/docs/sphinx/releases.rst
+++ b/src/docs/sphinx/releases.rst
@@ -53,8 +53,8 @@ https://github.com/LLNL/conduit/releases
 v0.2.1
 -----------------
 
-* `Source Tarball <https://github.com/LLNL/conduit/archive/v0.2.1.tar.gz>`_
-* `Docs <http://software.llnl.gov/conduit/v0.2.1>`_
+* `Source Tarball <https://github.com/LLNL/conduit/archive/v0.2.1.tar.gz>`__
+* `Docs <http://software.llnl.gov/conduit/v0.2.1>`__
 
 
 Highlights
@@ -75,14 +75,15 @@ Highlights
  * Added stand alone blueprint verify executable
 
 * **Relay**
+
  * Updated the version of civetweb used to avoid dlopen issues with SSL for static builds
 
 
 v0.2.0
 -----------------
 
-* `Source Tarball <https://github.com/LLNL/conduit/archive/v0.2.0.tar.gz>`_
-* `Docs <http://software.llnl.gov/conduit/v0.2.0>`_
+* `Source Tarball <https://github.com/LLNL/conduit/archive/v0.2.0.tar.gz>`__
+* `Docs <http://software.llnl.gov/conduit/v0.2.0>`__
     
 Highlights 
 +++++++++++++

--- a/src/examples/docker/ubuntu/Dockerfile
+++ b/src/examples/docker/ubuntu/Dockerfile
@@ -57,13 +57,6 @@ RUN apt-get update && apt-get install -y \
     python \
  && rm -rf /var/lib/apt/lists/*
 
-# at some sites, ssl certs are intercepted, which
-# cases issues fetching source via https.
-#
-# to resolve this, either install the proper certs into the image, or use 
-# the following commands to  disable ssl for git and curl (used by spack):
-RUN git config --global http.sslVerify false
-RUN echo insecure >> ~/.curlrc
 
 # untar the current source  (created as part of example_build.sh)
 COPY conduit.docker.src.tar.gz /
@@ -72,9 +65,20 @@ RUN tar -xzf conduit.docker.src.tar.gz
 # if you would like to clone conduit master directly, you can use:
 #RUN git clone --depth 1 https://github.com/LLNL/conduit.git
 
+# at some sites ssl certs are intercepted, which cases issues fetching 
+# tpl sources via https
+
+# to resolve this, either:
+# 1) pass the "-k" option to uberenv (recommended), 
+# 2) install the proper certs into the image, or
+# 3) use  the following commands to disable ssl for git and 
+#    curl (both are used by spack):
+#RUN git config --global http.sslVerify false
+#RUN echo insecure >> ~/.curlrc
+
 # bootstrap third party libs using spack and uberenv
 #  for this example we use mpich for MPI and only build python2 (not python3)
-RUN cd conduit && python scripts/uberenv/uberenv.py --spec %gcc+mpich~python3
+RUN cd conduit && python scripts/uberenv/uberenv.py -k --spec %gcc+mpich~python3
 
 # configure a debug build with cmake
 RUN cd conduit && mkdir build-debug


### PR DESCRIPTION
Adds a "-k" option to uberenv that enables ignoring ssl errors

thanks to Arlie Capps at LLNL for the recipe for this.
