### PR TITLE
Bugfix: Node::diff fails for string data with offsets

### DIFF
--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -13680,8 +13680,8 @@ Node::diff(const Node &n, Node &info, const float64 epsilon) const
         {
             // NOTE: Can't use 'value' for characters since type aliasing can
             // confuse the 'char' type on various platforms.
-            char_array t_array((const void*)as_char8_str(), dtype());
-            char_array n_array((const void*)n.as_char8_str(), n.dtype());
+            char_array t_array((const void*)m_data, dtype());
+            char_array n_array((const void*)n.m_data, n.dtype());
             res |= t_array.diff(n_array, info, epsilon);
         }
         else
@@ -13830,8 +13830,8 @@ Node::diff_compatible(const Node &n, Node &info, const float64 epsilon) const
         {
             // NOTE: Can't use 'value' for characters since type aliasing can
             // confuse the 'char' type on various platforms.
-            char_array t_array((const void*)as_char8_str(), dtype());
-            char_array n_array((const void*)n.as_char8_str(), n.dtype());
+            char_array t_array((const void*)m_data, dtype());
+            char_array n_array((const void*)n.m_data, n.dtype());
             res |= t_array.diff_compatible(n_array, info, epsilon);
         }
         else

--- a/src/tests/conduit/t_conduit_node_compare.cpp
+++ b/src/tests/conduit/t_conduit_node_compare.cpp
@@ -204,6 +204,12 @@ TEST(conduit_node_compare, compare_leaf_string)
         {
             index_t leaf_tid = DataType::CHAR8_STR_ID;
             std::string leaf_str = compare_strs[ci];
+            // NOTE(JRC): This test applies a buffer offset to the data being
+            // tested to push the data to the end of the buffer. For an
+            // example test phrase "me", this buffer looks like the following:
+            //         leaf_buff
+            //   [ _ _ _ _ _ _ _ m e / ]
+            //     0 1 2 3 4 5 6 7 8 9
             DataType leaf_type(leaf_tid, leaf_str.length() + 1,
                 (10 - leaf_str.length() - 1) * DataType::default_bytes(leaf_tid),
                 DataType::default_bytes(leaf_tid), DataType::default_bytes(leaf_tid),


### PR DESCRIPTION
The changes in this pull request fix a bug in the `Node::diff` implementation that caused it to fail when comparing two nodes that had string data with non-zero offset values. This pull request also amends the `Node::diff` test cases to validate that these fixes work properly.