### PR TITLE
add filter functions for log nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to Conduit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project aspires to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased 
+
+### Added
+
+#### General 
+- Added a set of conduit::utils::log::remove_* filtering functions, which process conduit log/info nodes and strip out the requested information (useful for focusing the often verbose output in log/info nodes).
+
 
 ## [0.5.1] - Released 2020-01-18
 

--- a/src/libs/conduit/conduit_log.cpp
+++ b/src/libs/conduit/conduit_log.cpp
@@ -55,6 +55,8 @@
 
 using namespace conduit;
 
+typedef bool (*VerifyFun)(const Node&);
+
 //-----------------------------------------------------------------------------
 // -- begin conduit:: --
 //-----------------------------------------------------------------------------
@@ -115,62 +117,81 @@ validation(Node &info,
 
 
 //-----------------------------------------------------------------------------
-
-//-----------------------------------------------------------------------------
-void
-filter_invalid(Node &info)
+bool
+remove_tree(Node &info, const VerifyFun should_remove_fun)
 {
-    if(info.dtype().id() == DataType::OBJECT_ID)
+    if(info.dtype().is_object() || info.dtype().is_list())
     {
-        if(info.has_child("valid") && info["valid"].dtype().is_string() && info["valid"].as_string() == "true")
+        std::vector<index_t> removal_subtrees;
+
+        NodeIterator info_itr = info.children();
+        while(info_itr.has_next())
+        {
+            conduit::Node &info_child = info_itr.next();
+            if(remove_tree(info_child, should_remove_fun))
+            {
+                removal_subtrees.push_back(info_itr.index());
+            }
+        }
+
+        for(index_t ci = removal_subtrees.size(); ci-- > 0;)
+        {
+            info.remove(removal_subtrees[ci]);
+        }
+
+        // FIXME: This part of the solution makes it imperfect from a recursive
+        // standpoint, but it makes it well-suited to accomodate the child-informed
+        // removal criteria used for the 'log::remove_*' functions.
+        if(should_remove_fun(info))
         {
             info.set(DataType::empty());
         }
     }
-    if(info.dtype().id() == DataType::OBJECT_ID || info.dtype().id() == DataType::LIST_ID)
-    {
-        std::vector<index_t> filtered_children;
 
-        NodeIterator info_itr = info.children();
-        while(info_itr.has_next())
-        {
-            conduit::Node &info_child = info_itr.next();
-            filter_invalid(info_child);
-            if(info_child.dtype().is_empty())
-            {
-                filtered_children.push_back(info_itr.index());
-            }
-        }
-
-        for(index_t ci = filtered_children.size(); ci-- > 0;)
-        {
-            info.remove(filtered_children[ci]);
-        }
-    }
+    return should_remove_fun(info);
 }
 
+
+//-----------------------------------------------------------------------------
+bool is_valid(const Node &n)
+{
+    return n.dtype().is_empty() || (n.has_child("valid") && n["valid"].dtype().is_string() && n["valid"].as_string() == "true");
+};
 
 //-----------------------------------------------------------------------------
 void
-filter_nonoptional(Node &info)
+remove_valid(Node &info)
 {
-    if(info.dtype().id() == DataType::OBJECT_ID || info.dtype().id() == DataType::LIST_ID)
-    {
-        if(info.has_child("optional"))
-        {
-            info.remove("optional");
-        }
-
-        NodeIterator info_itr = info.children();
-        while(info_itr.has_next())
-        {
-            conduit::Node &info_child = info_itr.next();
-            filter_nonoptional(info_child);
-        }
-    }
+    remove_tree(info, is_valid);
 }
 
+
 //-----------------------------------------------------------------------------
+bool is_invalid(const Node &n)
+{
+    return n.dtype().is_empty() || (n.has_child("valid") && n["valid"].dtype().is_string() && n["valid"].as_string() == "false");
+};
+
+//-----------------------------------------------------------------------------
+void
+remove_invalid(Node &info)
+{
+    remove_tree(info, is_invalid);
+}
+
+
+//-----------------------------------------------------------------------------
+bool is_optional(const Node &n)
+{
+    return n.dtype().is_empty() || (n.name() == "optional");
+};
+
+//-----------------------------------------------------------------------------
+void
+remove_optional(Node &info)
+{
+    remove_tree(info, is_optional);
+}
 
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_log.hpp
+++ b/src/libs/conduit/conduit_log.hpp
@@ -95,11 +95,12 @@ void CONDUIT_API validation(conduit::Node &info,
 
 
 //-----------------------------------------------------------------------------
-void CONDUIT_API filter_invalid(conduit::Node &info);
+void CONDUIT_API remove_valid(conduit::Node &info);
+//-----------------------------------------------------------------------------
+void CONDUIT_API remove_invalid(conduit::Node &info);
 
 //-----------------------------------------------------------------------------
-void CONDUIT_API filter_nonoptional(conduit::Node &info);
-
+void CONDUIT_API remove_optional(conduit::Node &info);
 
 //-----------------------------------------------------------------------------
 std::string CONDUIT_API quote(const std::string &str,

--- a/src/libs/conduit/conduit_log.hpp
+++ b/src/libs/conduit/conduit_log.hpp
@@ -93,6 +93,14 @@ void CONDUIT_API error(conduit::Node &info,
 void CONDUIT_API validation(conduit::Node &info,
                             bool res);
 
+
+//-----------------------------------------------------------------------------
+void CONDUIT_API filter_invalid(conduit::Node &info);
+
+//-----------------------------------------------------------------------------
+void CONDUIT_API filter_nonoptional(conduit::Node &info);
+
+
 //-----------------------------------------------------------------------------
 std::string CONDUIT_API quote(const std::string &str,
                               bool pad_before = false);

--- a/src/tests/conduit/CMakeLists.txt
+++ b/src/tests/conduit/CMakeLists.txt
@@ -76,6 +76,7 @@ set(BASIC_TESTS t_conduit_smoke
                 t_conduit_node_iterator
                 t_conduit_schema
                 t_conduit_error
+                t_conduit_log
                 t_conduit_utils)
 
 

--- a/src/tests/conduit/t_conduit_log.cpp
+++ b/src/tests/conduit/t_conduit_log.cpp
@@ -1,0 +1,219 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_conduit_log.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+#include "conduit_log.hpp"
+
+#include "gtest/gtest.h"
+
+using namespace conduit;
+using namespace conduit::utils;
+
+/// Testing Constants ///
+
+typedef void (*LogFun)(Node&, const std::string&, const std::string&);
+
+/// Testing Functions ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_log, log_functions)
+{
+    LogFun log_functions[] = {log::info, log::optional, log::error};
+    const std::string log_headers[] = {"info", "optional", "errors"};
+    const index_t fun_count = sizeof(log_functions) / sizeof(log_functions[0]);
+
+    const std::string test_prototypes[] = {"p1", "p2"};
+    const std::string test_messages[] = {"m1", "m2"};
+    const index_t test_count = sizeof(test_prototypes) / sizeof(test_prototypes[0]);
+
+    for(index_t fi = 0; fi < fun_count; fi++)
+    {
+        LogFun log_fun = log_functions[fi];
+        const std::string &log_header = log_headers[fi];
+
+        Node info;
+        for(index_t ti = 0; ti < test_count; ti++)
+        {
+            log_fun(info, test_prototypes[ti], test_messages[ti]);
+
+            ASSERT_TRUE(info.dtype().is_object());
+            ASSERT_EQ(info.number_of_children(), 1);
+
+            ASSERT_TRUE(info.has_child(log_header));
+            ASSERT_TRUE(info[log_header].dtype().is_list());
+            ASSERT_EQ(info[log_header].number_of_children(), ti+1);
+
+            ASSERT_TRUE(info[log_header].child(ti).dtype().is_string());
+        }
+
+        ASSERT_NE(info[log_header].child(0).as_string(), info[log_header].child(1).as_string());
+    }
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_log, validation_functions)
+{
+    for(index_t ti = 0; ti < 2; ti++)
+    {
+        const bool test_valid = ti == 0;
+        const std::string test_validity_str = test_valid ? "true" : "false";
+
+        Node info;
+        log::validation(info, test_valid);
+
+        ASSERT_TRUE(info.dtype().is_object());
+        ASSERT_EQ(info.number_of_children(), 1);
+
+        ASSERT_TRUE(info.has_child("valid"));
+        ASSERT_TRUE(info["valid"].dtype().is_string());
+        ASSERT_EQ(info["valid"].as_string(), test_validity_str);
+
+        log::validation(info, true);
+        ASSERT_EQ(info.number_of_children(), 1);
+        ASSERT_EQ(info["valid"].as_string(), test_validity_str);
+
+        log::validation(info, false);
+        ASSERT_EQ(info.number_of_children(), 1);
+        ASSERT_EQ(info["valid"].as_string(), "false");
+    }
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_log, filter_invalid_function)
+{
+    { // Test: One-Level Filtered/Unfiltered //
+        for(index_t ti = 0; ti < 2; ti++)
+        {
+            const bool test_valid = ti == 0;
+            const std::string test_validity_str = test_valid ? "true" : "false";
+
+            std::ostringstream oss;
+            oss << "{\"valid\": \"" << test_validity_str << "\"}";
+            std::string trivial_schema = oss.str();
+
+            Generator gen_info(trivial_schema, "json");
+            Node info(gen_info, true);
+            log::filter_invalid(info);
+
+            ASSERT_EQ(info.dtype().is_empty(), test_valid);
+        }
+    }
+
+    { // Test: Multi-Level, Top-Level Filtered //
+        std::string basic_schema = "{\"valid\": \"true\", \"a\": {\"valid\": \"true\"}, \"b\": {\"valid\": \"true\"}, \"c\": 4}";
+
+        Generator gen_info(basic_schema, "json");
+        Node info(gen_info, true);
+        log::filter_invalid(info);
+
+        ASSERT_TRUE(info.dtype().is_empty());
+    }
+
+    { // Test: Multi-Level, Top-Level Unfiltered //
+        std::string nontrivial_schema = "{\"valid\": \"false\", \"a\": {\"valid\": \"false\"}, \"b\": {\"valid\": \"true\"}, \"c\": 4}";
+
+        Generator gen_info(nontrivial_schema, "json");
+        Node info(gen_info, true);
+        log::filter_invalid(info);
+
+        ASSERT_TRUE(info.dtype().is_object());
+        ASSERT_TRUE(info.has_child("valid"));
+        ASSERT_EQ(info["valid"].as_string(), "false");
+
+        ASSERT_TRUE(info.has_child("a"));
+        ASSERT_TRUE(info["a"].has_child("valid"));
+        ASSERT_EQ(info["a/valid"].as_string(), "false");
+
+        ASSERT_FALSE(info.has_child("b"));
+
+        ASSERT_TRUE(info.has_child("c"));
+    }
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_log, filter_nonoptional_function)
+{
+    { // Test: One-Level Filtering //
+        Node info;
+        log::info(info, "", "");
+        log::optional(info, "", ""),
+        log::error(info, "", "");
+        log::validation(info, true);
+        log::filter_nonoptional(info);
+
+        ASSERT_TRUE(info.dtype().is_object());
+        ASSERT_EQ(info.number_of_children(), 3);
+        ASSERT_TRUE(info.has_child("info"));
+        ASSERT_TRUE(info.has_child("errors"));
+        ASSERT_TRUE(info.has_child("valid"));
+    }
+
+    { // Test: Multi-Level Filtering //
+        Node info;
+        log::optional(info, "", ""),
+        log::info(info["a"], "", "");
+        log::optional(info["a"], "", ""),
+        log::info(info["b"], "", "");
+        log::filter_nonoptional(info);
+
+        ASSERT_TRUE(info.dtype().is_object());
+        ASSERT_EQ(info.number_of_children(), 2);
+        ASSERT_TRUE(info.has_child("a"));
+        ASSERT_TRUE(info.has_child("b"));
+
+        ASSERT_EQ(info["a"].number_of_children(), 1);
+        ASSERT_TRUE(info["a"].has_child("info"));
+        ASSERT_EQ(info["b"].number_of_children(), 1);
+        ASSERT_TRUE(info["b"].has_child("info"));
+    }
+}


### PR DESCRIPTION
The changes in this pull request add two filtering functions for log nodes output by Conduit in order to assist users with isolating and parsing critical log output. The exact set of functions added and their associated changes are as follows:

- [x] Add `conduit::utils::log::filter_invalid` to facilitate filtering all explicitly invalid nodes in a Conduit hierarchy (useful for `conduit::blueprint::mesh` log nodes).
- [x] Add `conduit::utils::log::filter_unoptional` to help with excluding all optional information from a Conduit hierarchy (useful for functions that output many log items with `conduit::utils::log::optional`).
- [x] Implement test cases for all of the logging functions in the `conduit::utils::log` namespace.