### PR TITLE
cmake hdf5 sanity check, now with more sanity

### DIFF
--- a/src/CMake/thirdparty/SetupHDF5.cmake
+++ b/src/CMake/thirdparty/SetupHDF5.cmake
@@ -82,10 +82,17 @@ set(HDF5_DIR ${HDF5_ROOT} CACHE PATH "" FORCE)
 #
 message(STATUS "Checking that found HDF5_INCLUDE_DIRS are in HDF5_DIR")
 
+#
+# HDF5_INCLUDE_DIRS may also include paths to external lib headers 
+# (such as szip), so we check that *at least one* of the includes
+# listed in HDF5_INCLUDE_DIRS exists in the HDF5_DIR specified. 
+#
 
+set(check_hdf5_inc_dir_ok 0)
 foreach(IDIR ${HDF5_INCLUDE_DIRS})
     if("${IDIR}" MATCHES "${HDF5_DIR}")
         message(STATUS " ${IDIR} includes HDF5_DIR (${HDF5_DIR})")
+        set(check_hdf5_inc_dir_ok 1)
     else()
         
         # The check above could fail b/c of relative vs abs path
@@ -97,11 +104,14 @@ foreach(IDIR ${HDF5_INCLUDE_DIRS})
 
         if("${IDIR}" MATCHES "${HDF5_DIR_ABS}")
             message(STATUS " ${IDIR} includes HDF5_DIR (${HDF5_DIR_ABS})")
-        else()
-            message(FATAL_ERROR " ${IDIR} does not include HDF5_DIR")
+            set(check_hdf5_inc_dir_ok 1)
         endif()
     endif()
 endforeach()
+
+if(NOT check_hdf5_inc_dir_ok)
+    message(FATAL_ERROR " ${HDF5_INCLUDE_DIRS} does not include HDF5_DIR")
+endif()
 
 #
 # filter HDF5_LIBRARIES to remove hdf5_hl if it exists


### PR DESCRIPTION
further harden the cmake hdf5 sanity check:

HDF5_INCLUDE_DIRS may also include paths to external lib headers (such as szip), so we check that *at least one* of the includes listed in HDF5_INCLUDE_DIRS exists in the HDF5_DIR specified. 