### PR TITLE
fix data indexing error in serialize

### DIFF
--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -13292,7 +13292,7 @@ Node::serialize(uint8 *data,index_t curr_offset) const
         if(is_compact())
         {
             memcpy(&data[curr_offset],
-                   m_data,
+                   element_ptr(0),
                    (size_t)total_bytes_compact());
         }
         else // ser as is. This copies stride * num_ele bytes

--- a/src/tests/conduit/t_conduit_serialize.cpp
+++ b/src/tests/conduit/t_conduit_serialize.cpp
@@ -170,4 +170,66 @@ TEST(conduit_serialize, compact)
 }
 
 
+//-----------------------------------------------------------------------------
+// Test for https://github.com/LLNL/conduit/issues/226
+//
+// Adapted from: test from @tomvierjahn's fork (linked above)
+//-----------------------------------------------------------------------------
+
+TEST(conduit_serialize, seralize_multiple)
+{
+    Node node;
+    node["a/b/c"].set((uint8)1);
+    node["a/b/d"].set((uint8)2);
+    node["a/e"].set((uint8)3);
+    
+    std::string schema;
+    std::vector<uint8> bytes;
+    
+    Schema s_compact;
+    // serialize
+    node.schema().compact_to(s_compact);
+    schema = s_compact.to_json();
+    node.serialize(bytes);
+    
+    const std::vector<uint8> bytes_serialization1(bytes);
+    const std::string schema_serialization1(schema);
+
+    
+    Node second_node;
+    second_node.set_data_using_schema(Schema(schema), bytes.data());
+    EXPECT_EQ(node["a/b/c"].as_uint8(), second_node["a/b/c"].as_uint8());
+    EXPECT_EQ(node["a/b/d"].as_uint8(), second_node["a/b/d"].as_uint8());
+    EXPECT_EQ(node["a/e"].as_uint8(), second_node["a/e"].as_uint8());
+    
+    // serialize again 
+    second_node.schema().compact_to(s_compact);
+    schema = s_compact.to_json();
+    second_node.serialize(bytes);
+    
+    const std::vector<uint8> bytes_serialization2(bytes);
+    const std::string schema_serialization2(schema);
+    
+    EXPECT_EQ(bytes_serialization1, bytes_serialization2);
+    EXPECT_EQ(schema_serialization1, schema_serialization2);
+    
+    Node third_node;
+    third_node.set_data_using_schema(Schema(schema), bytes.data());
+    
+    node.schema().print();
+    node.print();
+    
+    second_node.schema().print();
+    second_node.print();
+    
+    
+    third_node.schema().print();
+    third_node.print();
+
+
+    EXPECT_EQ(node["a/b/c"].as_uint8(), third_node["a/b/c"].as_uint8());
+    EXPECT_EQ(node["a/b/d"].as_uint8(), third_node["a/b/d"].as_uint8());
+    EXPECT_EQ(node["a/e"].as_uint8(), third_node["a/e"].as_uint8());
+}
+
 


### PR DESCRIPTION
Fixes #226 reported by @tomvierjahn
Also adds simple test for the issue, adapted from @tomvierjahn's tests

There was an indexing issue with the compact case, causing the offset not to be used in memcpy.


