### PR TITLE
add material-dominant relationship support to blueprint matsets

### DIFF
--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -531,15 +531,15 @@ The following diagram illustrates a simple **multi-buffer** material set example
 Material Set Indexing Variants
 =================================
 
-Another dimension along which material sets can vary is in how their volume fractions/topological element association is established.
-This dimension produces two additional material set variants: **element-dominant** association (element indices control volume fraction order) and **material-dominant** association (material indices control volume fraction order).
+Material sets can also vary in how volume fractions are associated with topological elements.
+This associative variance leads to two additional schema variants: **element-dominant** (elements/volumes have the same ordering) and **material-dominant** (elements/volumes have independent orderings).
 Both of these variants and their corresponding schemas are outlined in the subsections below.
 
 
 Element-Dominant Material Sets
 *********************************
 
-An **element-dominant** material set is one that orders its volume fraction data so that it matches the topological element ordering.
+In an **element-dominant** material set, the volume fraction data order matches the topological element order.
 In other words, the volume fraction group at ``i`` (e.g. ``matset/volume_fractions/mat[i]``) contains the volume fraction data for topological element ``i``.
 This variant is assumed in all material sets that don't have an ``element_ids`` child.
 
@@ -567,7 +567,7 @@ The following diagram illustrates a simple **element-dominant** material set exa
 Material-Dominant Material Sets
 *********************************
 
-A **material-dominant** material set is one that uses independent material/element orderings and associates these orderings via indirection arrays.
+In a **material-dominant** material set, the orders for the volume fractions and topological elements are mismatched and need to be bridged via indirection arrays.
 For these schemas, the ``element_ids`` field hosts these indirection arrays per material (with just one indirection array for uni-buffer material sets).
 In explicit terms, the **material-dominant** volume fraction group at ``i`` (e.g. ``matset/volume_fractions/mat[i]``) contains the volume fraction data for the indirected topological element ``i`` (e.g. ``matset/element_ids/mat[i]``).
 Complementary to the **element-dominant** variant, the **material-dominant** variant applies to all material sets that have an ``element_ids`` child.

