### PR TITLE
add iterator constructors that take node refs

### DIFF
--- a/src/libs/conduit/conduit_node_iterator.cpp
+++ b/src/libs/conduit/conduit_node_iterator.cpp
@@ -86,6 +86,15 @@ NodeIterator::NodeIterator(Node *node,
     m_num_children = node->number_of_children();
 }
 
+//---------------------------------------------------------------------------//
+NodeIterator::NodeIterator(Node &node,
+                           index_t idx)
+:m_node(&node),
+ m_index(idx)
+{
+    m_num_children = node.number_of_children();
+}
+
 
 //---------------------------------------------------------------------------//
 NodeIterator::NodeIterator(const NodeIterator &itr)
@@ -296,6 +305,15 @@ NodeConstIterator::NodeConstIterator(const Node *node,
     m_num_children = node->number_of_children();
 }
 
+
+//---------------------------------------------------------------------------//
+NodeConstIterator::NodeConstIterator(const Node &node,
+                                     index_t idx)
+:m_node(&node),
+ m_index(idx)
+{
+    m_num_children = node.number_of_children();
+}
 
 //---------------------------------------------------------------------------//
 NodeConstIterator::NodeConstIterator(const NodeConstIterator &itr)

--- a/src/libs/conduit/conduit_node_iterator.hpp
+++ b/src/libs/conduit/conduit_node_iterator.hpp
@@ -92,8 +92,14 @@ public:
     NodeIterator();
     /// Copy constructor.
     NodeIterator(const NodeIterator &itr);
+    
     /// Primary iterator constructor.
     NodeIterator(Node *node,index_t idx=0);
+    
+    /// Primary iterator constructor.
+    /// this will use the pointer to the passed Node ref.
+    NodeIterator(Node &node,index_t idx=0);
+    
     /// Destructor 
     ~NodeIterator();
  
@@ -175,6 +181,9 @@ public:
     NodeConstIterator(const NodeConstIterator &itr);
     /// Primary iterator constructor.
     NodeConstIterator(const Node *node,index_t idx=0);
+    /// Primary iterator constructor.
+    /// this will use the pointer to the passed Node ref.
+    NodeConstIterator(const Node &node,index_t idx=0);
     /// Destructor 
     ~NodeConstIterator();
 

--- a/src/tests/conduit/t_conduit_node_iterator.cpp
+++ b/src/tests/conduit/t_conduit_node_iterator.cpp
@@ -343,11 +343,56 @@ TEST(conduit_node_iterator, const_move_cursor)
     EXPECT_EQ(itr_2.name(),"c");
     
     EXPECT_FALSE(itr_2.has_next());
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_node_iterator, ref_constructor)
+{
+    uint32   a_val  = 10;
+    uint32   b_val  = 20;
+
+    Node n;
+    n["a"] = a_val;
+    n["b"] = b_val;
+    n["c"] = "myval";
+
+    NodeIterator itr(n);
     
+    EXPECT_TRUE(itr.has_next());
+    EXPECT_EQ(itr.next().as_uint32(),a_val);
+    EXPECT_EQ(itr.name(),"a");
     
+    EXPECT_TRUE(itr.has_next());
+    EXPECT_EQ(itr.next().as_uint32(),b_val);
+    EXPECT_EQ(itr.name(),"b");
+
+    EXPECT_TRUE(itr.has_next());
+    EXPECT_EQ(itr.next().as_string(),"myval");
+    EXPECT_EQ(itr.name(),"c");
     
+    EXPECT_FALSE(itr.has_next());
+
+
     
 
+    NodeConstIterator citr(n);
+    
+    EXPECT_TRUE(citr.has_next());
+    EXPECT_EQ(citr.next().as_uint32(),a_val);
+    EXPECT_EQ(citr.name(),"a");
+    
+    EXPECT_TRUE(citr.has_next());
+    EXPECT_EQ(citr.next().as_uint32(),b_val);
+    EXPECT_EQ(citr.name(),"b");
+
+    EXPECT_TRUE(citr.has_next());
+    EXPECT_EQ(citr.next().as_string(),"myval");
+    EXPECT_EQ(citr.name(),"c");
+    
+    EXPECT_FALSE(citr.has_next());
 
 }
+
+
 


### PR DESCRIPTION
The best way to obtain an iterator to  a node's children is via the `children()` method, for example:

```
NodeIterator itr = n.children();
NodeConstIterator citr = n.children();
```
However we also want to support using iterator constructors directly.

Prior to this update, the constructors only supported a pointer to a node:

`NodeIterator itr(&n);`

Which is awkward, given we usually write algorithms using Node refs.

This update adds constructors to support:

```
NodeIterator itr(n);
NodeConstIterator citr(n);

```


