### PR TITLE
fix bug with Node::set_node()

### DIFF
--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -461,7 +461,9 @@ Node::set_node(const Node &node)
 {
     if(node.dtype().id() == DataType::OBJECT_ID)
     {
+        reset();
         init(DataType::object());
+        
         const std::vector<std::string> &cld_names = node.child_names();
 
         for (std::vector<std::string>::const_iterator itr = cld_names.begin();
@@ -473,11 +475,12 @@ Node::set_node(const Node &node)
             curr_node->set_schema_ptr(curr_schema);
             curr_node->set_parent(this);
             curr_node->set(*node.m_children[idx]);
-            this->append_node_ptr(curr_node);       
-        }        
+            this->append_node_ptr(curr_node);
+        }
     }
-    else if(node.dtype().id() == DataType::LIST_ID)       
+    else if(node.dtype().id() == DataType::LIST_ID)
     {   
+        reset();
         init(DataType::list());
         for(size_t i=0;i< node.m_children.size(); i++)
         {

--- a/src/tests/conduit/t_conduit_node_set.cpp
+++ b/src/tests/conduit/t_conduit_node_set.cpp
@@ -2680,6 +2680,33 @@ TEST(conduit_node_set, set_vector_external)
 }
 
 
+//-----------------------------------------------------------------------------
+TEST(conduit_node, node_set_existing_obj)
+{   
+    Node n_init;
+
+    n_init["a"] = DataType::list();
+    
+    CONDUIT_INFO("INITIAL");
+    CONDUIT_INFO(n_init.to_json());
+
+    Node n_des;
+    n_des["a"].append().set("value");
+
+    
+    CONDUIT_INFO("DES");
+    CONDUIT_INFO(n_des.to_json());
+    
+    n_init = n_des;
+    
+    EXPECT_EQ(n_init.number_of_children(),1);
+    
+    CONDUIT_INFO("POST SET");
+    CONDUIT_INFO(n_init.to_json());
+
+
+}
+
 
 
 


### PR DESCRIPTION
Add a reset() to the object and list cases to avoid creating
bad nodes.

for the future: we would like to propagate sets in a way
that preserves existing schema and allocs if possible.

This will require adding some tricky logic, so the
this solution restores correctness.