### PR TITLE
fix report messages for blueprint references

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -343,14 +343,14 @@ bool verify_reference_field(const std::string &protocol,
 
         if(!node_tree.has_child(ref_path) || !node_tree[ref_path].has_child(ref_name))
         {
-            log::error(info, protocol, "reference to non-existent " + ref_path +
-                                        log::quote(field_name, 1));
+            log::error(info, protocol, "reference to non-existent " + field_name +
+                                        log::quote(ref_name, 1));
             res = false;
         }
         else if(info_tree[ref_path][ref_name]["valid"].as_string() != "true")
         {
-            log::error(info, protocol, "reference to invalid " + ref_path +
-                                       log::quote(field_name, 1));
+            log::error(info, protocol, "reference to invalid " + field_name +
+                                       log::quote(ref_name, 1));
             res = false;
         }
     }


### PR DESCRIPTION
The changes in this pull request fix the error messages provided when the Blueprint code encounters an improper reference (see #275 for details).