### PR TITLE
use int instead of bool in c-api for wider compat

### DIFF
--- a/src/libs/blueprint/c/conduit_blueprint.h
+++ b/src/libs/blueprint/c/conduit_blueprint.h
@@ -76,9 +76,9 @@ CONDUIT_BLUEPRINT_API void conduit_blueprint_about(conduit_node *cnode);
 /// Verify passed node confirms to given blueprint protocol.
 /// Messages related to the verification are be placed in the "info" node.
 //-----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_verify(const char *protocol,
-                                                    const conduit_node *cnode,
-                                                    conduit_node *cinfo);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_verify(const char *protocol,
+                                                   const conduit_node *cnode,
+                                                   conduit_node *cinfo);
 
 #ifdef __cplusplus
 }

--- a/src/libs/blueprint/c/conduit_blueprint_c.cpp
+++ b/src/libs/blueprint/c/conduit_blueprint_c.cpp
@@ -73,14 +73,14 @@ conduit_blueprint_about(conduit_node *cnode)
 
 
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_verify(const char *protocol,
                          const conduit_node *cnode,
                          conduit_node *cinfo)
 {
     const Node *n = cpp_node(cnode);
     Node *info =  cpp_node(cinfo);
-    return blueprint::verify(std::string(protocol),*n,*info);
+    return (int)blueprint::verify(std::string(protocol),*n,*info);
 }
 
 }

--- a/src/libs/blueprint/c/conduit_blueprint_mcarray.h
+++ b/src/libs/blueprint/c/conduit_blueprint_mcarray.h
@@ -73,27 +73,27 @@ extern "C" {
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to the blueprint mcarray protocol.
 //-----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mcarray_verify(const conduit_node *cnode,
-                                                            conduit_node *cinfo);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mcarray_verify(const conduit_node *cnode,
+                                                           conduit_node *cinfo);
 
 
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to given blueprint mcarray sub protocol.
 //-----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mcarray_verify_sub_protocol(const char *protocol,
-                                                                         const conduit_node *cnode,
-                                                                         conduit_node *cinfo);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mcarray_verify_sub_protocol(const char *protocol,
+                                                                        const conduit_node *cnode,
+                                                                        conduit_node *cinfo);
 
 //----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mcarray_is_interleaved(const conduit_node *cnode);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mcarray_is_interleaved(const conduit_node *cnode);
 
 //----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mcarray_to_contiguous(const conduit_node *cnode,
-                                                                   conduit_node *cdest);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mcarray_to_contiguous(const conduit_node *cnode,
+                                                                  conduit_node *cdest);
 
 //-----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mcarray_to_interleaved(const conduit_node *cnode,
-                                                                    conduit_node *cdest);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mcarray_to_interleaved(const conduit_node *cnode,
+                                                                   conduit_node *cdest);
 
 //-----------------------------------------------------------------------------
 /// Interface to generate example mesh blueprint data.

--- a/src/libs/blueprint/c/conduit_blueprint_mcarray_c.cpp
+++ b/src/libs/blueprint/c/conduit_blueprint_mcarray_c.cpp
@@ -66,56 +66,56 @@ using namespace conduit;
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to the blueprint mcarray protocol.
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mcarray_verify(const conduit_node *cnode,
                                  conduit_node *cinfo)
 {
     const Node &n = cpp_node_ref(cnode);
     Node &info    = cpp_node_ref(cinfo);
-    return blueprint::mcarray::verify(n,info);
+    return (int)blueprint::mcarray::verify(n,info);
 }
 
 
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to given blueprint mcarray sub protocol.
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mcarray_verify_sub_protocol(const char *protocol,
                                               const conduit_node *cnode,
                                               conduit_node *cinfo)
 {
     const Node &n = cpp_node_ref(cnode);
     Node &info    = cpp_node_ref(cinfo);
-    return blueprint::mcarray::verify(std::string(protocol),n,info);
+    return (int)blueprint::mcarray::verify(std::string(protocol),n,info);
 }
 
 
 //----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mcarray_is_interleaved(const conduit_node *cnode)
 {
     const Node &n = cpp_node_ref(cnode);
-    return blueprint::mcarray::is_interleaved(n);
+    return (int)blueprint::mcarray::is_interleaved(n);
 }
 
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mcarray_to_contiguous(const conduit_node *cnode,
                                         conduit_node *cdest)
 {
     const Node &n = cpp_node_ref(cnode);
     Node &dest    = cpp_node_ref(cdest);
-    return blueprint::mcarray::to_contiguous(n,dest);
+    return (int)blueprint::mcarray::to_contiguous(n,dest);
 }
 
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mcarray_to_interleaved(const conduit_node *cnode,
                                          conduit_node *cdest)
 {
     const Node &n = cpp_node_ref(cnode);
     Node &dest    = cpp_node_ref(cdest);
-    return blueprint::mcarray::to_interleaved(n,dest);
+    return (int)blueprint::mcarray::to_interleaved(n,dest);
 }
 
 

