### PR TITLE
fix bugs in 'blueprint::mesh::specset::verify'

### DIFF
--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -986,14 +986,35 @@ TEST(conduit_blueprint_mesh_verify, specset_general)
             CHECK_MESH(verify_specset,n,info,false);
 
             n["matset_values"].reset();
+            n["matset_values"]["m1"].append().set(DataType::float64(5));
+            n["matset_values"]["m1"].append().set(DataType::float64(5));
+            CHECK_MESH(verify_specset,n,info,true);
+            n["matset_values"]["m2"].append().set(DataType::float64(5));
+            CHECK_MESH(verify_specset,n,info,true);
+
+            n["matset_values"].reset();
             n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
             n["matset_values"]["m2"]["s1"].set(DataType::float64(5));
             CHECK_MESH(verify_specset,n,info,true);
 
             n["matset_values"].reset();
-            n["matset_values"]["m1"]["s2"].set(DataType::float64(5));
+            n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
             n["matset_values"]["m2"]["s2"].set(DataType::float64(5));
             CHECK_MESH(verify_specset,n,info,true);
+            n["matset_values"]["m2"]["s3"].set(DataType::float64(5));
+            CHECK_MESH(verify_specset,n,info,true);
+
+            n["matset_values"].reset();
+            n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
+            n["matset_values"]["m1"]["s2"].set(DataType::float64(6));
+            CHECK_MESH(verify_specset,n,info,false);
+
+            n["matset_values"].reset();
+            n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
+            n["matset_values"]["m1"]["s2"].set(DataType::float64(5));
+            CHECK_MESH(verify_specset,n,info,true);
+            n["matset_values"]["m2"]["s3"].set(DataType::float64(6));
+            CHECK_MESH(verify_specset,n,info,false);
 
             n["matset_values"].reset();
             n["matset_values"].set(mfs);


### PR DESCRIPTION
The changes in this pull request fix the `blueprint::mesh::specset::verify` function so that it accepts species information in line with what's described in [the Blueprint documentation](https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#species-sets) instead of strictly `mlarray`-style specifications, as was done previously. This fix allows for specifications like the following to be accepted:

```
specset:
  matset: mesh_mats
  matset_values:
    copper:
      cu: [ ... ]
      zn: [ ... ]
    steel:
      fe: [ ... ]
      cr: [ ... ]
      ni: [ ... ]
      mn: [ ... ]
```