### PR TITLE
py, c, fortran api: add_child, child, remove_child for node and schema

### DIFF
--- a/src/libs/conduit/c/conduit_node.h
+++ b/src/libs/conduit/c/conduit_node.h
@@ -93,8 +93,16 @@ CONDUIT_API conduit_node *conduit_node_fetch(conduit_node *cnode,
 CONDUIT_API conduit_node *conduit_node_append(conduit_node *cnode);
 
 //-----------------------------------------------------------------------------
+CONDUIT_API conduit_node *conduit_node_add_child(conduit_node *cnode,
+                                                 const char *name);
+
+//-----------------------------------------------------------------------------
 CONDUIT_API conduit_node *conduit_node_child(conduit_node *cnode,
                                              conduit_index_t idx);
+
+//-----------------------------------------------------------------------------
+CONDUIT_API conduit_node *conduit_node_child_by_name(conduit_node *cnode,
+                                                     const char *name);
 
 //-----------------------------------------------------------------------------
 CONDUIT_API conduit_index_t conduit_node_number_of_children(conduit_node *cnode);
@@ -112,6 +120,10 @@ CONDUIT_API void conduit_node_remove_path(conduit_node *cnode,
 CONDUIT_API void conduit_node_remove_child(conduit_node *cnode,
                                            conduit_index_t idx);
 
+//-----------------------------------------------------------------------------
+/// remove child by name
+CONDUIT_API void conduit_node_remove_child_by_name(conduit_node *cnode,
+                                                   const char *name);
 
 //-----------------------------------------------------------------------------
 // TODO:  for Node::name() in c, the caller must free the result, 

--- a/src/libs/conduit/c/conduit_node_c.cpp
+++ b/src/libs/conduit/c/conduit_node_c.cpp
@@ -110,9 +110,26 @@ conduit_node_append(conduit_node *cnode)
 
 //-----------------------------------------------------------------------------
 conduit_node *
+conduit_node_add_child(conduit_node *cnode,
+                       const char *name)
+{
+    return c_node(&cpp_node(cnode)->add_child(name));
+}
+
+//-----------------------------------------------------------------------------
+conduit_node *
 conduit_node_child(conduit_node *cnode, conduit_index_t idx)
 {
     return c_node(cpp_node(cnode)->child_ptr(idx));
+}
+
+
+//-----------------------------------------------------------------------------
+conduit_node *
+conduit_node_child_by_name(conduit_node *cnode,
+                           const char *name)
+{
+    return c_node(&cpp_node(cnode)->child(name));
 }
 
 //-----------------------------------------------------------------------------
@@ -159,6 +176,15 @@ conduit_node_remove_child(conduit_node *cnode,
                           conduit_index_t idx)
 {
     cpp_node(cnode)->remove(idx);
+}
+
+//-----------------------------------------------------------------------------
+/// remove child by name
+void
+conduit_node_remove_child_by_name(conduit_node *cnode,
+                                  const char *name)
+{
+    cpp_node(cnode)->remove_child(name);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/fortran/conduit_fortran.F90
+++ b/src/libs/conduit/fortran/conduit_fortran.F90
@@ -190,6 +190,16 @@ module conduit
        end function conduit_node_child
 
     !--------------------------------------------------------------------------
+    function c_conduit_node_child_by_name(cnode,name) result(res) &
+            bind(C, name="conduit_node_child_by_name")
+        use iso_c_binding
+        implicit none
+        type(C_PTR), value, intent(IN) :: cnode
+        character(kind=C_CHAR), intent(IN) :: name(*)
+        type(C_PTR) :: res
+    end function c_conduit_node_child_by_name
+
+    !--------------------------------------------------------------------------
     ! node info methods
     !--------------------------------------------------------------------------
 
@@ -203,23 +213,23 @@ module conduit
      end function conduit_node_is_root
 
 
-     !--------------------------------------------------------------------------
-     function conduit_node_is_data_external(cnode) result(res) &
-              bind(C, name="conduit_node_is_data_external")
-          use iso_c_binding
-          implicit none
-          type(C_PTR), value, intent(IN) :: cnode
-          logical(C_BOOL) :: res
-      end function conduit_node_is_data_external
+    !--------------------------------------------------------------------------
+    function conduit_node_is_data_external(cnode) result(res) &
+          bind(C, name="conduit_node_is_data_external")
+        use iso_c_binding
+        implicit none
+        type(C_PTR), value, intent(IN) :: cnode
+        logical(C_BOOL) :: res
+    end function conduit_node_is_data_external
 
-      !--------------------------------------------------------------------------
-      function conduit_node_parent(cnode) result(res) &
-               bind(C, name="conduit_node_parent")
-           use iso_c_binding
-           implicit none
-           type(C_PTR), value, intent(IN) :: cnode
-           type(C_PTR) :: res
-       end function conduit_node_parent
+    !--------------------------------------------------------------------------
+    function conduit_node_parent(cnode) result(res) &
+           bind(C, name="conduit_node_parent")
+        use iso_c_binding
+        implicit none
+        type(C_PTR), value, intent(IN) :: cnode
+        type(C_PTR) :: res
+    end function conduit_node_parent
 
     !--------------------------------------------------------------------------
     function conduit_node_number_of_elements(cnode) result(res) &
@@ -266,7 +276,26 @@ module conduit
            type(C_PTR), value, intent(IN) :: cnode
            integer(C_SIZE_T), value, intent(in) :: idx
       end subroutine conduit_node_remove_child
-       
+
+      !--------------------------------------------------------------------------
+      function c_conduit_node_add_child(cnode,name) result(res) &
+               bind(C, name="conduit_node_add_child")
+           use iso_c_binding
+           implicit none
+           type(C_PTR), value, intent(IN) :: cnode
+           character(kind=C_CHAR), intent(IN) :: name(*)
+           type(C_PTR) :: res
+      end function c_conduit_node_add_child
+
+      !--------------------------------------------------------------------------
+      subroutine c_conduit_node_remove_child_by_name(cnode,name) &
+               bind(C, name="conduit_node_remove_child_by_name")
+           use iso_c_binding
+           implicit none
+           type(C_PTR), value, intent(IN) :: cnode
+           character(kind=C_CHAR), intent(IN) :: name(*)
+      end subroutine c_conduit_node_remove_child_by_name
+
       !--------------------------------------------------------------------------
       subroutine c_conduit_node_rename_child(cnode,old_name, new_name) &
                 bind(C, name="conduit_node_rename_child")
@@ -1176,7 +1205,6 @@ contains
         res = c_conduit_node_fetch(cnode, trim(path) // C_NULL_CHAR)
     end function conduit_node_fetch
 
-
     !--------------------------------------------------------------------------
     function conduit_node_has_child(cnode, name) result(res)
         use iso_c_binding
@@ -1189,6 +1217,28 @@ contains
     end function conduit_node_has_child
 
     !--------------------------------------------------------------------------
+    function conduit_node_add_child(cnode, name) result(res)
+        use iso_c_binding
+        implicit none
+        type(C_PTR), value, intent(IN) :: cnode
+        character(*), intent(IN) :: name
+        type(C_PTR) :: res
+        !---
+        res = c_conduit_node_add_child(cnode, trim(name) // C_NULL_CHAR)
+    end function conduit_node_add_child
+
+    !--------------------------------------------------------------------------
+    function conduit_node_child_by_name(cnode, name) result(res)
+        use iso_c_binding
+        implicit none
+        type(C_PTR), value, intent(IN) :: cnode
+        character(*), intent(IN) :: name
+        type(C_PTR) :: res
+        !---
+        res = c_conduit_node_child_by_name(cnode, trim(name) // C_NULL_CHAR)
+    end function conduit_node_child_by_name
+
+    !--------------------------------------------------------------------------
     subroutine conduit_node_remove_path(cnode, path)
         use iso_c_binding
         implicit none
@@ -1197,6 +1247,16 @@ contains
         !---
         call c_conduit_node_remove_path(cnode, trim(path) // C_NULL_CHAR)
     end subroutine conduit_node_remove_path
+
+    !--------------------------------------------------------------------------
+    subroutine conduit_node_remove_child_by_name(cnode, name)
+        use iso_c_binding
+        implicit none
+        type(C_PTR), value, intent(IN) :: cnode
+        character(*), intent(IN) :: name
+        !---
+        call c_conduit_node_remove_child_by_name(cnode, trim(name) // C_NULL_CHAR)
+    end subroutine conduit_node_remove_child_by_name
 
     !--------------------------------------------------------------------------
     subroutine conduit_node_rename_child(cnode, old_name, new_name)

--- a/src/libs/conduit/fortran/conduit_fortran_obj.f90
+++ b/src/libs/conduit/fortran/conduit_fortran_obj.f90
@@ -61,7 +61,8 @@ module conduit_obj
         !----------------------------------------------------------------------
         procedure :: fetch  => conduit_node_obj_fetch
         procedure :: append => conduit_node_obj_append
-        procedure :: child  => conduit_node_obj_child
+        procedure :: child_by_index => conduit_node_obj_child
+        procedure :: child_by_name  => conduit_node_obj_child_by_name
         procedure :: parent => conduit_node_obj_parent
         procedure :: info   => conduit_node_obj_info
         !----------------------------------------------------------------------
@@ -98,13 +99,15 @@ module conduit_obj
         procedure :: load  => conduit_node_obj_load
 
         !----------------------------------------------------------------------
+        procedure :: add_child  => conduit_node_obj_add_child
         procedure :: has_child  => conduit_node_obj_has_child
         procedure :: has_path   => conduit_node_obj_has_path
         procedure :: rename_child => conduit_node_obj_rename_child
 
         !----------------------------------------------------------------------
         procedure :: remove_path  => conduit_node_obj_remove_path
-        procedure :: remove_child => conduit_node_obj_remove_child
+        procedure :: remove_child_by_index => conduit_node_obj_remove_child
+        procedure :: remove_child_by_name  => conduit_node_obj_remove_child_by_name
 
         !----------------------------------------------------------------------
         !----------------------------------------------------------------------
@@ -231,8 +234,11 @@ module conduit_obj
 
         !----------------------------------------------------------------------
         
-        generic :: remove  => remove_path, &
-                              remove_child
+        generic :: remove  => remove_path
+
+        generic :: remove_child  => remove_child_by_index, &
+                                    remove_child_by_name
+
 
         generic :: set  => set_node, &
                            set_int32, &
@@ -240,6 +246,9 @@ module conduit_obj
                            set_float32, &
                            set_float64, &
                            set_char8_str
+
+        generic :: child  => child_by_index, &
+                             child_by_name
 
         generic :: set_ptr  => set_int32_ptr, &
                                set_int64_ptr, &
@@ -460,6 +469,16 @@ contains
     end function conduit_node_obj_append
 
     !--------------------------------------------------------------------------
+    function conduit_node_obj_add_child(obj, name) result(res)
+        use iso_c_binding
+        implicit none
+        class(node) :: obj
+        character(*) :: name
+        type(node) :: res
+        res%cnode = conduit_node_add_child(obj%cnode, name)
+    end function conduit_node_obj_add_child
+
+    !--------------------------------------------------------------------------
     function conduit_node_obj_child(obj, idx) result(res)
         use iso_c_binding
         implicit none
@@ -468,6 +487,16 @@ contains
         type(node) :: res
         res%cnode = conduit_node_child(obj%cnode, idx)
     end function conduit_node_obj_child
+
+    !--------------------------------------------------------------------------
+    function conduit_node_obj_child_by_name(obj, name) result(res)
+        use iso_c_binding
+        implicit none
+        class(node) :: obj
+        character(*) :: name
+        type(node) :: res
+        res%cnode = conduit_node_child_by_name(obj%cnode, name)
+    end function conduit_node_obj_child_by_name
 
     !--------------------------------------------------------------------------
     function conduit_node_obj_has_child(obj, name) result(res)
@@ -506,6 +535,15 @@ contains
         integer(C_SIZE_T) :: idx
         call conduit_node_remove_child(obj%cnode, idx)
     end subroutine conduit_node_obj_remove_child
+
+    !--------------------------------------------------------------------------
+    subroutine conduit_node_obj_remove_child_by_name(obj, name)
+        use iso_c_binding
+        implicit none
+        class(node) :: obj
+        character(*) :: name
+        call conduit_node_remove_child_by_name(obj%cnode, name)
+    end subroutine conduit_node_obj_remove_child_by_name
 
     !--------------------------------------------------------------------------
     subroutine conduit_node_obj_rename_child(obj, old_name, new_name)

--- a/src/tests/conduit/c/t_c_conduit_node.cpp
+++ b/src/tests/conduit/c/t_c_conduit_node.cpp
@@ -415,3 +415,38 @@ TEST(c_conduit_node, c_save_load)
     conduit_node_destroy(n1);
     conduit_node_destroy(n2);
 }
+
+
+//-----------------------------------------------------------------------------
+TEST(c_conduit_node, c_child_with_embedded_slashes)
+{
+    conduit_node *n = conduit_node_create();
+
+    conduit_node *n_1 = conduit_node_fetch(n,"normal/path");
+    conduit_node_set_int(n_1,10);
+
+    conduit_node *n_2 = conduit_node_add_child(n,"child_with_/_inside");
+    conduit_node_set_int(n_2,42);
+
+    EXPECT_TRUE(conduit_node_has_path(n,"normal/path"));
+    EXPECT_FALSE(conduit_node_has_child(n,"normal/path"));
+    EXPECT_FALSE(conduit_node_has_path(n,"child_with_/_inside"));
+    EXPECT_TRUE(conduit_node_has_child(n,"child_with_/_inside"));
+
+    EXPECT_EQ(conduit_node_number_of_children(n),2);
+    
+    conduit_node *n_2_test = conduit_node_child_by_name(n,"child_with_/_inside");
+
+    EXPECT_EQ(n_2, n_2_test);
+    
+    EXPECT_EQ(conduit_node_as_int(n_1),10);
+    EXPECT_EQ(conduit_node_as_int(n_2_test),42);
+
+    conduit_node_remove_child_by_name(n,"child_with_/_inside");
+    EXPECT_EQ(conduit_node_number_of_children(n),1);
+    EXPECT_TRUE(conduit_node_has_path(n,"normal/path"));
+    EXPECT_FALSE(conduit_node_has_child(n,"child_with_/_inside"));
+
+
+    conduit_node_destroy(n);
+}

--- a/src/tests/conduit/fortran/t_f_conduit_node.f90
+++ b/src/tests/conduit/fortran/t_f_conduit_node.f90
@@ -528,6 +528,57 @@ contains
         call conduit_node_destroy(cnode2)
     end subroutine t_node_save_load
 
+    !--------------------------------------------------------------------------
+     subroutine t_node_names_embedded_slashes
+         type(C_PTR)  cn
+         type(C_PTR)  cn_1
+         type(C_PTR)  cn_2
+         type(C_PTR)  cn_2_test
+         real(kind=8) val
+         integer      nchld
+
+         !----------------------------------------------------------------------
+         call set_case_name("t_node_names_embedded_slashes")
+         !----------------------------------------------------------------------
+
+         cn = conduit_node_create()
+
+         cn_1 = conduit_node_fetch(cn,"normal/path");
+         cn_2 = conduit_node_add_child(cn,"child_with_/_inside");
+
+         call conduit_node_set_float64(cn_1,10.0d+0)
+         call conduit_node_set_float64(cn_2,42.0d+0)
+
+         val = conduit_node_as_float64(cn_1);
+         call assert_equals(10.0d+0, val)
+
+         val = conduit_node_as_float64(cn_2);
+         call assert_equals(42.0d+0, val)
+
+         call assert_true( conduit_node_has_path(cn,"normal/path") .eqv. .true. )
+         call assert_true( conduit_node_has_child(cn,"normal/path") .eqv. .false. )
+
+         call assert_true( conduit_node_has_path(cn,"child_with_/_inside") .eqv. .false. )
+         call assert_true( conduit_node_has_child(cn,"child_with_/_inside") .eqv. .true. )
+
+         nchld = conduit_node_number_of_children(cn)
+         call assert_equals( nchld , 2 )
+         ! by name, or just child ?
+         cn_2_test = conduit_node_child_by_name(cn,"child_with_/_inside")
+         val = conduit_node_as_float64(cn_2_test);
+         call assert_equals(42.0d+0, val)
+
+         ! by name or just remote_child
+         call conduit_node_remove_child_by_name(cn,"child_with_/_inside")
+
+         nchld = conduit_node_number_of_children(cn)
+         call assert_equals(nchld , 1 )
+         call assert_true( conduit_node_has_path(cn,"normal/path") .eqv. .true.)
+
+         call conduit_node_destroy(cn)
+
+     end subroutine t_node_names_embedded_slashes
+
 
 
 
@@ -560,7 +611,8 @@ program fortran_test
   call t_node_remove
   call t_node_parse
   call t_node_save_load
-
+  call t_node_names_embedded_slashes
+  
   call fruit_summary
   call fruit_finalize
   call is_all_successful(ok)

--- a/src/tests/conduit/fortran/t_f_conduit_node_obj.f90
+++ b/src/tests/conduit/fortran/t_f_conduit_node_obj.f90
@@ -871,9 +871,6 @@ contains
         val = n_2%as_float64();
         call assert_equals(42.0d+0, val)
 
-        call assert_true( n%has_path("a") .eqv. .false.)
-        call assert_true( n%has_path("b") .eqv. .true.)
-
         call assert_true( n%has_path("normal/path") .eqv. .true.)
         call assert_true( n%has_child("normal/path") .eqv. .false.)
 

--- a/src/tests/conduit/fortran/t_f_conduit_node_obj.f90
+++ b/src/tests/conduit/fortran/t_f_conduit_node_obj.f90
@@ -815,8 +815,8 @@ contains
         call conduit_node_obj_destroy(n)
 
     end subroutine t_node_obj_parse
-
-   !--------------------------------------------------------------------------
+ 
+    !--------------------------------------------------------------------------
     subroutine t_node_obj_save_load
         type(node) n1
         type(node) n2
@@ -844,6 +844,58 @@ contains
         call conduit_node_obj_destroy(n2)
 
     end subroutine t_node_obj_save_load
+   !--------------------------------------------------------------------------
+    subroutine t_node_obj_names_embedded_slashes
+        type(node) n
+        type(node) n_1
+        type(node) n_2
+        type(node) n_2_test
+        real(kind=8) val
+        integer      nchld
+
+        !----------------------------------------------------------------------
+        call set_case_name("t_node_obj_names_embedded_slashes")
+        !----------------------------------------------------------------------
+
+        n = conduit_node_obj_create()
+
+        n_1 = n%fetch("normal/path")
+        n_2 = n%add_child("child_with_/_inside")
+
+        call n_1%set(10.0d+0)
+        call n_2%set(42.0d+0)
+
+        val = n_1%as_float64();
+        call assert_equals(10.0d+0, val)
+
+        val = n_2%as_float64();
+        call assert_equals(42.0d+0, val)
+
+        call assert_true( n%has_path("a") .eqv. .false.)
+        call assert_true( n%has_path("b") .eqv. .true.)
+
+        call assert_true( n%has_path("normal/path") .eqv. .true.)
+        call assert_true( n%has_child("normal/path") .eqv. .false.)
+
+        call assert_true( n%has_path("child_with_/_inside") .eqv. .false.)
+        call assert_true( n%has_child("child_with_/_inside") .eqv. .true.)
+
+        nchld = n%number_of_children()
+        call assert_equals( nchld, 2 )
+
+        n_2_test = n%child("child_with_/_inside")
+        val = n_2_test%as_float64()
+        call assert_equals(42.0d+0, val)
+
+        call n%remove_child("child_with_/_inside")
+
+        nchld = n%number_of_children()
+        call assert_equals( nchld, 1 )
+        call assert_true( n%has_path("normal/path") .eqv. .true.)
+
+        call conduit_node_obj_destroy(n)
+
+    end subroutine t_node_obj_names_embedded_slashes
 
 
 !------------------------------------------------------------------------------
@@ -883,6 +935,7 @@ program fortran_test
   call t_node_obj_remove
   call t_node_obj_parse
   call t_node_obj_save_load
+  call t_node_obj_names_embedded_slashes
 
   call fruit_summary
   call fruit_finalize

--- a/src/tests/conduit/python/t_python_conduit_node.py
+++ b/src/tests/conduit/python/t_python_conduit_node.py
@@ -193,8 +193,6 @@ class Test_Conduit_Node(unittest.TestCase):
         self.assertTrue(n4["here"][0],"a")
         self.assertTrue(n4["here"][1],"b")
 
-
-    
     def test_remove(self):
         n = Node()
         n['a'] = 1
@@ -468,7 +466,23 @@ class Test_Conduit_Node(unittest.TestCase):
         print(n)
         self.assertEqual(n[0], 1.0)
         self.assertEqual(n[1], "there")
-        
+
+    def test_key_with_slash(self):
+        n = Node()
+        n["normal/path"] = 10
+        n.add_child("child_with_/_inside").set(42)
+        print(n)
+        self.assertTrue(n.has_path("normal/path"))
+        self.assertFalse(n.has_child("normal/path"))
+        self.assertFalse(n.has_path("child_with_/_inside"))
+        self.assertTrue(n.has_child("child_with_/_inside"))
+        self.assertEqual(2,n.number_of_children())
+        self.assertEqual(n["normal/path"],10);
+        self.assertEqual(n.child(name="child_with_/_inside").value(),42);
+        n["normal"].remove_child("path")
+        self.assertFalse(n.has_path("normal/path"))
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/tests/conduit/python/t_python_conduit_schema.py
+++ b/src/tests/conduit/python/t_python_conduit_schema.py
@@ -90,7 +90,23 @@ class Test_Conduit_Schema(unittest.TestCase):
         self.assertEqual(sr.total_strided_bytes(), 8 * 10 + 4 * 10)
         self.assertEqual(sr["a"].total_strided_bytes(),8 * 10)
         self.assertEqual(sr["b"].total_strided_bytes(),4 * 10)
-        
+
+    def test_schema_remove(self):
+        s = Schema()
+        s['a'] = DataType.float64(1)
+        s['b'] = DataType.float64(1)
+        s['c'] = DataType.float64(1)
+        self.assertEqual(s.number_of_children(),3)
+        s.remove(path='c')
+        self.assertEqual(s.number_of_children(),2)
+        paths = s.child_names()
+        for v in ['a','b']:
+            self.assertTrue(v in paths)
+        s.remove(index=0)
+        paths = s.child_names()
+        for v in ['b']:
+            self.assertTrue(v in paths)
+
     def test_schema_child_rename(self):
         s = Schema()
         with self.assertRaises(Exception):
@@ -112,7 +128,21 @@ class Test_Conduit_Schema(unittest.TestCase):
         self.assertEqual(sr["a"].total_strided_bytes(),8 * 10)
         self.assertEqual(sr["c"].total_strided_bytes(),4 * 10)
 
-
+    def test_key_with_slash(self):
+        s = Schema()
+        s["normal/path"] = DataType.float64(1)
+        s.add_child("child_with_/_inside").set(DataType.float64(1))
+        print(s)
+        self.assertTrue(s.has_path("normal/path"))
+        self.assertFalse(s.has_child("normal/path"))
+        self.assertFalse(s.has_path("child_with_/_inside"))
+        self.assertTrue(s.has_child("child_with_/_inside"))
+        self.assertEqual(2,s.number_of_children())
+        self.assertEqual(s.child(1).dtype().id(),DataType.float64().id())
+        self.assertEqual(s.child(name="child_with_/_inside").dtype().id(),DataType.float64().id())
+        s["normal"].remove_child("path")
+        self.assertFalse(s.has_path("normal/path"))
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
adds python wrappers and tests for new node and schema methods supporting child names with embedded slashes