### PR TITLE
fix json sanitize bug with sci notation literals

### DIFF
--- a/src/libs/conduit/conduit_utils.cpp
+++ b/src/libs/conduit/conduit_utils.cpp
@@ -487,10 +487,17 @@ json_sanitize(const std::string &json)
                 
                 if( !in_id && check_word_char(json[i]))
                 {
-                    in_id = true;
-                    // accum id chars
-                    cur_id += json[i];
-                    emit = false;
+                    // ids can't start with numbers ,
+                    // check the prior char if it exists
+                    if(i > 0 && 
+                       !check_num_char(json[i-1]) &&
+                       json[i-1] != '.')
+                    {
+                        in_id = true;
+                        // accum id chars
+                        cur_id += json[i];
+                        emit = false;
+                    }
                 }
                 else if(in_id) // finish the id
                 {

--- a/src/tests/conduit/t_conduit_json_sanitize.cpp
+++ b/src/tests/conduit/t_conduit_json_sanitize.cpp
@@ -44,7 +44,7 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: conduit_json_sanitize.cpp
+/// file: t_conduit_json_sanitize.cpp
 ///
 //-----------------------------------------------------------------------------
 
@@ -161,3 +161,13 @@ TEST(conduit_json_sanitize, simple_quoteless_schema)
     delete [] data4;
 }
 
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_json_sanitize, sci_notation)
+{
+    std::string json_in = "{ \"data\": { \"value\": 1.2e-11 } }";
+    
+    EXPECT_EQ(json_in,utils::json_sanitize(json_in));
+    
+}


### PR DESCRIPTION
fixed bug with json sanitize, where the 'e' in json literals
using sci notation would be escaped, causing parse errors.


resolves #158 