### PR TITLE
add explicit default "to string" operations

### DIFF
--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -11254,6 +11254,7 @@ Node::to_json_stream(const std::string &stream_path,
         CONDUIT_ERROR("Unknown to_json protocol:" << protocol);
     }
 }
+
 //-----------------------------------------------------------------------------
 void
 Node::to_json_stream(std::ostream &os,
@@ -11281,6 +11282,12 @@ Node::to_json_stream(std::ostream &os,
     }
 }
 
+//-----------------------------------------------------------------------------
+std::string
+Node::to_json_default() const
+{
+    return to_json();
+}
 
 //-----------------------------------------------------------------------------
 // -- YAML construction methods ---
@@ -11298,6 +11305,7 @@ Node::to_yaml(const std::string &protocol,
     {
         return to_pure_yaml(indent,depth,pad,eoe);
     }
+    else
     {
         CONDUIT_ERROR("Unknown to_yaml protocol:" << protocol);
     }
@@ -11340,6 +11348,13 @@ Node::to_yaml_stream(std::ostream &os,
     {
         CONDUIT_ERROR("Unknown to_yaml protocol:" << protocol);
     }
+}
+
+//-----------------------------------------------------------------------------
+std::string
+Node::to_yaml_default() const
+{
+    return to_yaml();
 }
 
 //---------------------------------------------------------------------------//

--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -3340,6 +3340,10 @@ public:
                                        const std::string &pad=" ",
                                        const std::string &eoe="\n") const;
 
+    // NOTE(JRC): The primary reason this function exists is to enable easier
+    // compatibility with debugging tools (e.g. totalview, gdb) that have
+    // difficulty allocating default string parameters.
+    std::string         to_json_default() const;
 
 //-----------------------------------------------------------------------------
 // -- YAML construction methods ---
@@ -3367,6 +3371,10 @@ public:
                                        const std::string &pad=" ",
                                        const std::string &eoe="\n") const;
 
+    // NOTE(JRC): The primary reason this function exists is to enable easier
+    // compatibility with debugging tools (e.g. totalview, gdb) that have
+    // difficulty allocating default string parameters.
+    std::string         to_yaml_default() const;
 
 //-----------------------------------------------------------------------------
 //
@@ -3972,8 +3980,8 @@ private:
     void             append_node_ptr(Node *node)
                         {m_children.push_back(node);}
 
-    void             set_parent(Node *parent) 
-                        { m_parent = parent;}
+    void             set_parent(Node *new_parent) 
+                        { m_parent = new_parent;}
 
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_schema.cpp
+++ b/src/libs/conduit/conduit_schema.cpp
@@ -551,6 +551,30 @@ Schema::to_json_stream(std::ostream &os,
     }
 }
 
+//---------------------------------------------------------------------------//
+void
+Schema::to_json_stream(const std::string &stream_path,
+                       bool detailed, 
+                       index_t indent, 
+                       index_t depth,
+                       const std::string &pad,
+                       const std::string &eoe) const
+{
+    std::ofstream ofs;
+    ofs.open(stream_path.c_str());
+    if(!ofs.is_open())
+        CONDUIT_ERROR("<Schema::to_json_stream> failed to open: " << stream_path);
+    to_json_stream(ofs,detailed,indent,depth,pad,eoe);
+    ofs.close();
+}
+
+//---------------------------------------------------------------------------//
+std::string
+Schema::to_json_default() const
+{
+   return to_json();
+}
+
 //-----------------------------------------------------------------------------
 //
 /// Basic I/O methods

--- a/src/libs/conduit/conduit_schema.hpp
+++ b/src/libs/conduit/conduit_schema.hpp
@@ -208,6 +208,18 @@ public:
                                    const std::string &pad=" ",
                                    const std::string &eoe="\n") const;
 
+    void            to_json_stream(const std::string &stream_path,
+                                   bool detailed=true, 
+                                   index_t indent=2, 
+                                   index_t depth=0,
+                                   const std::string &pad=" ",
+                                   const std::string &eoe="\n") const;
+
+    // NOTE(JRC): The primary reason this function exists is to enable easier
+    // compatibility with debugging tools (e.g. totalview, gdb) that have
+    // difficulty allocating default string parameters.
+    std::string         to_json_default() const;
+
 //-----------------------------------------------------------------------------
 //
 /// Basic I/O methods

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -106,7 +106,6 @@ TEST(conduit_json, to_json_2)
     //
     EXPECT_EQ(n["a"].to_int64(),n2["a"].to_int64());
     EXPECT_EQ(n["b"].to_int64(),n2["b"].to_int64());
