### PR TITLE
fix typo in the blueprint documentation

### DIFF
--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -117,7 +117,7 @@ The mesh blueprint protocol supports three types of Coordinate Sets: ``uniform``
   * Spherical
 
 
-    * coordsets/coords/type: “uniform”
+    * coordsets/coords/type: “rectilinear”
     * coordsets/coords/values/{r,theta,phi}
 
 


### PR DESCRIPTION
The changes in this pull request fix a minor typo in the Blueprint documentation related to the specification for spherical rectilinear coordinate sets.