### PR TITLE
add one-to-many indexing schemes, uni-buffer matset support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added support to write and read Conduit lists to HDF5 files. Since HDF5 Groups do not support unnamed indexed children, each list child is written using a string name that represents its index and a special attribute is written to the HDF5 group to mark the list case. On read, the special attribute is used to detect and read this style of group back into a Conduit list.
 
 #### Blueprint
+- Added support for sparse one-to-many relationships with the new `blueprint::o2mrelation` protocol. See the `blueprint::o2mrelation::examples::uniform` example for details.
+- Added sparse one-to-many and uni-buffer specification support to Material sets. See the Material sets documentation
+(https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#material-sets) for more details.
 - Added support for Adjacency sets for Structured Mesh Topologies. See the `blueprint::mesh::examples::adjset_uniform` example.
 - Added `blueprint::mesh::examples::julia_nestsets_simple` and `blueprint::mesh::examples::julia_nestsets_complex` examples represent Julia set fractals using patch-based AMR meshes and the Mesh Blueprint Nesting Set protocol. See the Julia AMR Blueprint docs
 (https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#julia-amr-examples) for more details.

--- a/src/docs/sphinx/blueprint.rst
+++ b/src/docs/sphinx/blueprint.rst
@@ -60,6 +60,10 @@ For now, Blueprint is focused on conventions for two important types of data:
 
     Many taxonomies and concrete mesh data models have been developed to allow computational meshes to be used in software. Blueprint's conventions for representing mesh data were formed by negotiating with simulation application teams at LLNL and from a survey of existing projects that provide scientific mesh-related APIs including: ADIOS,  Damaris, EAVL, MFEM, Silo, VTK, VTKm, and Xdmf. Blueprint's mesh conventions are not a replacement for existing mesh data models or APIs. Our explicit goal is to outline a comprehensive, but small set of options for describing meshes in-core that simplifies the process of adapting data to several existing mesh-aware APIs.
 
+*  One-to-Many Relations (protocol: ``o2mrelation``)
+
+    A one-to-many relation is a collection of arbitrarily grouped values that encode element associations from a source ("one"s) to a destination ("many"s) space.
+    These constructs are used in computational meshes to represent sparse material data, polygonal/polyhedral topologies, and other non-uniform mappings.
 
 *  Multi-Component Arrays (protocol: ``mcarray``)
 
@@ -68,6 +72,7 @@ For now, Blueprint is focused on conventions for two important types of data:
 
 .. toctree::
     blueprint_mesh
+    blueprint_o2mrelation
     blueprint_mcarray
 
 

--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -436,12 +436,80 @@ Material Sets
 
 Materials Sets contain material name and volume fraction information defined over a specified mesh topology.
 
-A material set contains an **mcarray** that houses per-material, per-element volume fractions and a source topology over which these volume fractions are defined.
-To conform to protocol, each entry in the ``matsets`` section must be an *Object* that contains the following information:
+A material set is a type of **o2mrelation** that houses per-material, per-element volume fractions that are defined over a referenced source topology.
+Each material set conforms to one of two variants based on the presented structure of its volume fraction information.
+Both of these variants and their corresponding schemas are outlined in the subsections below.
+
+
+Uni-Buffer Material Sets
+=================================
+
+A **uni-buffer** material set is one that presents all of its volume fraction data in a single data buffer.
+In this case, the material set schema must include this volume fraction data buffer, a parallel buffer associated each volume with a material identifier, and an *Object* mapping of human-readable material names to each unique material identifier.
+Additionally, the top-level of this schema is an **o2mrelation** that sources from the volume fraction and material identifier buffers and targets the material topology.
+To conform to protocol, each ``matsets`` entry of this type must be an *Object* that contains the following information:
 
    * matsets/matset/topology: "topo"
-   * matsets/matset/volume_fractions: (mcarray)
+   * matsets/matset/material_map: (integer object)
+   * matsets/matset/material_ids: (integer array)
+   * matsets/matset/volume_fractions: (floating-point array)
 
+The following diagram illustrates a simple **uni-buffer** material set example:
+
+  .. code:: yaml
+
+      #     z0       z1       z2
+      # +--------+--------+--------+
+      # | a0     | a1 ___/|        |
+      # |___-----|----    |   b2   |
+      # |     b0 |     b1 |        |
+      # +--------+--------+--------+
+      #
+
+      matsets:
+        matset:
+          topology: topology
+          volume_fractions:
+            values: [0, a0, b2, b1, b0, 0, a1, 0]
+            material_ids: [0, 1, 2, 2, 2, 0, 1, 0]
+            material_map:
+              a: 1
+              b: 2
+              c: 0
+            sizes: [2, 2, 1]
+            offsets: [0, 2, 4]
+            indices: [1, 4, 6, 3, 2]
+
+
+Multi-Buffer Material Sets
+=================================
+
+A **multi-buffer** material set is a material set variant wherein the volume fraction data is split such that one buffer exists per material.
+The schema for this variant dictates that each material be presented as an *Object* entry of the ``volume_fractions`` field with the material name as the entry key and the material volume fractions as the entry value.
+Optionally, the value for each such entry can be specified as an **o2mrelation** instead of a flat array to enable greater specification flexibility.
+To conform to protocol, each ``matsets`` entry of this type must be an *Object* that contains the following information:
+
+   * matsets/matset/topology: "topo"
+   * matsets/matset/volume_fractions: (object)
+
+The following diagram illustrates a simple **multi-buffer** material set example:
+
+  .. code:: yaml
+
+      #     z0       z1       z2
+      # +--------+--------+--------+
+      # | a0     | a1 ___/|        |
+      # |___-----|----    |   b2   |
+      # |     b0 |     b1 |        |
+      # +--------+--------+--------+
+      #
+
+      matsets:
+        matset:
+          topology: topology
+          volume_fractions:
+            a: [a0, a1, 0]
+            b: [b0, b1, b2]
 
 
 Fields

--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -445,9 +445,9 @@ Uni-Buffer Material Sets
 =================================
 
 A **uni-buffer** material set is one that presents all of its volume fraction data in a single data buffer.
-In this case, the material set schema must include this volume fraction data buffer, a parallel buffer associated each volume with a material identifier, and an *Object* mapping of human-readable material names to each unique material identifier.
-Additionally, the top-level of this schema is an **o2mrelation** that sources from the volume fraction and material identifier buffers and targets the material topology.
-To conform to protocol, each ``matsets`` entry of this type must be an *Object* that contains the following information:
+In this case, the material set schema must include this volume fraction data buffer, a parallel buffer associating each volume with a material identifier, and an *Object* mapping of human-readable material names to each unique material identifier.
+Additionally, the top-level of this schema is an **o2mrelation** that sources from the volume fraction/material identifier buffers and targets the material topology.
+To conform to protocol, each ``matsets`` child of this type must be an *Object* that contains the following information:
 
    * matsets/matset/topology: "topo"
    * matsets/matset/material_map: (integer object)
@@ -487,7 +487,7 @@ Multi-Buffer Material Sets
 A **multi-buffer** material set is a material set variant wherein the volume fraction data is split such that one buffer exists per material.
 The schema for this variant dictates that each material be presented as an *Object* entry of the ``volume_fractions`` field with the material name as the entry key and the material volume fractions as the entry value.
 Optionally, the value for each such entry can be specified as an **o2mrelation** instead of a flat array to enable greater specification flexibility.
-To conform to protocol, each ``matsets`` entry of this type must be an *Object* that contains the following information:
+To conform to protocol, each ``matsets`` child of this type must be an *Object* that contains the following information:
 
    * matsets/matset/topology: "topo"
    * matsets/matset/volume_fractions: (object)

--- a/src/docs/sphinx/blueprint_o2mrelation.rst
+++ b/src/docs/sphinx/blueprint_o2mrelation.rst
@@ -54,7 +54,7 @@ To conform to the **o2mrelation** protocol, a *Node* must have the following cha
  * Be of an *Object* type (*List* types are not allowed)
  * Contain at least one child that is a numeric leaf
 
-The numeric leaf/leaves of the *Node* must not be under any of the following paths, which all have special meanings and particular requirements when specified as part of an **o2mrelation**:
+The numeric leaf/leaves of the *Node* must not be under any of the following "meta component" paths, which all have special meanings and particular requirements when specified as part of an **o2mrelation**:
 
  * ``sizes``: An integer leaf that specifies the number "many" items associated with each "one" in the relationship.
  * ``offsets``: An integer leaf that denotes the start index of the "many" sequence for each "one" in the relationship.
@@ -63,18 +63,18 @@ The numeric leaf/leaves of the *Node* must not be under any of the following pat
 All of the above paths are optional and will resolve to simple defaults if left unspecified. These defaults are outlined below:
 
  * ``sizes``: An array of ones (i.e. ``[1, 1, 1, ...]``) to indicate that the values have one-to-one correspondance.
- * ``offsets``: An array of monotonitcally increasing index values (i.e. ``[0, 1, 2, ...]``) to indicate that the values are compacted.
- * ``indices``: An array of monotonitcally increasing index values (i.e. ``[0, 1, 2, ...]``) to indicate that the values are ordered sequentially.
+ * ``offsets``: An array of monotonically increasing index values (i.e. ``[0, 1, 2, ...]``) to indicate that the values are compacted.
+ * ``indices``: An array of monotonically increasing index values (i.e. ``[0, 1, 2, ...]``) to indicate that the values are ordered sequentially.
 
 Taken in sum, the consituents of the **o2mrelation** schema describe how data (contained in numeric leaves and indexed through ``indices``) maps in grouped clusters (defined by ``sizes`` and ``offsets``) from a source space (the "one" space) to a destination space (the "many" space).
 
 .. note::
-   While the ``sizes``, ``offsets``, and ``indices`` meta-components of the **o2mrelation** definition are
+   While the ``sizes``, ``offsets``, and ``indices`` meta components of the **o2mrelation** definition are
    independently defined, they interplay in ways that aren't immediately obvious. The most commonly missed
    of these "gotcha" behaviors are defined below:
 
    * Every **o2mrelation** must define both or neither of ``sizes`` and ``offsets``.
-   * If none of the meta-component paths are specified, their defaults set the **o2mrelation** to be a compacted, one-to-one relationship.
+   * If none of the meta component paths are specified, their defaults set the **o2mrelation** to be a compacted, one-to-one relationship.
    * The ``sizes`` and ``offsets`` values always refer to entries in ``indices``. If ``indices`` isn't present, it defaults to a "pass through" index, so in this case ``sizes`` and ``offsets`` can be thought of as indexing directly into the numeric leaves.
 
 Properties, Queries, and Transforms
@@ -82,9 +82,9 @@ Properties, Queries, and Transforms
 
  * **conduit::blueprint::o2mrelation::query_paths(const Node &o2mrelation, Node &res)**
 
-     Fills in the ``res`` node with detected value paths found in ``o2mrelation``.
+     Makes the ``res`` node an object with keys being the detected value paths found in ``o2mrelation`` and values being empty nodes.
 
-     * Example: {values: [int64], sizes: [int64], offsets: [int32], meta: [char8]} => [values]
+     * Example: {values: [int64], sizes: [int64], offsets: [int32], other: [char8]} => {values: (empty)}
 
  * **conduit::blueprint::o2mrelation::to_compact(Node &o2mrelation)**
 
@@ -117,7 +117,7 @@ This function's arguments have the following precise meanings:
    * ``"default"``: The default value for index indirection will be supplied in the output.
    * ``"reversed"``: The index indirection will be specified such that the data is reversed relative to its default order.
 
-The ``nmany`` and ``noffset`` parameters can both be set to zero to omit the ``sizes`` and ``offsets`` meta-components from the output.
+The ``nmany`` and ``noffset`` parameters can both be set to zero to omit the ``sizes`` and ``offsets`` meta components from the output.
 Similarly, the ``index_type`` parameter can be omitted or set to ``"unspecified"`` in order to remove the ``indices`` section from the output.
 
 For more details, see the unit tests that exercise these examples in ``src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp``.

--- a/src/docs/sphinx/blueprint_o2mrelation.rst
+++ b/src/docs/sphinx/blueprint_o2mrelation.rst
@@ -1,0 +1,123 @@
+.. ############################################################################
+.. # Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+.. # 
+.. # Produced at the Lawrence Livermore National Laboratory
+.. # 
+.. # LLNL-CODE-666778
+.. # 
+.. # All rights reserved.
+.. # 
+.. # This file is part of Conduit. 
+.. # 
+.. # For details, see: http://software.llnl.gov/conduit/.
+.. # 
+.. # Please also read conduit/LICENSE
+.. # 
+.. # Redistribution and use in source and binary forms, with or without 
+.. # modification, are permitted provided that the following conditions are met:
+.. # 
+.. # * Redistributions of source code must retain the above copyright notice, 
+.. #   this list of conditions and the disclaimer below.
+.. # 
+.. # * Redistributions in binary form must reproduce the above copyright notice,
+.. #   this list of conditions and the disclaimer (as noted below) in the
+.. #   documentation and/or other materials provided with the distribution.
+.. # 
+.. # * Neither the name of the LLNS/LLNL nor the names of its contributors may
+.. #   be used to endorse or promote products derived from this software without
+.. #   specific prior written permission.
+.. # 
+.. # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.. # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.. # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.. # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+.. # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+.. # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+.. # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.. # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.. # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+.. # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+.. # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+.. # POSSIBILITY OF SUCH DAMAGE.
+.. # 
+.. ############################################################################
+
+=====================
+O2MRelation Blueprint
+=====================
+
+Protocol
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To conform to the **o2mrelation** protocol, a *Node* must have the following characteristics:
+
+ * Be of an *Object* type (*List* types are not allowed)
+ * Contain at least one child that is a numeric leaf
+
+The numeric leaf/leaves of the *Node* must not be under any of the following paths, which all have special meanings and particular requirements when specified as part of an **o2mrelation**:
+
+ * ``sizes``: An integer leaf that specifies the number "many" items associated with each "one" in the relationship.
+ * ``offsets``: An integer leaf that denotes the start index of the "many" sequence for each "one" in the relationship.
+ * ``indices``: An integer leaf that indicates the index values of items in the values array(s).
+
+All of the above paths are optional and will resolve to simple defaults if left unspecified. These defaults are outlined below:
+
+ * ``sizes``: An array of ones (i.e. ``[1, 1, 1, ...]``) to indicate that the values have one-to-one correspondance.
+ * ``offsets``: An array of monotonitcally increasing index values (i.e. ``[0, 1, 2, ...]``) to indicate that the values are compacted.
+ * ``indices``: An array of monotonitcally increasing index values (i.e. ``[0, 1, 2, ...]``) to indicate that the values are ordered sequentially.
+
+Taken in sum, the consituents of the **o2mrelation** schema describe how data (contained in numeric leaves and indexed through ``indices``) maps in grouped clusters (defined by ``sizes`` and ``offsets``) from a source space (the "one" space) to a destination space (the "many" space).
+
+.. note::
+   While the ``sizes``, ``offsets``, and ``indices`` meta-components of the **o2mrelation** definition are
+   independently defined, they interplay in ways that aren't immediately obvious. The most commonly missed
+   of these "gotcha" behaviors are defined below:
+
+   * Every **o2mrelation** must define both or neither of ``sizes`` and ``offsets``.
+   * If none of the meta-component paths are specified, their defaults set the **o2mrelation** to be a compacted, one-to-one relationship.
+   * The ``sizes`` and ``offsets`` values always refer to entries in ``indices``. If ``indices`` isn't present, it defaults to a "pass through" index, so in this case ``sizes`` and ``offsets`` can be thought of as indexing directly into the numeric leaves.
+
+Properties, Queries, and Transforms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ * **conduit::blueprint::o2mrelation::query_paths(const Node &o2mrelation, Node &res)**
+
+     Fills in the ``res`` node with detected value paths found in ``o2mrelation``.
+
+     * Example: {values: [int64], sizes: [int64], offsets: [int32], meta: [char8]} => [values]
+
+ * **conduit::blueprint::o2mrelation::to_compact(Node &o2mrelation)**
+
+     Updates the contents of the ``offsets`` array so that it refers to a compacted sequence of relationships.
+
+     * Example: sizes: {2, 5, 3, 8} => offsets: {0, 2, 7, 10}
+
+O2MRelation Examples
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The **o2mrelation** blueprint namespace includes a function *uniform()*, which generates example
+hierarchies that cover a range of **o2mrelation** use cases.
+
+.. code:: cpp
+
+    conduit::blueprint::o2mrelation::examples::uniform(conduit::Node &res,
+                                                       conduit::index_t nones,
+                                                       conduit::index_t nmany = 0,
+                                                       conduit::index_t noffset = 0,
+                                                       const std::string &index_type = "unspecified");
+
+This function's arguments have the following precise meanings:
+
+ * ``nones``: The number of "one"s in the one-to-many relationship.
+ * ``nmany``: The number of "many"s associated with each of the "one"s.
+ * ``noffset``: The stride between each "many" sequence (must be at least ``nmany``).
+ * ``index_type``: The style of element indirection, which must be one of the following:
+
+   * ``"unspecified"``: Index indirection will be omitted from the output.
+   * ``"default"``: The default value for index indirection will be supplied in the output.
+   * ``"reversed"``: The index indirection will be specified such that the data is reversed relative to its default order.
+
+The ``nmany`` and ``noffset`` parameters can both be set to zero to omit the ``sizes`` and ``offsets`` meta-components from the output.
+Similarly, the ``index_type`` parameter can be omitted or set to ``"unspecified"`` in order to remove the ``indices`` section from the output.
+
+For more details, see the unit tests that exercise these examples in ``src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp``.

--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -66,6 +66,7 @@ set(blueprint_headers
     conduit_blueprint_mcarray.hpp
     conduit_blueprint_mcarray_examples.hpp
     conduit_blueprint_o2mrelation.hpp
+    conduit_blueprint_o2mrelation_examples.hpp
     conduit_blueprint_zfparray.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/conduit_blueprint_exports.h
 )
@@ -92,6 +93,7 @@ set(blueprint_sources
     conduit_blueprint_mcarray.cpp
     conduit_blueprint_mcarray_examples.cpp
     conduit_blueprint_o2mrelation.cpp
+    conduit_blueprint_o2mrelation_examples.cpp
     conduit_blueprint_zfparray.cpp
     )
 

--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -65,6 +65,7 @@ set(blueprint_headers
     conduit_blueprint_mesh_examples_venn.hpp
     conduit_blueprint_mcarray.hpp
     conduit_blueprint_mcarray_examples.hpp
+    conduit_blueprint_o2mrelation.hpp
     conduit_blueprint_zfparray.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/conduit_blueprint_exports.h
 )
@@ -90,6 +91,7 @@ set(blueprint_sources
     conduit_blueprint_mesh_examples_venn.cpp
     conduit_blueprint_mcarray.cpp
     conduit_blueprint_mcarray_examples.cpp
+    conduit_blueprint_o2mrelation.cpp
     conduit_blueprint_zfparray.cpp
     )
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3908,13 +3908,15 @@ mesh::matset::verify(const Node &matset,
     {
         // TODO(JRC): Maybe add a verifier for 'number' or 'object' at the top
         // here so as to make the validation as explicit as possible.
-
         if(!matset["volume_fractions"].dtype().is_object())
         {
             log::info(info, protocol, "detected uni-buffer matset");
 
             res &= verify_number_field(protocol, matset, info, "volume_fractions");
             res &= verify_integer_field(protocol, matset, info, "material_ids");
+            // TODO(JRC): Add a more in-depth verifier for 'material_map' that
+            // verifies that it's one level deep and that each child child houses
+            // an integer-style array.
             res &= verify_object_field(protocol, matset, info, "material_map");
 
             res &= blueprint::o2mrelation::verify(matset, info);

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation.cpp
@@ -145,11 +145,13 @@ bool verify(const conduit::Node &n,
         if(!(sizes_node != NULL && offsets_node != NULL))
         {
             log::error(info,proto_name,"requires both 'sizes' and 'offsets' specs");
+            res = false;
         }
         else if(sizes_node->dtype().number_of_elements() !=
                 offsets_node->dtype().number_of_elements())
         {
             log::error(info,proto_name,"requires equal length 'sizes' and 'offsets' specs");
+            res = false;
         }
     }
 

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation.cpp
@@ -1,0 +1,265 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_blueprint_o2mrelation.cpp
+///
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// conduit includes
+//-----------------------------------------------------------------------------
+#include "conduit_blueprint_o2mrelation.hpp"
+#include "conduit_log.hpp"
+
+//-----------------------------------------------------------------------------
+// -- standard cpp lib includes -- 
+//-----------------------------------------------------------------------------
+#include <algorithm>
+#include <map>
+#include <set>
+#include <limits>
+
+using namespace conduit;
+// Easier access to the Conduit logging functions
+using namespace conduit::utils;
+
+static const std::string o2m_path_list[] = {"sizes", "offsets", "indices"};
+static const std::vector<std::string> o2m_paths(o2m_path_list,
+    o2m_path_list + sizeof(o2m_path_list) / sizeof(o2m_path_list[0]));
+
+//-----------------------------------------------------------------------------
+// -- begin conduit:: --
+//-----------------------------------------------------------------------------
+namespace conduit
+{
+
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint:: --
+//-----------------------------------------------------------------------------
+namespace blueprint
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+namespace o2mrelation
+{
+
+//-----------------------------------------------------------------------------
+bool
+verify(const std::string &/*protocol*/,
+       const Node &/*n*/,
+       Node &info)
+{
+    // o2mrelation doens't provide any nested protocols
+
+    info.reset();
+    log::validation(info,false);
+    return false;
+}
+
+
+//----------------------------------------------------------------------------
+bool verify(const conduit::Node &n,
+            Node &info)
+{
+    info.reset();
+    bool res = true;
+
+    const std::string proto_name = "o2mrelation";
+
+    if(!n.dtype().is_object())
+    {
+        log::error(info,proto_name,"base node is not an object");
+        res = false;
+    }
+
+    // Verify Correctness of Meta Sections //
+
+    std::set<const conduit::Node*> o2m_nodeset;
+    for(index_t path_idx = 0; path_idx < (index_t)o2m_paths.size(); path_idx++)
+    {
+        const std::string &o2m_path = o2m_paths[path_idx];
+        const conduit::Node *o2m_node = n.fetch_ptr(o2m_path);
+        o2m_nodeset.insert(o2m_node);
+
+        if(o2m_node != NULL && !o2m_node->dtype().is_integer())
+        {
+            std::ostringstream oss;
+            oss << "'" << o2m_path << "' metadata uses non-index type";
+            log::error(info,proto_name,oss.str());
+            res = false;
+        }
+    }
+
+    const conduit::Node *sizes_node = n.fetch_ptr("sizes");
+    const conduit::Node *offsets_node = n.fetch_ptr("offsets");
+    // const conduit::Node *indices_node = n.fetch_ptr("indices");
+
+    if(sizes_node != NULL || offsets_node != NULL)
+    {
+        if(!(sizes_node != NULL && offsets_node != NULL))
+        {
+            log::error(info,proto_name,"requires both 'sizes' and 'offsets' specs");
+        }
+        else if(sizes_node->dtype().number_of_elements() !=
+                offsets_node->dtype().number_of_elements())
+        {
+            log::error(info,proto_name,"requires equal length 'sizes' and 'offsets' specs");
+        }
+    }
+
+    // Verify Correctness of Relation Section(s) //
+
+    std::set<const conduit::Node*> data_nodeset;
+
+    NodeConstIterator niter = n.children();
+    while(niter.has_next())
+    {
+        const Node &nchld = niter.next();
+        const std::string &nchld_name = niter.name();
+        if(o2m_nodeset.find(&nchld) == o2m_nodeset.end())
+        {
+            if(nchld.dtype().is_number())
+            {
+                std::ostringstream oss;
+                oss << "applying relation to path '" << nchld_name << "'";
+                log::info(info,proto_name,oss.str());
+                data_nodeset.insert(&nchld);
+            }
+        }
+    }
+
+    if(data_nodeset.empty())
+    {
+        log::error(info,proto_name,"need at least one relation data array");
+        res = false;
+    }
+
+    // NOTE(JRC): Assuming that values in a relation are unique for a one-to-one
+    // pair (i.e. no two sources share a target value by having duplicates in the
+    // 'indices' array), then checks can be added here to assert that each relation
+    // is at least as large as the s/o/i arrays.
+
+    log::validation(info,res);
+
+    return res;
+}
+
+
+//----------------------------------------------------------------------------
+std::vector<const conduit::Node*>
+find(const conduit::Node &n, Node &info)
+{
+    std::vector<const conduit::Node*> o2m_roots;
+
+    const std::string proto_name = "o2mrelation";
+
+    std::vector<const conduit::Node*> node_bag( 1, &n );
+    while(!node_bag.empty())
+    {
+        const conduit::Node *curr_node = node_bag.back();
+        node_bag.pop_back();
+
+        if(curr_node->dtype().is_object())
+        {
+            bool is_o2m_candidate = false;
+            for(index_t path_idx = 0; path_idx < (index_t)o2m_paths.size(); path_idx++)
+            {
+                const std::string &o2m_path = o2m_paths[path_idx];
+                const conduit::Node *o2m_node = curr_node->fetch_ptr(o2m_path);
+                is_o2m_candidate |= o2m_node != NULL &&
+                   !o2m_node->dtype().is_object() &&
+                   !o2m_node->dtype().is_list();
+            }
+
+            if(is_o2m_candidate)
+            {
+                std::ostringstream oss;
+                oss << "found viable relation at path '" << curr_node->path() << "'";
+                log::info(info,proto_name,oss.str());
+                o2m_roots.push_back(curr_node);
+            }
+            else
+            {
+                NodeConstIterator child_it = curr_node->children();
+                while(child_it.has_next())
+                {
+                    node_bag.push_back(&child_it.next());
+                }
+            }
+        }
+        else if(curr_node->dtype().is_list())
+        {
+            NodeConstIterator child_it = curr_node->children();
+            while(child_it.has_next())
+            {
+                node_bag.push_back(&child_it.next());
+            }
+        }
+    }
+
+    return o2m_roots;
+}
+
+//-----------------------------------------------------------------------------
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint:: --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit:: --
+//-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation.hpp
@@ -89,8 +89,18 @@ bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,
                                   const conduit::Node &n,
                                   conduit::Node &info);
 
-std::vector<const conduit::Node*> CONDUIT_BLUEPRINT_API
-find(const conduit::Node &n, conduit::Node &info);
+//-----------------------------------------------------------------------------
+/// o2mrelation blueprint property/query/transform methods
+///
+/// These methods can be called on any verified o2mrelation
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+void CONDUIT_BLUEPRINT_API query_paths(const conduit::Node &o2mrelation,
+                                        conduit::Node &res);
+
+//-----------------------------------------------------------------------------
+void CONDUIT_BLUEPRINT_API to_compact(conduit::Node &o2mrelation);
 
 //-----------------------------------------------------------------------------
 }

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation.hpp
@@ -1,0 +1,117 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_blueprint_o2mrelation.hpp
+///
+//-----------------------------------------------------------------------------
+
+#ifndef CONDUIT_BLUEPRINT_O2M_HPP
+#define CONDUIT_BLUEPRINT_O2M_HPP
+
+//-----------------------------------------------------------------------------
+// conduit lib includes
+//-----------------------------------------------------------------------------
+#include "conduit.hpp"
+#include "conduit_blueprint_exports.h"
+
+
+//-----------------------------------------------------------------------------
+// -- begin conduit:: --
+//-----------------------------------------------------------------------------
+namespace conduit
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint --
+//-----------------------------------------------------------------------------
+namespace blueprint
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+namespace o2mrelation
+{
+
+//-----------------------------------------------------------------------------
+// blueprint protocol interface
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+bool CONDUIT_BLUEPRINT_API verify(const conduit::Node &n,
+                                  conduit::Node &info);
+
+//-----------------------------------------------------------------------------
+bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,
+                                  const conduit::Node &n,
+                                  conduit::Node &info);
+
+std::vector<const conduit::Node*> CONDUIT_BLUEPRINT_API
+find(const conduit::Node &n, conduit::Node &info);
+
+//-----------------------------------------------------------------------------
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit:: --
+//-----------------------------------------------------------------------------
+
+
+#endif 
+
+
+

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.cpp
@@ -1,75 +1,64 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 // Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
-//
+// 
 // Produced at the Lawrence Livermore National Laboratory
-//
+// 
 // LLNL-CODE-666778
-//
+// 
 // All rights reserved.
-//
-// This file is part of Conduit.
-//
+// 
+// This file is part of Conduit. 
+// 
 // For details, see: http://software.llnl.gov/conduit/.
-//
+// 
 // Please also read conduit/LICENSE
-//
-// Redistribution and use in source and binary forms, with or without
+// 
+// Redistribution and use in source and binary forms, with or without 
 // modification, are permitted provided that the following conditions are met:
-//
-// * Redistributions of source code must retain the above copyright notice,
+// 
+// * Redistributions of source code must retain the above copyright notice, 
 //   this list of conditions and the disclaimer below.
-//
+// 
 // * Redistributions in binary form must reproduce the above copyright notice,
 //   this list of conditions and the disclaimer (as noted below) in the
 //   documentation and/or other materials provided with the distribution.
-//
+// 
 // * Neither the name of the LLNS/LLNL nor the names of its contributors may
 //   be used to endorse or promote products derived from this software without
 //   specific prior written permission.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 // LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
 // DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 // OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 // POSSIBILITY OF SUCH DAMAGE.
-//
+// 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 //-----------------------------------------------------------------------------
 ///
-/// file: conduit_blueprint.hpp
+/// file: conduit_blueprint_o2mrelation_examples.cpp
 ///
 //-----------------------------------------------------------------------------
 
-#ifndef CONDUIT_BLUEPRINT_HPP
-#define CONDUIT_BLUEPRINT_HPP
+//-----------------------------------------------------------------------------
+// std lib includes
+//-----------------------------------------------------------------------------
+#include <string.h>
+#include <math.h>
 
 //-----------------------------------------------------------------------------
-// conduit lib includes
+// conduit includes
 //-----------------------------------------------------------------------------
-#include "conduit.hpp"
-
-#include "conduit_blueprint_exports.h"
-
-#include "conduit_blueprint_mesh.hpp"
-#include "conduit_blueprint_mesh_examples.hpp"
-#include "conduit_blueprint_mesh_examples_julia.hpp"
-#include "conduit_blueprint_mesh_examples_venn.hpp"
-
-#include "conduit_blueprint_o2mrelation.hpp"
 #include "conduit_blueprint_o2mrelation_examples.hpp"
 
-#include "conduit_blueprint_mcarray.hpp"
-#include "conduit_blueprint_mcarray_examples.hpp"
-
-#include "conduit_blueprint_zfparray.hpp"
 
 //-----------------------------------------------------------------------------
 // -- begin conduit:: --
@@ -78,34 +67,53 @@ namespace conduit
 {
 
 //-----------------------------------------------------------------------------
-// -- begin conduit::blueprint --
+// -- begin conduit::blueprint:: --
 //-----------------------------------------------------------------------------
 namespace blueprint
 {
 
 //-----------------------------------------------------------------------------
-/// The about methods construct human readable info about how blueprint was
-/// configured.
-//-----------------------------------------------------------------------------
-std::string CONDUIT_BLUEPRINT_API about();
-void        CONDUIT_BLUEPRINT_API about(conduit::Node &n);
-
-//-----------------------------------------------------------------------------
-/// blueprint verify interface
+// -- begin blueprint::o2mrelation --
 //-----------------------------------------------------------------------------
 
+namespace o2mrelation
+{
+
 //-----------------------------------------------------------------------------
-/// Verify passed node confirms to given blueprint protocol.
-/// Messages related to the verification are be placed in the "info" node.
+// -- begin blueprint::o2mrelation::examples --
 //-----------------------------------------------------------------------------
-bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,
-                                  const conduit::Node &n,
-                                  conduit::Node &info);
+
+namespace examples
+{
+
+//---------------------------------------------------------------------------//
+void
+todo(const std::string &o2mrelation_type,
+     index_t npts, // total number of points
+     Node &res)
+{
+    // TODO(JRC)
+    CONDUIT_ERROR("unknown o2mrelation_type = " << o2mrelation_type);
+}
+
+
 
 //-----------------------------------------------------------------------------
 }
 //-----------------------------------------------------------------------------
-// -- end conduit::blueprint --
+// -- end conduit::blueprint::o2mrelation::examples --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint:: --
 //-----------------------------------------------------------------------------
 
 
@@ -113,9 +121,3 @@ bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,
 //-----------------------------------------------------------------------------
 // -- end conduit:: --
 //-----------------------------------------------------------------------------
-
-
-#endif
-
-
-

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.cpp
@@ -88,12 +88,100 @@ namespace examples
 
 //---------------------------------------------------------------------------//
 void
-todo(const std::string &o2mrelation_type,
-     index_t npts, // total number of points
-     Node &res)
+uniform(Node &res,
+        conduit::index_t nones,
+        conduit::index_t nmany,
+        conduit::index_t noffset,
+        const std::string &index_type)
 {
-    // TODO(JRC)
-    CONDUIT_ERROR("unknown o2mrelation_type = " << o2mrelation_type);
+    res.reset();
+
+    bool use_sizes = true;
+    { // Argument Wrangling for Sizes/Offsets //
+        if(nmany == 0 && noffset != 0)
+        {
+            nmany = 1;
+        }
+        else if(nmany != 0 && noffset == 0)
+        {
+            noffset = nmany;
+        }
+        else if(nmany == 0 && noffset == 0)
+        {
+            nmany = noffset = 1;
+            use_sizes = false;
+        }
+
+        if(noffset < nmany)
+        {
+            CONDUIT_ERROR("cannot construct one-to-many w/ noffset < many size");
+        }
+    }
+
+    bool use_indices = true;
+    bool rev_indices = false;
+    { // Argument Wrangling for Indices //
+        if(index_type == "unspecified")
+        {
+            use_indices = false;
+        }
+        else if(index_type == "default")
+        {
+            rev_indices = false;
+        }
+        else if(index_type == "reversed")
+        {
+            rev_indices = true;
+        }
+        else
+        {
+            CONDUIT_ERROR("unknown index_type = " << index_type);
+        }
+    }
+
+    const index_t total_data_count = noffset * nones;
+    const index_t valid_data_count = nmany * nones;
+
+    res["data"].set(DataType::float32(total_data_count));
+    float32_array res_data = res["data"].value();
+    res["indices"].set(DataType::uint32(valid_data_count));
+    uint32_array res_indices = res["indices"].value();
+
+    for(index_t datum_idx = 0; datum_idx < total_data_count; datum_idx++)
+    {
+        res_data[datum_idx] = -1.0f;
+    }
+    for(index_t one_idx = 0, datum_idx = 0; one_idx < nones; one_idx++)
+    {
+        for(index_t many_idx = 0; many_idx < nmany; many_idx++, datum_idx++)
+        {
+            res_data[one_idx * noffset + many_idx] = datum_idx + 1.0f;
+            res_indices[datum_idx] = many_idx + noffset *
+                ( !rev_indices ? one_idx : nones - one_idx - 1 );
+        }
+    }
+
+    if(!use_indices)
+    {
+        res.remove("indices");
+    }
+
+    if(use_sizes)
+    {
+        res["sizes"].set(DataType::uint32(nones));
+        uint32_array res_sizes = res["sizes"].value();
+        for(index_t one_idx = 0; one_idx < nones; one_idx++)
+        {
+            res_sizes[one_idx] = nmany;
+        }
+
+        res["offsets"].set(DataType::uint32(nones));
+        uint32_array res_offsets = res["offsets"].value();
+        for(index_t one_idx = 0; one_idx < nones; one_idx++)
+        {
+            res_offsets[one_idx] = use_indices ? one_idx * nmany : one_idx * noffset;
+        }
+    }
 }
 
 

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.hpp
@@ -83,16 +83,17 @@ namespace o2mrelation
 namespace examples
 {
     //-------------------------------------------------------------------------
-    /// creates o2mrelation with num pts * 3 components. 
-    /// with the following layout options (passed via o2mrelation_type)
-    ///  interleaved
-    ///  separate
-    ///  contiguous
-    ///  interleaved_mixed
+    /// creates a one-to-many relation with a given uniform relationship size,
+    /// a given uniform offset, and an index specification, which can be one of:
+    ///  unspecified
+    ///  default
+    ///  reversed
     //-------------------------------------------------------------------------
-    void CONDUIT_BLUEPRINT_API todo(const std::string &o2mrelation_type,
-                                   conduit::index_t npts, // total # of points
-                                   conduit::Node &res);
+    void CONDUIT_BLUEPRINT_API uniform(conduit::Node &res,
+                                       conduit::index_t nones,
+                                       conduit::index_t nmany = 0,
+                                       conduit::index_t noffset = 0,
+                                       const std::string &index_type = "unspecified");
 
 //-----------------------------------------------------------------------------
 }

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_examples.hpp
@@ -1,75 +1,62 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 // Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
-//
+// 
 // Produced at the Lawrence Livermore National Laboratory
-//
+// 
 // LLNL-CODE-666778
-//
+// 
 // All rights reserved.
-//
-// This file is part of Conduit.
-//
+// 
+// This file is part of Conduit. 
+// 
 // For details, see: http://software.llnl.gov/conduit/.
-//
+// 
 // Please also read conduit/LICENSE
-//
-// Redistribution and use in source and binary forms, with or without
+// 
+// Redistribution and use in source and binary forms, with or without 
 // modification, are permitted provided that the following conditions are met:
-//
-// * Redistributions of source code must retain the above copyright notice,
+// 
+// * Redistributions of source code must retain the above copyright notice, 
 //   this list of conditions and the disclaimer below.
-//
+// 
 // * Redistributions in binary form must reproduce the above copyright notice,
 //   this list of conditions and the disclaimer (as noted below) in the
 //   documentation and/or other materials provided with the distribution.
-//
+// 
 // * Neither the name of the LLNS/LLNL nor the names of its contributors may
 //   be used to endorse or promote products derived from this software without
 //   specific prior written permission.
-//
+// 
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 // ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
 // LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
 // DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
 // OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 // POSSIBILITY OF SUCH DAMAGE.
-//
+// 
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 //-----------------------------------------------------------------------------
 ///
-/// file: conduit_blueprint.hpp
+/// file: conduit_blueprint_o2mrelation_examples.hpp
 ///
 //-----------------------------------------------------------------------------
 
-#ifndef CONDUIT_BLUEPRINT_HPP
-#define CONDUIT_BLUEPRINT_HPP
+#ifndef CONDUIT_BLUEPRINT_O2MRELATION_EXAMPLES_HPP
+#define CONDUIT_BLUEPRINT_O2MRELATION_EXAMPLES_HPP
 
 //-----------------------------------------------------------------------------
 // conduit lib includes
 //-----------------------------------------------------------------------------
 #include "conduit.hpp"
-
 #include "conduit_blueprint_exports.h"
 
-#include "conduit_blueprint_mesh.hpp"
-#include "conduit_blueprint_mesh_examples.hpp"
-#include "conduit_blueprint_mesh_examples_julia.hpp"
-#include "conduit_blueprint_mesh_examples_venn.hpp"
-
-#include "conduit_blueprint_o2mrelation.hpp"
-#include "conduit_blueprint_o2mrelation_examples.hpp"
-
-#include "conduit_blueprint_mcarray.hpp"
-#include "conduit_blueprint_mcarray_examples.hpp"
-
-#include "conduit_blueprint_zfparray.hpp"
 
 //-----------------------------------------------------------------------------
 // -- begin conduit:: --
@@ -84,38 +71,55 @@ namespace blueprint
 {
 
 //-----------------------------------------------------------------------------
-/// The about methods construct human readable info about how blueprint was
-/// configured.
-//-----------------------------------------------------------------------------
-std::string CONDUIT_BLUEPRINT_API about();
-void        CONDUIT_BLUEPRINT_API about(conduit::Node &n);
-
-//-----------------------------------------------------------------------------
-/// blueprint verify interface
+// -- begin conduit::blueprint::o2mrelation --
 //-----------------------------------------------------------------------------
 
+namespace o2mrelation
+{
+
 //-----------------------------------------------------------------------------
-/// Verify passed node confirms to given blueprint protocol.
-/// Messages related to the verification are be placed in the "info" node.
+/// Methods that generate example multi-component arrays.
 //-----------------------------------------------------------------------------
-bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,
-                                  const conduit::Node &n,
-                                  conduit::Node &info);
+namespace examples
+{
+    //-------------------------------------------------------------------------
+    /// creates o2mrelation with num pts * 3 components. 
+    /// with the following layout options (passed via o2mrelation_type)
+    ///  interleaved
+    ///  separate
+    ///  contiguous
+    ///  interleaved_mixed
+    //-------------------------------------------------------------------------
+    void CONDUIT_BLUEPRINT_API todo(const std::string &o2mrelation_type,
+                                   conduit::index_t npts, // total # of points
+                                   conduit::Node &res);
 
 //-----------------------------------------------------------------------------
 }
 //-----------------------------------------------------------------------------
-// -- end conduit::blueprint --
+// -- end conduit::blueprint::mesh::examples --
 //-----------------------------------------------------------------------------
 
 
 }
 //-----------------------------------------------------------------------------
-// -- end conduit:: --
+// -- end conduit::blueprint::o2mrelation --
 //-----------------------------------------------------------------------------
 
 
-#endif
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint:: --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit --
+//-----------------------------------------------------------------------------
+
+
+#endif 
 
 
 

--- a/src/tests/blueprint/CMakeLists.txt
+++ b/src/tests/blueprint/CMakeLists.txt
@@ -50,12 +50,14 @@
 # blueprint lib Unit Tests
 ################################
 set(BLUEPRINT_TESTS t_blueprint_smoke
+                    t_blueprint_mcarray_verify
+                    t_blueprint_mcarray_examples
+                    t_blueprint_o2mrelation_verify
+                    t_blueprint_o2mrelation_examples
                     t_blueprint_mesh_verify
                     t_blueprint_mesh_transform
                     t_blueprint_mesh_generate
-                    t_blueprint_mcarray_verify
-                    t_blueprint_mesh_examples
-                    t_blueprint_mcarray_examples)
+                    t_blueprint_mesh_examples)
 
 
 ################################

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -929,7 +929,55 @@ TEST(conduit_blueprint_mesh_verify, matset_general)
             n["volume_fractions"]["m2"].set(DataType::float64(5));
             CHECK_MESH(verify_matset,n,info,true);
 
-            n["volume_fractions"].reset();
+            { // Uni-Buffer Tests //
+                n.reset();
+                n["topology"].set("mesh");
+
+                n["volume_fractions"].set(DataType::float64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+
+                n["material_ids"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,false);
+                n.remove("material_ids");
+                n["material_map"]["m1"].set(1);
+                CHECK_MESH(verify_matset,n,info,false);
+                n["material_ids"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,true);
+
+                n["indices"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,true);
+                n["sizes"].set(DataType::uint32(5));
+                n["offsets"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,true);
+            }
+
+            { // Multi-Buffer Tests //
+                n.reset();
+                n["topology"].set("mesh");
+
+                n["volume_fractions"]["m1"]["values"].set(DataType::float64(8));
+                n["volume_fractions"]["m1"]["indices"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,true);
+
+                n["volume_fractions"]["m2"]["indices"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["volume_fractions"]["m2"]["values"].set(DataType::float64(10));
+                CHECK_MESH(verify_matset,n,info,true);
+
+                n["volume_fractions"]["m3"]["sizes"].set(DataType::uint32(3));
+                n["volume_fractions"]["m3"]["values"].set(DataType::float64(30));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["volume_fractions"]["m3"]["offsets"].set(DataType::uint32(3));
+                CHECK_MESH(verify_matset,n,info,true);
+
+                n["volume_fractions"]["m4"]["test"]["values"].set(DataType::uint32(3));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["volume_fractions"]["m4"]["indices"].set(DataType::uint32(5));
+                CHECK_MESH(verify_matset,n,info,false);
+            }
+
+            n.reset();
+            n["topology"].set("mesh");
             n["volume_fractions"].set(vfs);
             CHECK_MESH(verify_matset,n,info,true);
         }

--- a/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
@@ -60,6 +60,30 @@ using namespace conduit;
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_o2mrelation_examples, o2mrelation_verify)
 {
-    // TODO(JRC)
-    EXPECT_TRUE(false);
+    Node n, info;
+
+    n.reset();
+    blueprint::o2mrelation::examples::uniform(n, 10);
+    std::cout << n.to_yaml_default() << std::endl;
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    blueprint::o2mrelation::examples::uniform(n, 5, 2);
+    std::cout << n.to_yaml_default() << std::endl;
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    blueprint::o2mrelation::examples::uniform(n, 5, 2, 4);
+    std::cout << n.to_yaml_default() << std::endl;
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    blueprint::o2mrelation::examples::uniform(n, 5, 0, 0, "reversed");
+    std::cout << n.to_yaml_default() << std::endl;
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    blueprint::o2mrelation::examples::uniform(n, 5, 3, 4, "default");
+    std::cout << n.to_yaml_default() << std::endl;
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
 }

--- a/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
@@ -1,0 +1,65 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see https://lc.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_blueprint_o2mrelation_examples.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+#include "conduit_blueprint.hpp"
+#include "conduit_relay.hpp"
+
+#include <iostream>
+#include "gtest/gtest.h"
+
+using namespace conduit;
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_examples, o2mrelation_verify)
+{
+    // TODO(JRC)
+    EXPECT_TRUE(false);
+}

--- a/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
@@ -64,26 +64,75 @@ TEST(conduit_blueprint_o2mrelation_examples, o2mrelation_verify)
 
     n.reset();
     blueprint::o2mrelation::examples::uniform(n, 10);
-    std::cout << n.to_yaml_default() << std::endl;
+    std::cout << n.to_yaml() << std::endl;
     EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
 
     n.reset();
     blueprint::o2mrelation::examples::uniform(n, 5, 2);
-    std::cout << n.to_yaml_default() << std::endl;
+    std::cout << n.to_yaml() << std::endl;
     EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
 
     n.reset();
     blueprint::o2mrelation::examples::uniform(n, 5, 2, 4);
-    std::cout << n.to_yaml_default() << std::endl;
+    std::cout << n.to_yaml() << std::endl;
     EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
 
     n.reset();
     blueprint::o2mrelation::examples::uniform(n, 5, 0, 0, "reversed");
-    std::cout << n.to_yaml_default() << std::endl;
+    std::cout << n.to_yaml() << std::endl;
     EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
 
     n.reset();
     blueprint::o2mrelation::examples::uniform(n, 5, 3, 4, "default");
-    std::cout << n.to_yaml_default() << std::endl;
+    std::cout << n.to_yaml() << std::endl;
     EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_examples, o2mrelation_query_paths)
+{
+    Node n, res;
+
+    Node baseline, info;
+    baseline["data"].set(conduit::DataType::float32(20));
+    baseline["sizes"].set(conduit::DataType::int32(4));
+    baseline["offsets"].set(conduit::DataType::int32(4));
+    baseline["indices"].set(conduit::DataType::int32(16));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(baseline,info));
+
+    n.set(baseline);
+    blueprint::o2mrelation::query_paths(n, res);
+    EXPECT_TRUE(res.dtype().is_object());
+    EXPECT_EQ(res.child_names(), std::vector<std::string>({"data"}));
+
+    n.set(baseline);
+    n["more_data"].set(n["data"]);
+    n["not_data_str"].set("string");
+    n["not_data_obj"]["nv1"].set(n["data"]);
+    n["not_data_obj"]["nv2"].set(n["data"]);
+    blueprint::o2mrelation::query_paths(n, res);
+    EXPECT_TRUE(res.dtype().is_object());
+    EXPECT_EQ(res.child_names(), std::vector<std::string>({"data", "more_data"}));
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_examples, o2mrelation_to_compact)
+{
+    Node n, ref, info;
+
+    blueprint::o2mrelation::examples::uniform(ref, 5, 3, 3);
+    n.set(ref);
+    blueprint::o2mrelation::to_compact(n);
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+    EXPECT_FALSE(ref.diff(n, info));
+
+    blueprint::o2mrelation::examples::uniform(ref, 5, 3, 4);
+    n.set(ref);
+    blueprint::o2mrelation::to_compact(n);
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+    EXPECT_TRUE(ref.diff(n, info));
+
+    blueprint::o2mrelation::examples::uniform(ref, 5, 3, 3);
+    EXPECT_FALSE(ref["sizes"].diff(n["sizes"], info));
+    EXPECT_FALSE(ref["offsets"].diff(n["offsets"], info));
 }

--- a/src/tests/blueprint/t_blueprint_o2mrelation_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_o2mrelation_verify.cpp
@@ -1,0 +1,158 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see https://lc.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_blueprint_o2mrelation_verify.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+#include "conduit_blueprint.hpp"
+#include "conduit_relay.hpp"
+
+#include <iostream>
+#include "gtest/gtest.h"
+
+using namespace conduit;
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_verify, o2mrelation_basic)
+{
+    Node n, info;
+
+    n["a"].set(DataType::float64(20));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n["b"].set(DataType::float64(20));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n["indices"].set(DataType::int32(20));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n["sizes"].set(DataType::int32(5));
+    n["offsets"].set(DataType::int32(5));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n.remove("indices");
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_verify, o2mrelation_structure)
+{
+    Node n, info;
+
+    n["a"].set(DataType::float64(20));
+    n["sizes"].set(DataType::int32(5));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+
+    n.remove("sizes");
+    n["offsets"].set(DataType::int32(5));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+
+    n["sizes"].set(DataType::int32(n["offsets"].dtype().number_of_elements() - 1));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+    n["sizes"].set(DataType::int32(n["offsets"].dtype().number_of_elements() + 1));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+    n["sizes"].set(DataType::int64(n["offsets"].dtype().number_of_elements()));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    n.remove("a");
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+    n["a"].set(DataType::char8_str(20));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+    n["a"].set(DataType::float64(20));
+    n["b"].set(DataType::char8_str(20));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_verify, o2mrelation_type)
+{
+    Node n, info;
+
+    n.reset();
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    n.set(DataType::float64(20));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    n.append().set(DataType::float64(20));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    n["a"].set(DataType::char8_str(20));
+    EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+
+    n.reset();
+    n["a"].set(DataType::float32(20));
+    n["sizes"].set(DataType::int32(20));
+    n["offsets"].set(DataType::int32(20));
+    n["indices"].set(DataType::int32(20));
+    EXPECT_TRUE(blueprint::o2mrelation::verify(n,info));
+
+    const std::string o2m_comps[] = {"sizes", "offsets", "indices"};
+    const index_t o2m_comps_count = sizeof(o2m_comps) / sizeof(o2m_comps[0]);
+    for(index_t comp_idx = 0; comp_idx < o2m_comps_count; comp_idx++)
+    {
+        const std::string &o2m_comp = o2m_comps[comp_idx];
+        Node temp = n[o2m_comp];
+        n[o2m_comp].set(DataType::float32(20));
+        EXPECT_FALSE(blueprint::o2mrelation::verify(n,info));
+        n[o2m_comp] = temp;
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_o2mrelation_verify, o2mrelation_verify_with_protocol)
+{
+    Node n, info;
+
+    EXPECT_FALSE(blueprint::o2mrelation::verify("protocol",n,info));
+    EXPECT_FALSE(blueprint::o2mrelation::verify("o2mrelation",n,info));
+}


### PR DESCRIPTION
The changes in this pull request address #511 and #513 by:

- [x] Adding the `conduit::blueprint::o2mrelation` namespace with a suite of one-to-many relationship verification/manipulation methods.
- [x] Updating the `conduit::blueprint::mesh::matset::verify` function to support uni-buffer volumes.
- [x] Updating the `conduit::blueprint::mesh::matset::verify` function to enable one-to-many indexing for both the uni-buffer and multi-buffer cases.
- [x] Adding test cases for the new `conduit::blueprint::o2mrelation` functions.
- [x] Adding examples to `conduit::blueprint::o2mrelation::examples` (a la `conduit::blueprint::mcarray::examples`).
- [x] Adding test cases for the new `conduit::blueprint::o2mrelation::examples` functions.
- [x] Adding test cases for the `conduit::blueprint::mesh::matset::verify` function in the uni-buffer case.
- [x] Adding test cases for the `conduit::blueprint::mesh::matset::verify` function in the one-to-many indexing case.
- [x] Adding documentation for one-to-many relationships similar to the MCArray documentation.
- [x] Revising the documentation for the `matsets` segment of the Blueprint to properly reflect that it accepts uni-buffer data.
- [x] Revising the documentation for the `matsets` segment of the Blueprint to clearly indicate that `volume_fractions` can be a one-to-many relationship in the multi-buffer case.