-
 }
 
 //-----------------------------------------------------------------------------
@@ -206,6 +205,16 @@ TEST(conduit_json, json_bool)
     n.print_detailed();
     EXPECT_EQ(n["value"].dtype().id(),DataType::UINT8_ID);
 
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_json, json_default)
+{
+    std::string pure_json ="{a:[0,1,2,3,4],b:[0.0,1.1,2.2,3.3]}";
+    Generator g(pure_json,"json");
+    Node n(g,true);
+
+    EXPECT_EQ(n.to_json_default(), n.to_json());
 }
 
 
@@ -730,8 +739,3 @@ TEST(conduit_json, dup_object_name_error)
     
 
 }
-
-
-
-
-

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -210,11 +210,18 @@ TEST(conduit_json, json_bool)
 //-----------------------------------------------------------------------------
 TEST(conduit_json, json_default)
 {
-    std::string pure_json ="{a:[0,1,2,3,4],b:[0.0,1.1,2.2,3.3]}";
-    Generator g(pure_json,"json");
-    Node n(g,true);
+    {
+        std::string pure_json ="{dtype:uint32, length:5}";
+        Schema s(pure_json);
+        EXPECT_EQ(s.to_json_default(), s.to_json());
+    }
 
-    EXPECT_EQ(n.to_json_default(), n.to_json());
+    {
+        std::string pure_json ="{a:[0,1,2,3,4],b:[0.0,1.1,2.2,3.3]}";
+        Generator g(pure_json,"json");
+        Node n(g,true);
+        EXPECT_EQ(n.to_json_default(), n.to_json());
+    }
 }
 
 

--- a/src/tests/conduit/t_conduit_yaml.cpp
+++ b/src/tests/conduit/t_conduit_yaml.cpp
@@ -324,6 +324,18 @@ TEST(conduit_yaml, yaml_bool)
 
 
 //-----------------------------------------------------------------------------
+TEST(conduit_yaml, yaml_default)
+{
+    std::string yaml_txt ="{\"a\": [0,1,2,3,4], \"b\":[0.0,1.1,2.2,3.3] }";
+    Generator g(yaml_txt,"yaml");
+    Node n;
+    g.walk(n);
+
+    EXPECT_EQ(n.to_yaml_default(), n.to_yaml());
+}
+
+
+//-----------------------------------------------------------------------------
 TEST(conduit_yaml, check_empty)
 {
     Node n;
@@ -579,11 +591,3 @@ TEST(conduit_yaml, dup_object_name_error)
     ASSERT_THROW(g3.walk(n),conduit::Error);
     EXPECT_TRUE(n3.dtype().is_empty());
 }
-
-
-
-
-
-
-
-

--- a/src/tests/conduit/t_conduit_yaml.cpp
+++ b/src/tests/conduit/t_conduit_yaml.cpp
@@ -330,7 +330,6 @@ TEST(conduit_yaml, yaml_default)
     Generator g(yaml_txt,"yaml");
     Node n;
     g.walk(n);
-
     EXPECT_EQ(n.to_yaml_default(), n.to_yaml());
 }
 


### PR DESCRIPTION
The changes in this pull request modify the `conduit::Node` and `conduit::Schema` classes so that their "to string" operations (e.g. `to_json`, `to_yaml`) have explicit default versions are available (i.e. versions wherein all arguments are filled with their default values and no additional arguments are accepted). The primary reason to include these functions is for better compatibility with debugging tools (e.g. totalview, gdb), which often have difficulties automatically filling in default string arguments.

The full list of changes in this pull request is as follows:
- [x] Implement `conduit::Node::to_*_default` functions.
- [x] Add regression test cases for the `conduit::Node::to_*_default` functions.
- [x] Implement `conduit::Schema::to_*_default` functions.
- [x] Add regression test cases for the `conduit::Schema::to_*_default` functions.
- [x] Fix compiler warning with `conduit::Node::set_parent`.