### PR TITLE
add quotes to child name in non-exist error msg

### DIFF
--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -10792,7 +10792,7 @@ Node::fetch_child(const std::string &path) const
     if(!m_schema->has_child(p_curr))
     {
         CONDUIT_ERROR("Cannot const fetch non-existent " 
-                      << "child " << p_curr << " from Node("
+                      << "child \"" << p_curr << "\" from Node("
                       << this->path()
                       << ")");
     }
@@ -10841,7 +10841,7 @@ Node::fetch_child(const std::string &path)
     if(!m_schema->has_child(p_curr))
     {
         CONDUIT_ERROR("Cannot const fetch non-existent "
-                      << "child " << p_curr << " from Node("
+                      << "child \"" << p_curr << "\" from Node("
                       << this->path()
                       << ")");
     }

--- a/src/libs/conduit/conduit_schema.cpp
+++ b/src/libs/conduit/conduit_schema.cpp
@@ -713,7 +713,7 @@ Schema::fetch_child(const std::string &path)
     // check for parent
     if(p_curr == "..")
     {
-        if(m_parent == NULL)// TODO: check for erro (no parent)
+        if(m_parent == NULL)
         {
             CONDUIT_ERROR("Tried to fetch non-existent parent Schema.")
         }


### PR DESCRIPTION
Add quotes to child name in error message for non-existent child fetch.

This will resolve #201 