--- a/src/libs/blueprint/conduit_blueprint_mcarray.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mcarray.cpp
@@ -348,14 +348,15 @@ verify(const std::string &/*protocol*/,
 bool verify(const conduit::Node &n,
             Node &info)
 {
-    return mlarray::verify(n, info, 0, std::numeric_limits<index_t>::max());
+    return mlarray::verify(n, info, 0, std::numeric_limits<index_t>::max(), true);
 }
 
 //----------------------------------------------------------------------------
 bool verify(const conduit::Node &n,
             Node &info,
             const index_t min_depth,
-            const index_t max_depth)
+            const index_t max_depth,
+            const bool leaf_uniformity)
 {
     info.reset();
     bool res = true;
@@ -453,7 +454,7 @@ bool verify(const conduit::Node &n,
                 log::error(info,protocol,"node leaves have non-numerical types");
                 res = false;
             }
-            else if(curr_node->dtype().number_of_elements() != depth_elems)
+            else if(leaf_uniformity && curr_node->dtype().number_of_elements() != depth_elems)
             {
                 log::error(info,protocol,"node leaves have element count differences");
                 res = false;

--- a/src/libs/blueprint/conduit_blueprint_mcarray.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mcarray.hpp
@@ -134,7 +134,8 @@ bool CONDUIT_BLUEPRINT_API verify(const conduit::Node &n,
 bool CONDUIT_BLUEPRINT_API verify(const conduit::Node &n,
                                   conduit::Node &info,
                                   const index_t min_depth,
-                                  const index_t max_pepth);
+                                  const index_t max_pepth,
+                                  const bool leaf_uniformity);
 
 //-----------------------------------------------------------------------------
 bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2649,8 +2649,8 @@ mesh::coordset::rectilinear::verify(const Node &coordset,
             const std::string chld_name = itr.name();
             if(!chld.dtype().is_number())
             {
-                log::error(info, protocol, "value child \"" + chld_name + "\" " +
-                                           "is not a number array");
+                log::error(info, protocol, "value child " + log::quote(chld_name) +
+                                           " is not a number array");
                 res = false;
             }
         }
@@ -3179,7 +3179,7 @@ mesh::topology::unstructured::verify(const Node &topo,
         }
         else
         {
-            log::error(info,protocol,"invalid child \"elements\"");
+            log::error(info,protocol,"invalid child 'elements'");
             res = false;
         }
 
@@ -4053,7 +4053,7 @@ mesh::field::verify(const Node &field,
     bool has_basis = field.has_child("basis");
     if(!has_assoc && !has_basis)
     {
-        log::error(info, protocol, "missing child \"association\" or \"basis\"");
+        log::error(info, protocol, "missing child 'association' or 'basis'");
         res = false;
     }
     if(has_assoc)
@@ -4067,17 +4067,41 @@ mesh::field::verify(const Node &field,
 
     bool has_topo = field.has_child("topology");
     bool has_matset = field.has_child("matset");
+    bool has_topo_values = field.has_child("values");
+    bool has_matset_values = field.has_child("matset_values");
     if(!has_topo && !has_matset)
     {
-        log::error(info, protocol, "missing child \"topology\" or \"matset\"");
+        log::error(info, protocol, "missing child 'topology' or 'matset'");
         res = false;
     }
-    if(has_topo)
+
+    if(has_topo ^ has_topo_values)
+    {
+        std::ostringstream oss;
+        oss << "'" << (has_topo ? "topology" : "values") <<"'"
+            << " is present, but its companion "
+            << "'" << (has_topo ? "values" : "topology") << "'"
+            << " is missing";
+        log::error(info, protocol, oss.str());
+        res = false;
+    }
+    else if(has_topo && has_topo_values)
     {
         res &= verify_string_field(protocol, field, info, "topology");
         res &= verify_mlarray_field(protocol, field, info, "values", 0, 1);
     }
-    if(has_matset)
+
+    if(has_matset ^ has_matset_values)
+    {
+        std::ostringstream oss;
+        oss << "'" << (has_matset ? "matset" : "matset_values") <<"'"
+            << " is present, but its companion "
+            << "'" << (has_matset ? "matset_values" : "matset") << "'"
+            << " is missing";
+        log::error(info, protocol, oss.str());
+        res = false;
+    }
+    else if(has_matset && has_matset_values)
     {
         res &= verify_string_field(protocol, field, info, "matset");
         res &= verify_mlarray_field(protocol, field, info, "matset_values", 1, 2);
@@ -4129,7 +4153,7 @@ mesh::field::index::verify(const Node &field_idx,
     bool has_basis = field_idx.has_child("basis");
     if(!has_assoc && !has_basis)
     {
-        log::error(info, protocol, "missing child \"association\" or \"basis\"");
+        log::error(info, protocol, "missing child 'association' or 'basis'");
         res = false;
     }
     if(has_assoc)
@@ -4145,7 +4169,7 @@ mesh::field::index::verify(const Node &field_idx,
     bool has_matset = field_idx.has_child("matset");
     if(!has_topo && !has_matset)
     {
-        log::error(info, protocol, "missing child \"topology\" or \"matset\"");
+        log::error(info, protocol, "missing child 'topology' or 'matset'");
         res = false;
     }
     if(has_topo)

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -567,7 +567,8 @@ bool verify_mlarray_field(const std::string &protocol,
                           conduit::Node &info,
                           const std::string &field_name,
                           const index_t min_depth,
-                          const index_t max_depth)
+                          const index_t max_depth,
+                          const bool leaf_uniformity)
 {
     Node &field_info = info[field_name];
 
@@ -575,7 +576,7 @@ bool verify_mlarray_field(const std::string &protocol,
     if(res)
     {
         const Node &field_node = node[field_name];
-        res = blueprint::mlarray::verify(field_node,field_info,min_depth,max_depth);
+        res = blueprint::mlarray::verify(field_node,field_info,min_depth,max_depth,leaf_uniformity);
         if(res)
         {
             log::info(info, protocol, log::quote(field_name) + "is an mlarray");
@@ -4088,7 +4089,7 @@ mesh::field::verify(const Node &field,
     else if(has_topo && has_topo_values)
     {
         res &= verify_string_field(protocol, field, info, "topology");
-        res &= verify_mlarray_field(protocol, field, info, "values", 0, 1);
+        res &= verify_mlarray_field(protocol, field, info, "values", 0, 1, false);
     }
 
     if(has_matset ^ has_matset_values)
@@ -4104,7 +4105,7 @@ mesh::field::verify(const Node &field,
     else if(has_matset && has_matset_values)
     {
         res &= verify_string_field(protocol, field, info, "matset");
-        res &= verify_mlarray_field(protocol, field, info, "matset_values", 1, 2);
+        res &= verify_mlarray_field(protocol, field, info, "matset_values", 1, 2, false);
     }
 
     // TODO(JRC): Enable 'volume_dependent' once it's confirmed to be a required

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3917,13 +3917,14 @@ mesh::matset::verify(const Node &matset,
         {
             log::info(info, protocol, "detected uni-buffer matset");
 
-            res &= verify_integer_field(protocol, matset, info, "material_ids");
+            vfs_res &= verify_integer_field(protocol, matset, info, "material_ids");
             // TODO(JRC): Add a more in-depth verifier for 'material_map' that
             // verifies that it's one level deep and that each child child houses
             // an integer-style array.
-            res &= verify_object_field(protocol, matset, info, "material_map");
+            vfs_res &= verify_object_field(protocol, matset, info, "material_map");
+            vfs_res &= blueprint::o2mrelation::verify(matset, info);
 
-            res &= blueprint::o2mrelation::verify(matset, info);
+            res &= vfs_res;
         }
         else if(matset["volume_fractions"].dtype().is_object() &&
             verify_object_field(protocol, matset, info, "volume_fractions"))
@@ -3995,7 +3996,7 @@ mesh::matset::verify(const Node &matset,
             else if(matset["element_ids"].dtype().is_integer() &&
                 matset["volume_fractions"].dtype().is_number())
             {
-                res &= verify_integer_field(protocol, matset, info, "element_ids");
+                res &= eids_res &= verify_integer_field(protocol, matset, info, "element_ids");
             }
             else
             {

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -573,12 +573,14 @@ void venn(const std::string &matset_type,
     // Area is trivial to compute and easy to verify.
     res["fields/area/association"] = "element";
     res["fields/area/topology"] = "topo";
+    res["fields/area/matset"] = "matset";
     res["fields/area/values"] = DataType::float64(nx * ny);
     // "Importance" is a made-up field.
     // Circles a, b, and c have differing importance.
     // Background material has importance that varies with position.
     res["fields/importance/association"] = "element";
     res["fields/importance/topology"] = "topo";
+    res["fields/importance/matset"] = "matset";
     res["fields/importance/values"] = DataType::float64(nx * ny);
 
 

--- a/src/tests/blueprint/t_blueprint_mcarray_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mcarray_verify.cpp
@@ -252,6 +252,10 @@ TEST(conduit_blueprint_mcarray_verify, mlarray_invalid_structure)
 
     n["a/z"].set(DataType::float64(3));
     EXPECT_FALSE(blueprint::mlarray::verify(n,info));
+
+    n["a/z"].reset();
+    n["a/z"].set(DataType::float64(2));
+    EXPECT_TRUE(blueprint::mlarray::verify(n,info));
 }
 
 

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -526,31 +526,18 @@ void venn_test(const std::string &venn_type)
     Node res, info;
     blueprint::mesh::examples::venn(venn_type, nx, ny, radius, res);
 
-    // TODO(JRC): Remove the conditional once sparse materials are supported by
-    // the Blueprint verify function.
-    if(venn_type == "full")
-    {
-        EXPECT_TRUE(blueprint::mesh::verify(res, info));
-        CONDUIT_INFO(info.to_yaml());
-    }
-
+    EXPECT_TRUE(blueprint::mesh::verify(res, info));
+    CONDUIT_INFO(info.to_yaml());
     CONDUIT_INFO(res.schema().to_json());
 
-    // TODO(JRC): Remove the conditional once sparse materials are supported by
-    // the Blueprint verify function.
-    if(venn_type == "full")
-    {
-        std::string ofbase = "venn_example_" + venn_type;
-        std::cout << "[Saving " << ofbase << "]" << std::endl;
-
-        relay::io_blueprint::save(res, ofbase + ".blueprint_root");
-    }
+    std::string ofbase = "venn_example_" + venn_type;
+    std::cout << "[Saving " << ofbase << "]" << std::endl;
+    relay::io_blueprint::save(res, ofbase + ".blueprint_root");
 
     {
         std::cout << "[Verifying field area is correct]" << std::endl;
 
         Node &area_actual = res["fields/area/values"];
-
         Node area_expected;
         area_expected.set(std::vector<double>(
             area_actual.dtype().number_of_elements(), 1.0 / (nx * ny)));

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -51,6 +51,7 @@
 #include "conduit.hpp"
 #include "conduit_blueprint.hpp"
 #include "conduit_relay.hpp"
+#include "conduit_log.hpp"
 
 #include <math.h>
 #include <iostream>
@@ -527,6 +528,7 @@ void venn_test(const std::string &venn_type)
     blueprint::mesh::examples::venn(venn_type, nx, ny, radius, res);
 
     EXPECT_TRUE(blueprint::mesh::verify(res, info));
+    utils::log::remove_valid(info);
     CONDUIT_INFO(info.to_yaml());
     CONDUIT_INFO(res.schema().to_json());
 

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -976,6 +976,52 @@ TEST(conduit_blueprint_mesh_verify, matset_general)
                 CHECK_MESH(verify_matset,n,info,false);
             }
 
+            { // Element ID Tests //
+                // Multi-Buffer Volume Fractions //
+                n.reset();
+                n["topology"].set("mesh");
+                n["volume_fractions"]["m1"].set(DataType::float64(5));
+                n["volume_fractions"]["m2"].set(DataType::float64(5));
+
+                n["element_ids"].reset();
+                n["element_ids"].set(DataType::float64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["element_ids"].set(DataType::int64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+
+                n["element_ids"].reset();
+                n["element_ids"]["m1"].set(DataType::int64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["element_ids"]["m2"].set(DataType::int64(5));
+                CHECK_MESH(verify_matset,n,info,true);
+                n["element_ids"]["m3"].set(DataType::int64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+
+                n["element_ids"].reset();
+                n["element_ids"]["m1"].set(DataType::int64(5));
+                n["element_ids"]["m2"].set(DataType::float32(5));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["element_ids"]["m2"].set(DataType::int32(5));
+                CHECK_MESH(verify_matset,n,info,true);
+
+                // Uni-Buffer Volume Fractions //
+                n["volume_fractions"].reset();
+                n["volume_fractions"].set(DataType::float64(5));
+                n["material_map"]["m1"].set(1);
+                n["material_ids"].set(DataType::uint32(5));
+
+                n["element_ids"].reset();
+                n["element_ids"]["m1"].set(DataType::int64(5));
+                n["element_ids"]["m2"].set(DataType::int64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+
+                n["element_ids"].reset();
+                n["element_ids"].set(DataType::float64(5));
+                CHECK_MESH(verify_matset,n,info,false);
+                n["element_ids"].set(DataType::int32(5));
+                CHECK_MESH(verify_matset,n,info,true);
+            }
+
             n.reset();
             n["topology"].set("mesh");
             n["volume_fractions"].set(vfs);


### PR DESCRIPTION
The changes in this pull request address #512  by making the following changes:

- [x] Update the `blueprint::mesh::matset::verify` function to recognize material-dominant schemas.
- [x] Implement test cases to validate the correctness of the new `blueprint::mesh::matset::verify` functionality.
- [x] Update the ["Material Sets"](https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#material-sets) documentation to include details for the new material-dominant option.
- [x] Update the `blueprint::mesh::examples::venn` regressions to all validate their results with `blueprint::mesh::verify`.