--- a/src/libs/blueprint/c/conduit_blueprint_mesh.h
+++ b/src/libs/blueprint/c/conduit_blueprint_mesh.h
@@ -72,16 +72,16 @@ extern "C" {
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to the blueprint mesh protocol.
 //-----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mesh_verify(const conduit_node *cnode,
-                                                         conduit_node *cinfo);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mesh_verify(const conduit_node *cnode,
+                                                        conduit_node *cinfo);
 
 
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to given blueprint mesh sub protocol.
 //-----------------------------------------------------------------------------
-CONDUIT_BLUEPRINT_API bool conduit_blueprint_mesh_verify_sub_protocol(const char *protocol,
-                                                                      const conduit_node *cnode,
-                                                                      conduit_node *cinfo);
+CONDUIT_BLUEPRINT_API int conduit_blueprint_mesh_verify_sub_protocol(const char *protocol,
+                                                                     const conduit_node *cnode,
+                                                                     conduit_node *cinfo);
 
 //-----------------------------------------------------------------------------
 /// Generate mesh::index from valid mesh.

--- a/src/libs/blueprint/c/conduit_blueprint_mesh_c.cpp
+++ b/src/libs/blueprint/c/conduit_blueprint_mesh_c.cpp
@@ -66,27 +66,27 @@ using namespace conduit;
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to the blueprint mesh protocol.
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mesh_verify(const conduit_node *cnode,
                               conduit_node *cinfo)
 {
     const Node &n = cpp_node_ref(cnode);
     Node &info    = cpp_node_ref(cinfo);
-    return blueprint::mesh::verify(n,info);
+    return (int)blueprint::mesh::verify(n,info);
 }
 
 
 //-----------------------------------------------------------------------------
 /// Verify passed node confirms to given blueprint mesh sub protocol.
 //-----------------------------------------------------------------------------
-bool
+int
 conduit_blueprint_mesh_verify_sub_protocol(const char *protocol,
                                            const conduit_node *cnode,
                                            conduit_node *cinfo)
 {
     const Node &n = cpp_node_ref(cnode);
     Node &info    = cpp_node_ref(cinfo);
-    return blueprint::mesh::verify(std::string(protocol),n,info);
+    return (int)blueprint::mesh::verify(std::string(protocol),n,info);
 }
 
 

--- a/src/libs/conduit/c/conduit_node.h
+++ b/src/libs/conduit/c/conduit_node.h
@@ -109,18 +109,18 @@ CONDUIT_API conduit_index_t conduit_node_number_of_elements(conduit_node *cnode)
 // CONDUIT_API char *conduit_node_path(const conduit_node *cnode);
 
 //-----------------------------------------------------------------------------
-CONDUIT_API bool conduit_node_has_child(const conduit_node *cnode, 
-                                        const char *name);
-CONDUIT_API bool conduit_node_has_path(const conduit_node *cnode, 
-                                       const char *path);
+CONDUIT_API int conduit_node_has_child(const conduit_node *cnode, 
+                                       const char *name);
+CONDUIT_API int conduit_node_has_path(const conduit_node *cnode, 
+                                      const char *path);
 
 //-----------------------------------------------------------------------------
 // -- node info --
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-CONDUIT_API bool conduit_node_is_root(conduit_node *cnode);
-CONDUIT_API bool conduit_node_is_data_external(const conduit_node *cnode);
+CONDUIT_API int conduit_node_is_root(conduit_node *cnode);
+CONDUIT_API int conduit_node_is_data_external(const conduit_node *cnode);
 
 //-----------------------------------------------------------------------------
 CONDUIT_API conduit_node *conduit_node_parent(conduit_node *cnode);
