### PR TITLE
FIX: Force travis job to terminate if uberenv fails [fix/travis_exit_on_error]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ script:
   - export FC=${COMPILER_FC}
   - ${CC} --version
   - cd $TRAVIS_BUILD_DIR
-  - echo $TRAVIS_BUILD_DIR 
+  - echo $TRAVIS_BUILD_DIR
   # setup spack spec based on our travis options
   - export SPACK_SPEC="%gcc@4.8"
   # variants
@@ -175,7 +175,7 @@ script:
   # Output something every 10 minutes or Travis kills the job
   - while sleep 540; do echo "=====[ $SECONDS seconds still running ]====="; done &
   # build deps using uberenv
-  - python scripts/uberenv/uberenv.py --spec "${SPACK_SPEC}" --spack-config-dir=scripts/uberenv/spack_configs/travis/
+  - python scripts/uberenv/uberenv.py --spec "${SPACK_SPEC}" --spack-config-dir=scripts/uberenv/spack_configs/travis/ || travis_terminate 1;
   # todo:
   #- export SPACK_PYTHON_BIN_DIR=`ls -d ${TRAVIS_BUILD_DIR}/uberenv_libs/spack/opt/spack/*/*/python*/bin`
   #- pip install cpp-coveralls
@@ -217,7 +217,7 @@ script:
   # test our examples that demo using an installed conduit
   - cd $TRAVIS_BUILD_DIR
   - ./scripts/ci/travis-test-build-examples-vs-install.sh
-  - ./scripts/ci/travis-test-python-example-vs-install.sh 
+  - ./scripts/ci/travis-test-python-example-vs-install.sh
 
 after_success:
   - test ${ENABLE_COVERAGE} = "ON" && coveralls --gcov /usr/bin/gcov-4.8 --include src/libs/conduit --include src/libs/blueprint --gcov-options '\-lp' --root $TRAVIS_BUILD_DIR --build-root $TRAVIS_BUILD_DIR/travis-debug-build;


### PR DESCRIPTION
When uberenv fails it exits with a non zero status. However, travis is not interrupted, and will eventually fail somewhere else.

I would like to suggest making this step blocking. We can do so by forcing travis to terminate the job when uberenv ends with non-zero status. We could also call a script instead of exposing each command in travis yaml file. This way we would have better control on the behavior regarding errors.