### PR TITLE
remove uness number of domains ref in docs

### DIFF
--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -315,7 +315,6 @@ To conform, the ``state`` entry must be an *Object* and can have the following o
 
    * state/time: (number)
    * state/cycle: (number)
-   * state/number_of_domains: (integer)
    * state/domain_id: (integer)
 
 


### PR DESCRIPTION
Resolves #151 

number_of_domains was only mentioned in the docs, end even though it was optional -- it not checked in any verify methods, so this is an easy fix. 