@@ -130,18 +130,18 @@ CONDUIT_API conduit_index_t conduit_node_total_strided_bytes(const conduit_node 
 CONDUIT_API conduit_index_t conduit_node_total_bytes_compact(const conduit_node *cnode);
     
 //-----------------------------------------------------------------------------
-CONDUIT_API bool conduit_node_is_compact(const conduit_node *cnode);
+CONDUIT_API int conduit_node_is_compact(const conduit_node *cnode);
 
 //-----------------------------------------------------------------------------
-CONDUIT_API bool conduit_node_is_contiguous(const conduit_node *cnode);
-CONDUIT_API bool conduit_node_contiguous_with_node(const conduit_node *cnode,
-                                                   const conduit_node *cother);
-CONDUIT_API bool conduit_node_contiguous_with_address(const conduit_node *cnode,
-                                                      void *address);
+CONDUIT_API int conduit_node_is_contiguous(const conduit_node *cnode);
+CONDUIT_API int conduit_node_contiguous_with_node(const conduit_node *cnode,
+                                                  const conduit_node *cother);
+CONDUIT_API int conduit_node_contiguous_with_address(const conduit_node *cnode,
+                                                     void *address);
 
 //-----------------------------------------------------------------------------
-CONDUIT_API bool conduit_node_compatible(const conduit_node *cnode,
-                                         const conduit_node *cother);
+CONDUIT_API int conduit_node_compatible(const conduit_node *cnode,
+                                        const conduit_node *cother);
 
 CONDUIT_API void conduit_node_info(const conduit_node *cnode,
                                    const conduit_node *cnres);

--- a/src/libs/conduit/c/conduit_node_c.cpp
+++ b/src/libs/conduit/c/conduit_node_c.cpp
@@ -123,33 +123,33 @@ conduit_node_number_of_elements(conduit_node *cnode)
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int 
 conduit_node_has_child(const conduit_node *cnode, 
                        const char *name)
 {
-    return cpp_node(cnode)->has_child(std::string(name));
+    return (int)cpp_node(cnode)->has_child(std::string(name));
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int
 conduit_node_has_path(const conduit_node *cnode, 
                       const char *path)
 {
-    return cpp_node(cnode)->has_path(std::string(path));
+    return (int)cpp_node(cnode)->has_path(std::string(path));
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int
 conduit_node_is_root(conduit_node *cnode)
 {
-    return cpp_node(cnode)->is_root();
+    return (int)cpp_node(cnode)->is_root();
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int
 conduit_node_is_data_external(const conduit_node *cnode)
 {
-    return cpp_node(cnode)->is_data_external();
+    return (int)cpp_node(cnode)->is_data_external();
 }
 
 
@@ -175,33 +175,33 @@ conduit_node_total_bytes_compact(const conduit_node *cnode)
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int
 conduit_node_is_compact(const conduit_node *cnode)
 {
-    return cpp_node(cnode)->is_compact();
+    return (int)cpp_node(cnode)->is_compact();
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int 
 conduit_node_is_contiguous(const conduit_node *cnode)
 {
-    return cpp_node(cnode)->is_contiguous();
+    return (int)cpp_node(cnode)->is_contiguous();
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int 
 conduit_node_contiguous_with_node(const conduit_node *cnode,
                                   const conduit_node *cother)
 {
-    return cpp_node(cnode)->contiguous_with(cpp_node_ref(cother));
+    return (int)cpp_node(cnode)->contiguous_with(cpp_node_ref(cother));
 }
 
 //-----------------------------------------------------------------------------
-bool 
+int 
 conduit_node_contiguous_with_address(const conduit_node *cnode,
                                      void *address)
 {
-    return cpp_node(cnode)->contiguous_with(address);
+    return (int)cpp_node(cnode)->contiguous_with(address);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
changes all instances of bool to in in the c-api
for conduit + blueprint.

bool is in C99, but requires include of stdbool.h
using int instead of bool will make c-api easier
to use on a wider set of compilers.