### PR TITLE
fix crash in relay mpi bcast with non empty recv nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added is_open() method to IOHandle in the C++ and Python interfaces
 - Added file name information to Relay HDF5 error messages
 
+
+### Fixed
+
+#### Relay
+
+- Fixed crash with mpi broadcast_using_schema() when receiving tasks pass a non empty node.
+
 ## [0.4.0] - Released 2019-03-01
 
 ### Added

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -1438,7 +1438,18 @@ broadcast_using_schema(Node &node,
         Generator gen(bcast_buffers["schema"].as_char8_str());
         gen.walk(bcast_schema);
         
-        if( bcast_schema.compatible(node.schema()))
+        // only check compat for leaves
+        // there are more zero copy cases possible here, but
+        // we need a better way to identify them
+        // compatible won't work for object cases that
+        // have different named leaves
+        if( !(node.dtype().is_empty() ||
+              node.dtype().is_object() ||
+              node.dtype().is_list() ) && 
+            !(bcast_schema.dtype().is_empty() ||
+              bcast_schema.dtype().is_object() ||
+              bcast_schema.dtype().is_list() )
+            && bcast_schema.compatible(node.schema()))
         {
             
             bcast_data_ptr  = node.contiguous_data_ptr();

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -1017,7 +1017,7 @@ TEST(conduit_mpi_test, bcast_using_schema)
 
 
 //-----------------------------------------------------------------------------
-TEST(conduit_mpi_test, bcast_using_schema_crash) 
+TEST(conduit_mpi_test, bcast_using_schema_non_empty_node) 
 {
 
     int rank = mpi::rank(MPI_COMM_WORLD);
@@ -1028,18 +1028,22 @@ TEST(conduit_mpi_test, bcast_using_schema_crash)
         Node n;
 
         std::vector<int64> vals;
-        // if(rank == root)
-        // {
+        if(rank == root)
+        {
             vals.push_back(11);
             vals.push_back(22);
             vals.push_back(33);
         
             n["here"].set(vals);
-        // }
+        }
+        else
+        {
+            n["there"] = "here is a string";
+        }
 
         mpi::broadcast_using_schema(n,root,MPI_COMM_WORLD);
-
-        int64 *vals_ptr = n.value();
+        n.print();
+        int64 *vals_ptr = n["here"].value();
 
         EXPECT_EQ(vals_ptr[0], 11);
         EXPECT_EQ(vals_ptr[1], 22);

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -1017,6 +1017,42 @@ TEST(conduit_mpi_test, bcast_using_schema)
 
 
 //-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, bcast_using_schema_crash) 
+{
+
+    int rank = mpi::rank(MPI_COMM_WORLD);
+    int com_size = mpi::size(MPI_COMM_WORLD);
+    
+    for(int root = 0; root < com_size; root++)
+    {
+        Node n;
+
+        std::vector<int64> vals;
+        // if(rank == root)
+        // {
+            vals.push_back(11);
+            vals.push_back(22);
+            vals.push_back(33);
+        
+            n["here"].set(vals);
+        // }
+
+        mpi::broadcast_using_schema(n,root,MPI_COMM_WORLD);
+
+        int64 *vals_ptr = n.value();
+
+        EXPECT_EQ(vals_ptr[0], 11);
+        EXPECT_EQ(vals_ptr[1], 22);
+        EXPECT_EQ(vals_ptr[2], 33);
+    
+        CONDUIT_INFO("Bcast from root = " 
+                     << root  << "\n"
+                     << "rank: " << rank << " res = "
+                     << n.to_json());
+    }
+}
+
+//-----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     int result = 0;


### PR DESCRIPTION
Schema::compatible() doesn't give is the green light to zero copy complex types, so we need more checks to avoid crashes. 


