### PR TITLE
fix compilation bug in silo reader/writer code

### DIFF
--- a/src/libs/relay/conduit_relay_silo.cpp
+++ b/src/libs/relay/conduit_relay_silo.cpp
@@ -104,10 +104,10 @@ silo_write(const Node &node,
     // check for ":" split
     std::string file_path;
     std::string silo_obj_base;
-    io::split_path(path,
-                   std::string(":"),
-                   file_path,
-                   silo_obj_base);
+    conduit::utils::split_file_path(path,
+                                    std::string(":"),
+                                    file_path,
+                                    silo_obj_base);
 
     /// If silo_obj_base is empty, we have a problem ... 
     if(silo_obj_base.size() == 0)
@@ -126,10 +126,10 @@ silo_read(const std::string &path,
     // check for ":" split    
     std::string file_path;
     std::string silo_obj_base;
-    io::split_path(path,
-                   std::string(":"),
-                   file_path,
-                   silo_obj_base);
+    conduit::utils::split_file_path(path,
+                                    std::string(":"),
+                                    file_path,
+                                    silo_obj_base);
 
     /// If silo_obj_base is empty, we have a problem ... 
     if(silo_obj_base.size() == 0)
@@ -1340,10 +1340,10 @@ silo_mesh_write(const Node &node,
     // check for ":" split
     std::string file_path;
     std::string silo_obj_base;
-    io::split_path(path,
-                   std::string(":"),
-                   file_path,
-                   silo_obj_base);
+    conduit::utils::split_file_path(path,
+                                    std::string(":"),
+                                    file_path,
+                                    silo_obj_base);
 
     /// If silo_obj_base is empty, we have a problem ... 
     if(silo_obj_base.size() == 0)


### PR DESCRIPTION
The changes in this pull request fix compilation errors introduced into the Silo reader/writer code as a result of the refactoring performed in #244.  These changes re-enable compilation of Silo-enabled versions of Conduit.