### PR TITLE
fix validity status for blueprint functions

### DIFF
--- a/src/libs/conduit/conduit_log.cpp
+++ b/src/libs/conduit/conduit_log.cpp
@@ -102,11 +102,39 @@ error(Node &info,
 
 
 //-----------------------------------------------------------------------------
+// private recursive helper for the 'log::validation' function
+void
+_validation(Node &info,
+            bool res)
+{
+    if(info.has_child("valid"))
+    {
+        bool info_res = info["valid"].as_string() == "true";
+        info_res &= res;
+        info["valid"].set(res ? "true" : "false");
+
+        if(!info.is_root())
+        {
+            _validation(*info.parent(), info_res);
+        }
+    }
+}
+
+
+//-----------------------------------------------------------------------------
 void
 validation(Node &info,
            bool res)
 {
-    info["valid"] = res ? "true" : "false";
+    // NOTE: if the given node already has a "valid" child, it's updated to
+    // be the logical and of its current value and the new value so that
+    // invalid nodes aren't changed to valid by later updates
+    bool info_res = info.has_child("valid") ? info["valid"].as_string() == "true" : true;
+    info["valid"].set(res && info_res ? "true" : "false");
+
+    // NOTE(JRC): This behavior is currently disabled due to performance and
+    // ambiguity concerns.
+    // _validation(info,res);
 }
 
 


### PR DESCRIPTION
The changes in this pull request fix the issues outlined in #277 as well as a plethora of related issues. A full outline of the major changes in this PR can be found below:

* Fixed a number of bugs in validity setting for `info` nodes in `conduit::blueprint*::verify` functions.
* Updated the Blueprint test cases to more thoroughly check correctness of info node validity.
* Updated `conduit::utils::log::validation` to account for existing Node validity values.