### PR TITLE
Set _IMPORT_PREFIX, as needed by vcpkg machinery

### DIFF
--- a/src/config/ConduitConfig.cmake.in
+++ b/src/config/ConduitConfig.cmake.in
@@ -58,6 +58,14 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
 if(NOT CONDUIT_FOUND)
 
+    # Compute the installation prefix relative to this file.
+    get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+    if(_IMPORT_PREFIX STREQUAL "/")
+      set(_IMPORT_PREFIX "")
+    endif()
+
     set(CONDUIT_VERSION "@PROJECT_VERSION@")
     set(CONDUIT_INSTALL_PREFIX "@CONDUIT_INSTALL_PREFIX@")
     set(CONDUIT_HDF5_DIR  "@HDF5_DIR@")


### PR DESCRIPTION
When used through vcpkg, several LIBRARY_DIR variables get set to the value `${_IMPORT_PREFIX}`.  This change copies the logic for setting up _IMPORT_PREFIX to before it gets used.

Many thanks to @white238 for his help on this.