### PR TITLE
add iterator support for `o2mrelation` structures

### DIFF
--- a/src/docs/sphinx/blueprint_o2mrelation.rst
+++ b/src/docs/sphinx/blueprint_o2mrelation.rst
@@ -80,17 +80,69 @@ Taken in sum, the consituents of the **o2mrelation** schema describe how data (c
 Properties, Queries, and Transforms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- * **conduit::blueprint::o2mrelation::query_paths(const Node &o2mrelation, Node &res)**
+ * **conduit::blueprint::o2mrelation::data_paths(const Node &o2mrelation)**
 
-     Makes the ``res`` node an object with keys being the detected value paths found in ``o2mrelation`` and values being empty nodes.
+     Returns a ``std::vector<std::string>`` object containing all of the data paths in the given **o2mrelation** node.
 
-     * Example: {values: [int64], sizes: [int64], offsets: [int32], other: [char8]} => {values: (empty)}
+     * Example:
 
- * **conduit::blueprint::o2mrelation::to_compact(Node &o2mrelation)**
+     .. code:: json
 
-     Updates the contents of the ``offsets`` array so that it refers to a compacted sequence of relationships.
+         // Input //
+         {
+           "values": [int64],
+           "sizes": [int64],
+           "offsets": [int32],
+           "other": [char8]
+         }
 
-     * Example: sizes: {2, 5, 3, 8} => offsets: {0, 2, 7, 10}
+         // Output //
+         ["values"]
+
+
+ * **conduit::blueprint::o2mrelation::compact_to(const Node &o2mrelation, Node &res)**
+
+     Generates a data-compacted version of the given **o2mrelation** (first parameter) and stores it in the given output node (second parameter).
+
+     * Example:
+
+     .. code:: json
+
+         // Input //
+         {
+           "values": [-1, 2, 3, -1, 0, 1, -1],
+           "sizes": [2, 2],
+           "offsets": [4, 1]
+         }
+
+         // Output //
+         {
+           "values": [0, 1, 2, 3],
+           "sizes": [2, 2],
+           "offsets": [0, 2]
+         }
+
+
+ * **conduit::blueprint::o2mrelation::generate_offsets(Node &n, Node &info)**
+
+     Updates the contents of the given node's ``offsets`` child so that it refers to a compacted sequence of one-to-many relationships.
+
+     * Example:
+
+     .. code:: json
+
+         // Input //
+         {
+           "values": [0, 1, 2, 3],
+           "sizes": [2, 2]
+         }
+
+         // Output //
+         {
+           "values": [0, 1, 2, 3],
+           "sizes": [2, 2],
+           "offsets": [0, 2]
+         }
 
 O2MRelation Examples
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -66,6 +66,7 @@ set(blueprint_headers
     conduit_blueprint_mcarray.hpp
     conduit_blueprint_mcarray_examples.hpp
     conduit_blueprint_o2mrelation.hpp
+    conduit_blueprint_o2mrelation_iterator.hpp
     conduit_blueprint_o2mrelation_examples.hpp
     conduit_blueprint_zfparray.hpp
     ${CMAKE_CURRENT_BINARY_DIR}/conduit_blueprint_exports.h
@@ -93,6 +94,7 @@ set(blueprint_sources
     conduit_blueprint_mcarray.cpp
     conduit_blueprint_mcarray_examples.cpp
     conduit_blueprint_o2mrelation.cpp
+    conduit_blueprint_o2mrelation_iterator.cpp
     conduit_blueprint_o2mrelation_examples.cpp
     conduit_blueprint_zfparray.cpp
     )

--- a/src/libs/blueprint/conduit_blueprint.hpp
+++ b/src/libs/blueprint/conduit_blueprint.hpp
@@ -65,6 +65,7 @@
 
 #include "conduit_blueprint_o2mrelation.hpp"
 #include "conduit_blueprint_o2mrelation_examples.hpp"
+#include "conduit_blueprint_o2mrelation_iterator.hpp"
 
 #include "conduit_blueprint_mcarray.hpp"
 #include "conduit_blueprint_mcarray_examples.hpp"

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation.hpp
@@ -96,11 +96,22 @@ bool CONDUIT_BLUEPRINT_API verify(const std::string &protocol,
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
-void CONDUIT_BLUEPRINT_API query_paths(const conduit::Node &o2mrelation,
-                                        conduit::Node &res);
+std::vector<std::string> CONDUIT_BLUEPRINT_API data_paths(const conduit::Node &o2mrelation);
 
 //-----------------------------------------------------------------------------
-void CONDUIT_BLUEPRINT_API to_compact(conduit::Node &o2mrelation);
+void CONDUIT_BLUEPRINT_API compact_to(const conduit::Node &o2mrelation,
+                                      conduit::Node &res);
+
+//-----------------------------------------------------------------------------
+/// o2mrelation blueprint miscellaneous methods
+///
+/// These methods can be called on unverified o2mrelation to bring them
+/// into compliance.
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+bool CONDUIT_BLUEPRINT_API generate_offsets(conduit::Node &n,
+                                            conduit::Node &info);
 
 //-----------------------------------------------------------------------------
 }

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
@@ -375,7 +375,7 @@ O2MIterator::to_back(IndexType itype)
     if(itype == IndexType::DATA)
     {
         m_one_index = elements(0, IndexType::ONE);
-        m_many_index = elements(m_one_index, IndexType::MANY);
+        m_many_index = 1;
     }
     else if(itype == IndexType::ONE)
     {
@@ -481,17 +481,25 @@ O2MIterator::elements(index_t one_index, IndexType itype) const
     }
     else // if(itype == IndexType::MANY)
     {
-        if(m_node->has_child("sizes"))
+        // if the one index is too high, we return 0
+        if(one_index < elements(0, IndexType::ONE))
         {
-            const conduit::Node &sizes_node = m_node->fetch_existing("sizes");
-            const conduit::Node size_node(
-                conduit::DataType(sizes_node.dtype().id(), 1),
-                (void*)sizes_node.element_ptr(one_index), true);
-            nelements = size_node.to_index_t();
+            if(m_node->has_child("sizes"))
+            {
+                const conduit::Node &sizes_node = m_node->fetch_existing("sizes");
+                const conduit::Node size_node(
+                    conduit::DataType(sizes_node.dtype().id(), 1),
+                    (void*)sizes_node.element_ptr(one_index), true);
+                nelements = size_node.to_index_t();
+            }
+            else
+            {
+                nelements = 1;
+            }
         }
         else
         {
-            nelements = 1;
+            nelements = 0;
         }
     }
 

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
@@ -1,0 +1,516 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// 
+// Produced at the Lawrence Livermore National Laboratory
+// 
+// LLNL-CODE-666778
+// 
+// All rights reserved.
+// 
+// This file is part of Conduit. 
+// 
+// For details, see: http://software.llnl.gov/conduit/.
+// 
+// Please also read conduit/LICENSE
+// 
+// Redistribution and use in source and binary forms, with or without 
+// modification, are permitted provided that the following conditions are met:
+// 
+// * Redistributions of source code must retain the above copyright notice, 
+//   this list of conditions and the disclaimer below.
+// 
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the disclaimer (as noted below) in the
+//   documentation and/or other materials provided with the distribution.
+// 
+// * Neither the name of the LLNS/LLNL nor the names of its contributors may
+//   be used to endorse or promote products derived from this software without
+//   specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
+// LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+// IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+// POSSIBILITY OF SUCH DAMAGE.
+// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_node_iterator.cpp
+///
+//-----------------------------------------------------------------------------
+#include <sstream>
+
+#include "conduit_blueprint_o2mrelation.hpp"
+#include "conduit_blueprint_o2mrelation_iterator.hpp"
+
+#include "conduit_error.hpp"
+#include "conduit_utils.hpp"
+
+//-----------------------------------------------------------------------------
+// -- begin conduit:: --
+//-----------------------------------------------------------------------------
+namespace conduit
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint --
+//-----------------------------------------------------------------------------
+namespace blueprint
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+namespace o2mrelation
+{
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// O2MIterator
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// O2MIterator Construction and Destruction
+//-----------------------------------------------------------------------------
+
+
+//---------------------------------------------------------------------------//
+O2MIterator::O2MIterator()
+: m_node(NULL),
+  m_data_node(NULL),
+  m_one_index(0),
+  m_many_index(0)
+{
+    
+}
+
+//---------------------------------------------------------------------------//
+O2MIterator::O2MIterator(Node *node)
+: m_node(node),
+  m_one_index(0),
+  m_many_index(0)
+{
+    Node paths;
+    conduit::blueprint::o2mrelation::query_paths(*node, paths);
+    m_data_node = &node->fetch_existing(paths.child_names()[0]);
+}
+
+//---------------------------------------------------------------------------//
+O2MIterator::O2MIterator(Node &node)
+: O2MIterator(&node)
+{
+    
+}
+
+
+//---------------------------------------------------------------------------//
+O2MIterator::O2MIterator(const O2MIterator &itr)
+: m_node(itr.m_node),
+  m_data_node(itr.m_data_node),
+  m_one_index(itr.m_one_index),
+  m_many_index(itr.m_many_index)
+{
+    
+}
+
+//---------------------------------------------------------------------------//
+O2MIterator::~O2MIterator()
+{
+    
+}
+
+//---------------------------------------------------------------------------//
+O2MIterator &
+O2MIterator::operator=(const O2MIterator &itr)
+{
+    if(this != &itr)
+    {
+        m_node = itr.m_node;
+        m_data_node = itr.m_data_node;
+        m_one_index = itr.m_one_index;
+        m_many_index = itr.m_many_index;
+    }
+    return *this;
+}
+
+//-----------------------------------------------------------------------------
+/// Iterator value and property access.
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::index(IndexType itype) const
+{
+    return index(m_one_index, m_many_index, itype);
+}
+
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::elements(IndexType itype) const
+{
+    return elements(m_one_index, itype);
+}
+
+//-----------------------------------------------------------------------------
+/// Iterator forward control.
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------//
+bool
+O2MIterator::has_next(IndexType itype) const
+{
+    bool is_next = false;
+
+    if(itype == IndexType::DATA)
+    {
+        is_next = has_next(IndexType::ONE) || has_next(IndexType::MANY);
+    }
+    else if(itype == IndexType::ONE)
+    {
+        is_next = m_one_index < elements(0, IndexType::ONE) - 1;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        is_next = m_many_index < elements(m_one_index, IndexType::MANY);
+    }
+
+    return is_next;
+}
+
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::next(IndexType itype)
+{
+    index_t nindex = 0;
+
+    if(itype == IndexType::DATA)
+    {
+        if(m_many_index < elements(m_one_index, IndexType::MANY))
+        {
+            m_many_index++;
+        }
+        else
+        {
+            m_many_index = 1;
+            m_one_index++;
+        }
+
+        nindex = index(m_one_index, m_many_index, IndexType::DATA);
+    }
+    else if(itype == IndexType::ONE)
+    {
+        nindex = ++m_one_index;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        nindex = ++m_many_index;
+    }
+
+    return nindex;
+}
+
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::peek_next(IndexType itype) const
+{
+    index_t nindex = 0;
+
+    if(itype == IndexType::DATA)
+    {
+        if(m_many_index < elements(m_one_index, IndexType::MANY))
+        {
+            nindex = index(m_one_index, m_many_index + 1, IndexType::DATA);
+        }
+        else
+        {
+            nindex = index(m_one_index + 1, 1, IndexType::DATA);
+        }
+    }
+    else if(itype == IndexType::ONE)
+    {
+        nindex = m_one_index + 1;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        nindex = m_many_index + 1;
+    }
+
+    return nindex;
+}
+
+
+//---------------------------------------------------------------------------//
+void
+O2MIterator::to_front(IndexType itype)
+{
+    if(itype == IndexType::DATA)
+    {
+        m_one_index = 0;
+        m_many_index = 0;
+    }
+    else if(itype == IndexType::ONE)
+    {
+        m_one_index = 0;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        m_many_index = 1;
+    }
+}
+
+//-----------------------------------------------------------------------------
+/// Iterator reverse control.
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------//
+bool
+O2MIterator::has_previous(IndexType itype) const
+{
+    bool is_prev = false;
+
+    if(itype == IndexType::DATA)
+    {
+        is_prev = has_previous(IndexType::ONE) || has_previous(IndexType::MANY);
+    }
+    else if(itype == IndexType::ONE)
+    {
+        is_prev = m_one_index > 0;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        is_prev = m_many_index > 1;
+    }
+
+    return is_prev;
+}
+
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::previous(IndexType itype)
+{
+    index_t pindex = 0;
+
+    if(itype == IndexType::DATA)
+    {
+        if(m_many_index > 1)
+        {
+            m_many_index--;
+        }
+        else
+        {
+            m_many_index = elements(m_one_index - 1, IndexType::MANY);
+            m_one_index--;
+        }
+
+        pindex = index(m_one_index, m_many_index, IndexType::DATA);
+    }
+    else if(itype == IndexType::ONE)
+    {
+        pindex = --m_one_index;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        pindex = --m_many_index;
+    }
+
+    return pindex;
+}
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::peek_previous(IndexType itype) const
+{
+    index_t pindex = 0;
+
+    if(itype == IndexType::DATA)
+    {
+        if(m_many_index > 1)
+        {
+            pindex = index(m_one_index, m_many_index - 1, IndexType::DATA);
+        }
+        else
+        {
+            pindex = index(m_one_index - 1, elements(m_one_index - 1, IndexType::MANY), IndexType::DATA);
+        }
+    }
+    else if(itype == IndexType::ONE)
+    {
+        pindex = m_one_index - 1;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        pindex = m_many_index - 1;
+    }
+
+    return pindex;
+}
+
+
+//---------------------------------------------------------------------------//
+void
+O2MIterator::to_back(IndexType itype)
+{
+    if(itype == IndexType::DATA)
+    {
+        m_one_index = elements(0, IndexType::ONE);
+        m_many_index = elements(m_one_index, IndexType::MANY);
+    }
+    else if(itype == IndexType::ONE)
+    {
+        m_one_index = elements(0, IndexType::ONE);
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        m_many_index = elements(m_one_index, IndexType::MANY);
+    }
+}
+
+//-----------------------------------------------------------------------------
+/// Human readable info about this iterator
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------//
+void
+O2MIterator::info(Node &res) const
+{
+    res.reset();
+    res["o2m_ref"] = utils::to_hex_string(m_node);
+    res["data_ref"] = utils::to_hex_string(m_data_node);
+    res["one_index"] = m_one_index;
+    res["many_index"] = m_many_index;
+}
+
+//-----------------------------------------------------------------------------
+/// Private helper functions
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::index(index_t one_index, index_t many_index, IndexType itype) const
+{
+    index_t index = 0;
+
+    if(itype == IndexType::DATA)
+    {
+        index_t offset = one_index;
+        if(m_node->has_child("offsets"))
+        {
+            const conduit::Node &offsets_node = m_node->fetch_existing("offsets");
+            const conduit::Node offset_node(
+                conduit::DataType(offsets_node.dtype().id(), 1),
+                (void*)offsets_node.element_ptr(one_index), true);
+            offset = offset_node.to_index_t();
+        }
+
+        index = offset;
+        if(m_node->has_child("indices"))
+        {
+            const conduit::Node &indices_node = m_node->fetch_existing("indices");
+            const conduit::Node index_node(
+                conduit::DataType(indices_node.dtype().id(), 1),
+                (void*)indices_node.element_ptr(offset), true);
+            index = index_node.to_index_t();
+        }
+
+        index += (many_index - 1);
+    }
+    else if(itype == IndexType::ONE)
+    {
+        index = one_index;
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        index = (many_index - 1);
+    }
+
+    return index;
+}
+
+
+//---------------------------------------------------------------------------//
+index_t
+O2MIterator::elements(index_t one_index, IndexType itype) const
+{
+    index_t nelements = 0;
+
+    if(itype == IndexType::DATA)
+    {
+        for(index_t oi = 0; oi < elements(0, IndexType::ONE); oi++)
+        {
+            nelements += elements(oi, IndexType::MANY);
+        }
+    }
+    else if(itype == IndexType::ONE)
+    {
+        if(m_node->has_child("sizes"))
+        {
+            const conduit::Node &sizes_node = m_node->fetch_existing("sizes");
+            nelements = sizes_node.dtype().number_of_elements();
+        }
+        else if(m_node->has_child("indices"))
+        {
+            const conduit::Node &indices_node = m_node->fetch_existing("indices");
+            nelements = indices_node.dtype().number_of_elements();
+        }
+        else
+        {
+            nelements = m_data_node->dtype().number_of_elements();
+        }
+    }
+    else // if(itype == IndexType::MANY)
+    {
+        if(m_node->has_child("sizes"))
+        {
+            const conduit::Node &sizes_node = m_node->fetch_existing("sizes");
+            const conduit::Node size_node(
+                conduit::DataType(sizes_node.dtype().id(), 1),
+                (void*)sizes_node.element_ptr(one_index), true);
+            nelements = size_node.to_index_t();
+        }
+        else
+        {
+            nelements = 1;
+        }
+    }
+
+    return nelements;
+}
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// End O2MIterator
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit:: --
+//-----------------------------------------------------------------------------
+
+

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
@@ -95,18 +95,17 @@ O2MIterator::O2MIterator()
 }
 
 //---------------------------------------------------------------------------//
-O2MIterator::O2MIterator(Node *node)
+O2MIterator::O2MIterator(const Node *node)
 : m_node(node),
   m_one_index(0),
   m_many_index(0)
 {
-    Node paths;
-    conduit::blueprint::o2mrelation::query_paths(*node, paths);
-    m_data_node = &node->fetch_existing(paths.child_names()[0]);
+    std::vector<std::string> paths = conduit::blueprint::o2mrelation::data_paths(*node);
+    m_data_node = &node->fetch_existing(paths.front());
 }
 
 //---------------------------------------------------------------------------//
-O2MIterator::O2MIterator(Node &node)
+O2MIterator::O2MIterator(const Node &node)
 : O2MIterator(&node)
 {
     

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
@@ -211,11 +211,19 @@ O2MIterator::next(IndexType itype)
     }
     else if(itype == IndexType::ONE)
     {
-        nindex = ++m_one_index;
+        if(m_many_index < 1)
+        {
+            m_many_index++;
+            nindex = m_one_index;
+        }
+        else
+        {
+            nindex = ++m_one_index;
+        }
     }
     else // if(itype == IndexType::MANY)
     {
-        nindex = ++m_many_index;
+        nindex = m_many_index++;
     }
 
     return nindex;
@@ -241,11 +249,11 @@ O2MIterator::peek_next(IndexType itype) const
     }
     else if(itype == IndexType::ONE)
     {
-        nindex = m_one_index + 1;
+        nindex = m_one_index + ((m_many_index < 1) ? 0 : 1);
     }
     else // if(itype == IndexType::MANY)
     {
-        nindex = m_many_index + 1;
+        nindex = m_many_index;
     }
 
     return nindex;
@@ -267,7 +275,7 @@ O2MIterator::to_front(IndexType itype)
     }
     else // if(itype == IndexType::MANY)
     {
-        m_many_index = 1;
+        m_many_index = 0;
     }
 }
 
@@ -324,7 +332,7 @@ O2MIterator::previous(IndexType itype)
     }
     else // if(itype == IndexType::MANY)
     {
-        pindex = --m_many_index;
+        pindex = --m_many_index - 1;
     }
 
     return pindex;
@@ -353,7 +361,7 @@ O2MIterator::peek_previous(IndexType itype) const
     }
     else // if(itype == IndexType::MANY)
     {
-        pindex = m_many_index - 1;
+        pindex = m_many_index - 2;
     }
 
     return pindex;
@@ -391,7 +399,7 @@ O2MIterator::info(Node &res) const
     res["o2m_ref"] = utils::to_hex_string(m_node);
     res["data_ref"] = utils::to_hex_string(m_data_node);
     res["one_index"] = m_one_index;
-    res["many_index"] = m_many_index;
+    res["many_index"] = m_many_index - 1;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.cpp
@@ -172,17 +172,17 @@ O2MIterator::has_next(IndexType itype) const
 {
     bool is_next = false;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
-        is_next = has_next(IndexType::ONE) || has_next(IndexType::MANY);
+        is_next = has_next(ONE) || has_next(MANY);
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
-        is_next = m_one_index < elements(0, IndexType::ONE) - 1;
+        is_next = m_one_index < elements(0, ONE) - 1;
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
-        is_next = m_many_index < elements(m_one_index, IndexType::MANY);
+        is_next = m_many_index < elements(m_one_index, MANY);
     }
 
     return is_next;
@@ -195,9 +195,9 @@ O2MIterator::next(IndexType itype)
 {
     index_t nindex = 0;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
-        if(m_many_index < elements(m_one_index, IndexType::MANY))
+        if(m_many_index < elements(m_one_index, MANY))
         {
             m_many_index++;
         }
@@ -207,9 +207,9 @@ O2MIterator::next(IndexType itype)
             m_one_index++;
         }
 
-        nindex = index(m_one_index, m_many_index, IndexType::DATA);
+        nindex = index(m_one_index, m_many_index, DATA);
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         if(m_many_index < 1)
         {
@@ -221,7 +221,7 @@ O2MIterator::next(IndexType itype)
             nindex = ++m_one_index;
         }
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         nindex = m_many_index++;
     }
@@ -236,22 +236,22 @@ O2MIterator::peek_next(IndexType itype) const
 {
     index_t nindex = 0;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
-        if(m_many_index < elements(m_one_index, IndexType::MANY))
+        if(m_many_index < elements(m_one_index, MANY))
         {
-            nindex = index(m_one_index, m_many_index + 1, IndexType::DATA);
+            nindex = index(m_one_index, m_many_index + 1, DATA);
         }
         else
         {
-            nindex = index(m_one_index + 1, 1, IndexType::DATA);
+            nindex = index(m_one_index + 1, 1, DATA);
         }
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         nindex = m_one_index + ((m_many_index < 1) ? 0 : 1);
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         nindex = m_many_index;
     }
@@ -264,16 +264,16 @@ O2MIterator::peek_next(IndexType itype) const
 void
 O2MIterator::to_front(IndexType itype)
 {
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
         m_one_index = 0;
         m_many_index = 0;
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         m_one_index = 0;
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         m_many_index = 0;
     }
@@ -289,15 +289,15 @@ O2MIterator::has_previous(IndexType itype) const
 {
     bool is_prev = false;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
-        is_prev = has_previous(IndexType::ONE) || has_previous(IndexType::MANY);
+        is_prev = has_previous(ONE) || has_previous(MANY);
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         is_prev = m_one_index > 0;
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         is_prev = m_many_index > 1;
     }
@@ -312,7 +312,7 @@ O2MIterator::previous(IndexType itype)
 {
     index_t pindex = 0;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
         if(m_many_index > 1)
         {
@@ -320,17 +320,17 @@ O2MIterator::previous(IndexType itype)
         }
         else
         {
-            m_many_index = elements(m_one_index - 1, IndexType::MANY);
+            m_many_index = elements(m_one_index - 1, MANY);
             m_one_index--;
         }
 
-        pindex = index(m_one_index, m_many_index, IndexType::DATA);
+        pindex = index(m_one_index, m_many_index, DATA);
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         pindex = --m_one_index;
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         pindex = --m_many_index - 1;
     }
@@ -344,22 +344,22 @@ O2MIterator::peek_previous(IndexType itype) const
 {
     index_t pindex = 0;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
         if(m_many_index > 1)
         {
-            pindex = index(m_one_index, m_many_index - 1, IndexType::DATA);
+            pindex = index(m_one_index, m_many_index - 1, DATA);
         }
         else
         {
-            pindex = index(m_one_index - 1, elements(m_one_index - 1, IndexType::MANY), IndexType::DATA);
+            pindex = index(m_one_index - 1, elements(m_one_index - 1, MANY), DATA);
         }
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         pindex = m_one_index - 1;
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         pindex = m_many_index - 2;
     }
@@ -372,18 +372,18 @@ O2MIterator::peek_previous(IndexType itype) const
 void
 O2MIterator::to_back(IndexType itype)
 {
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
-        m_one_index = elements(0, IndexType::ONE);
+        m_one_index = elements(0, ONE);
         m_many_index = 1;
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
-        m_one_index = elements(0, IndexType::ONE);
+        m_one_index = elements(0, ONE);
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
-        m_many_index = elements(m_one_index, IndexType::MANY);
+        m_many_index = elements(m_one_index, MANY);
     }
 }
 
@@ -412,7 +412,7 @@ O2MIterator::index(index_t one_index, index_t many_index, IndexType itype) const
 {
     index_t index = 0;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
         index_t offset = one_index;
         if(m_node->has_child("offsets"))
@@ -436,11 +436,11 @@ O2MIterator::index(index_t one_index, index_t many_index, IndexType itype) const
 
         index += (many_index - 1);
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         index = one_index;
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         index = (many_index - 1);
     }
@@ -455,14 +455,14 @@ O2MIterator::elements(index_t one_index, IndexType itype) const
 {
     index_t nelements = 0;
 
-    if(itype == IndexType::DATA)
+    if(itype == DATA)
     {
-        for(index_t oi = 0; oi < elements(0, IndexType::ONE); oi++)
+        for(index_t oi = 0; oi < elements(0, ONE); oi++)
         {
-            nelements += elements(oi, IndexType::MANY);
+            nelements += elements(oi, MANY);
         }
     }
-    else if(itype == IndexType::ONE)
+    else if(itype == ONE)
     {
         if(m_node->has_child("sizes"))
         {
@@ -479,10 +479,10 @@ O2MIterator::elements(index_t one_index, IndexType itype) const
             nelements = m_data_node->dtype().number_of_elements();
         }
     }
-    else // if(itype == IndexType::MANY)
+    else // if(itype == MANY)
     {
         // if the one index is too high, we return 0
-        if(one_index < elements(0, IndexType::ONE))
+        if(one_index < elements(0, ONE))
         {
             if(m_node->has_child("sizes"))
             {

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
@@ -126,24 +126,24 @@ public:
 //-----------------------------------------------------------------------------
 /// Iterator value and property access.
 //-----------------------------------------------------------------------------
-    index_t     index(IndexType itype = IndexType::DATA) const;
-    index_t     elements(IndexType itype = IndexType::DATA) const;
+    index_t     index(IndexType itype = DATA) const;
+    index_t     elements(IndexType itype = DATA) const;
 
 //-----------------------------------------------------------------------------
 /// Iterator forward control.
 //-----------------------------------------------------------------------------
-    bool        has_next(IndexType itype = IndexType::DATA) const;
-    index_t     next(IndexType itype = IndexType::DATA);
-    index_t     peek_next(IndexType itype = IndexType::DATA) const;
-    void        to_front(IndexType itype = IndexType::DATA);
+    bool        has_next(IndexType itype = DATA) const;
+    index_t     next(IndexType itype = DATA);
+    index_t     peek_next(IndexType itype = DATA) const;
+    void        to_front(IndexType itype = DATA);
 
 //-----------------------------------------------------------------------------
 /// Iterator reverse control.
 //-----------------------------------------------------------------------------
-    bool        has_previous(IndexType itype = IndexType::DATA) const;
-    index_t     previous(IndexType itype = IndexType::DATA);
-    index_t     peek_previous(IndexType itype = IndexType::DATA) const;
-    void        to_back(IndexType itype = IndexType::DATA);
+    bool        has_previous(IndexType itype = DATA) const;
+    index_t     previous(IndexType itype = DATA);
+    index_t     peek_previous(IndexType itype = DATA) const;
+    void        to_back(IndexType itype = DATA);
 
 //-----------------------------------------------------------------------------
 /// Human readable info about this iterator
@@ -191,8 +191,6 @@ private:
 //-----------------------------------------------------------------------------
 // -- end conduit::blueprint::o2mrelation --
 //-----------------------------------------------------------------------------
-
-typedef o2mrelation::IndexType O2MIndexType;
 
 }
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
@@ -78,9 +78,9 @@ namespace o2mrelation
 
 typedef enum
 {
-    DATA = 0,     // empty (default type)
-    ONE  = 1,     // empty (default type)
-    MANY = 2      // char8 string (incore c-string)
+    DATA = 0,     // data array index
+    ONE  = 1,     // one group (outer) index
+    MANY = 2      // many item (inner) index
 } IndexType;
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
@@ -111,11 +111,11 @@ public:
     O2MIterator(const O2MIterator &itr);
 
     /// Primary iterator constructor.
-    O2MIterator(Node *node);
+    O2MIterator(const Node *node);
 
     /// Primary iterator constructor.
     /// this will use the pointer to the passed Node ref.
-    O2MIterator(Node &node);
+    O2MIterator(const Node &node);
 
     /// Destructor
     ~O2MIterator();
@@ -168,9 +168,9 @@ private:
 /// Iterator state/fields.
 //-----------------------------------------------------------------------------
     /// pointer to the Node wrapped by this iterator
-    Node    *m_node;
+    const Node *m_node;
     /// pointer to an internal data Node for the 'o2mrelation'
-    Node    *m_data_node;
+    const Node *m_data_node;
 
     /// current 'one' index in 'o2mrelation' space
     index_t  m_one_index;

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
@@ -44,17 +44,19 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: conduit_node_iterator.hpp
+/// file: conduit_blueprint_o2miterator.hpp
 ///
 //-----------------------------------------------------------------------------
 
-#ifndef CONDUIT_NODE_ITERATOR_HPP
-#define CONDUIT_NODE_ITERATOR_HPP
+#ifndef CONDUIT_BLUEPRINT_O2MITERATOR_HPP
+#define CONDUIT_BLUEPRINT_O2MITERATOR_HPP
 
 //-----------------------------------------------------------------------------
-// -- conduit includes -- 
+// conduit lib includes
 //-----------------------------------------------------------------------------
-#include "conduit_node.hpp"
+#include "conduit.hpp"
+#include "conduit_blueprint_exports.h"
+
 
 //-----------------------------------------------------------------------------
 // -- begin conduit:: --
@@ -62,189 +64,146 @@
 namespace conduit
 {
 
-// forward declare NodeConstIterator so it can be a used as a friend
-// to NodeIterator
-class NodeConstIterator;
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint --
+//-----------------------------------------------------------------------------
+namespace blueprint
+{
 
 //-----------------------------------------------------------------------------
-// -- begin conduit::NodeIterator --
+// -- begin conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+namespace o2mrelation
+{
+
+typedef enum
+{
+    DATA = 0,     // empty (default type)
+    ONE  = 1,     // empty (default type)
+    MANY = 2      // char8 string (incore c-string)
+} IndexType;
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::O2MIterator --
 //-----------------------------------------------------------------------------
 ///
-/// class: conduit::NodeIterator
+/// class: conduit::O2MIterator
 ///
 /// description:
-///  General purpose iterator for Nodes.
+///  General purpose iterator for 'o2mrelation' Nodes.
 ///
 //-----------------------------------------------------------------------------
-class CONDUIT_API NodeIterator
+class CONDUIT_API O2MIterator
 {
 public:
 //-----------------------------------------------------------------------------
 //
-// -- conduit::NodeIterator public members --
+// -- conduit::O2MIterator public members --
 //
 //-----------------------------------------------------------------------------
-    friend class NodeConstIterator;
+
 //-----------------------------------------------------------------------------
-/// NodeIterator Construction and Destruction
+/// O2MIterator Construction and Destruction
 //-----------------------------------------------------------------------------
     /// Default constructor.
-    NodeIterator();
+    O2MIterator();
     /// Copy constructor.
-    NodeIterator(const NodeIterator &itr);
-    
+    O2MIterator(const O2MIterator &itr);
+
     /// Primary iterator constructor.
-    NodeIterator(Node *node,index_t idx=0);
-    
+    O2MIterator(Node *node);
+
     /// Primary iterator constructor.
     /// this will use the pointer to the passed Node ref.
-    NodeIterator(Node &node,index_t idx=0);
-    
-    /// Destructor 
-    ~NodeIterator();
- 
+    O2MIterator(Node &node);
+
+    /// Destructor
+    ~O2MIterator();
+
     /// Assignment operator.
-    NodeIterator &operator=(const NodeIterator &itr);
- 
+    O2MIterator &operator=(const O2MIterator &itr);
+
 //-----------------------------------------------------------------------------
 /// Iterator value and property access.
 //-----------------------------------------------------------------------------
-    std::string name()  const;
-    index_t     index() const;
-    Node       &node();
+    index_t     index(IndexType itype = IndexType::DATA) const;
+    index_t     elements(IndexType itype = IndexType::DATA) const;
 
 //-----------------------------------------------------------------------------
 /// Iterator forward control.
 //-----------------------------------------------------------------------------
-    bool        has_next() const;
-    Node       &next();
-    Node       &peek_next();
-    void        to_front();
+    bool        has_next(IndexType itype = IndexType::DATA) const;
+    index_t     next(IndexType itype = IndexType::DATA);
+    index_t     peek_next(IndexType itype = IndexType::DATA) const;
+    void        to_front(IndexType itype = IndexType::DATA);
 
 //-----------------------------------------------------------------------------
 /// Iterator reverse control.
 //-----------------------------------------------------------------------------
-    bool        has_previous() const;
-    Node       &previous();
-    Node       &peek_previous();
-    void        to_back();
+    bool        has_previous(IndexType itype = IndexType::DATA) const;
+    index_t     previous(IndexType itype = IndexType::DATA);
+    index_t     peek_previous(IndexType itype = IndexType::DATA) const;
+    void        to_back(IndexType itype = IndexType::DATA);
 
 //-----------------------------------------------------------------------------
 /// Human readable info about this iterator
 //-----------------------------------------------------------------------------
     void        info(Node &res) const;
-    
+
 private:
+
 //-----------------------------------------------------------------------------
 //
-// -- conduit::NodeIterator private data members --
+// -- conduit::O2MIterator private members --
 //
 //-----------------------------------------------------------------------------
-    /// pointer to the Node wrapped by this iterator 
-    Node    *m_node;
-    /// current child index
-    index_t  m_index;
-    /// total number of children 
-    index_t  m_num_children; 
-};
-//-----------------------------------------------------------------------------
-// -- end conduit::NodeIterator --
-//-----------------------------------------------------------------------------
-
-
-    
-//-----------------------------------------------------------------------------
-// -- begin conduit::NodeIterator --
-//-----------------------------------------------------------------------------
-///
-/// class: conduit::NodeConstIterator
-///
-/// description:
-///  General purpose const iterator for Nodes.
-///
-//-----------------------------------------------------------------------------
-class CONDUIT_API NodeConstIterator
-{
-public:
-//-----------------------------------------------------------------------------
-//
-// -- conduit::NodeConstIterator public members --
-//
-//-----------------------------------------------------------------------------
-    
-//-----------------------------------------------------------------------------
-/// NodeConstIterator Construction and Destruction
-//-----------------------------------------------------------------------------
-    /// Default constructor.
-    NodeConstIterator();
-    /// Copy constructor.
-    NodeConstIterator(const NodeConstIterator &itr);
-    /// Primary iterator constructor.
-    NodeConstIterator(const Node *node,index_t idx=0);
-    /// Primary iterator constructor.
-    /// this will use the pointer to the passed Node ref.
-    NodeConstIterator(const Node &node,index_t idx=0);
-    /// Destructor 
-    ~NodeConstIterator();
-
-    /// Construct from non const
-    NodeConstIterator(const NodeIterator &itr);
- 
-    /// Assignment operator.
-    NodeConstIterator &operator=(const NodeConstIterator &itr);
-
-    /// Assignment operator from non const
-    NodeConstIterator &operator=(const NodeIterator &itr);
- 
-//-----------------------------------------------------------------------------
-/// Iterator value and property access.
-//-----------------------------------------------------------------------------
-    std::string name()  const;
-    index_t     index() const;
-    const Node &node();
-    void        to_front();
 
 //-----------------------------------------------------------------------------
-/// Iterator forward control.
+/// Iterator property helper functions.
 //-----------------------------------------------------------------------------
-    bool        has_next() const;
-    const Node &next();
-    const Node &peek_next();
+    index_t index(index_t one_index, index_t many_index, IndexType itype) const;
+    index_t elements(index_t one_index, IndexType itype) const;
 
 //-----------------------------------------------------------------------------
-/// Iterator reverse control.
-//-----------------------------------------------------------------------------
-    bool        has_previous() const;
-    const Node &previous();
-    const Node &peek_previous();
-    void        to_back();
-
-//-----------------------------------------------------------------------------
-/// Human readable info about this iterator
-//-----------------------------------------------------------------------------
-    void        info(Node &res) const;
-    
-private:
-//-----------------------------------------------------------------------------
-//
-// -- conduit::NodeIterator private data members --
-//
+/// Iterator state/fields.
 //-----------------------------------------------------------------------------
     /// pointer to the Node wrapped by this iterator
-    const Node  *m_node;
-    /// current child index
-    index_t      m_index;
-    /// total number of children 
-    index_t      m_num_children; 
+    Node    *m_node;
+    /// pointer to an internal data Node for the 'o2mrelation'
+    Node    *m_data_node;
+
+    /// current 'one' index in 'o2mrelation' space
+    index_t  m_one_index;
+    /// current 'many' index in 'one' space
+    index_t  m_many_index;
+
+    // /// current 'one' count for 'o2mrelation' (constant)
+    // index_t m_num_ones;
+    // /// current 'many' count for 'o2mrelation' (depends on 'one')
+    // index_t m_num_manys;
 };
 //-----------------------------------------------------------------------------
-// -- end conduit::NodeIterator --
+// -- end conduit::O2MIterator --
 //-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::o2mrelation --
+//-----------------------------------------------------------------------------
+
+typedef o2mrelation::IndexType O2MIndexType;
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint --
+//-----------------------------------------------------------------------------
+
 
 }
 //-----------------------------------------------------------------------------
 // -- end conduit:: --
 //-----------------------------------------------------------------------------
 
-#endif
 
+#endif

--- a/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_o2mrelation_examples.cpp
@@ -193,57 +193,57 @@ TEST(conduit_blueprint_o2mrelation_examples, o2mrelation_iterator_properties)
 
     { // Index Tests //
         blueprint::o2mrelation::O2MIterator niter(n);
-        niter.next(blueprint::O2MIndexType::DATA);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::ONE), 0);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::MANY), 0);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::DATA), 0);
+        niter.next(blueprint::o2mrelation::DATA);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::ONE), 0);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::MANY), 0);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::DATA), 0);
 
-        niter.next(blueprint::O2MIndexType::MANY);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::ONE), 0);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::MANY), 1);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::DATA), 1);
+        niter.next(blueprint::o2mrelation::MANY);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::ONE), 0);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::MANY), 1);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::DATA), 1);
 
-        niter.next(blueprint::O2MIndexType::ONE);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::ONE), 1);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::MANY), 1);
-        EXPECT_EQ(niter.index(blueprint::O2MIndexType::DATA), 5);
+        niter.next(blueprint::o2mrelation::ONE);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::ONE), 1);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::MANY), 1);
+        EXPECT_EQ(niter.index(blueprint::o2mrelation::DATA), 5);
     }
 
     { // Elements Tests //
         blueprint::o2mrelation::O2MIterator niter(n);
-        niter.next(blueprint::O2MIndexType::DATA);
-        EXPECT_EQ(niter.elements(blueprint::O2MIndexType::ONE), 3);
-        EXPECT_EQ(niter.elements(blueprint::O2MIndexType::MANY), 2);
-        EXPECT_EQ(niter.elements(blueprint::O2MIndexType::DATA), 6);
+        niter.next(blueprint::o2mrelation::DATA);
+        EXPECT_EQ(niter.elements(blueprint::o2mrelation::ONE), 3);
+        EXPECT_EQ(niter.elements(blueprint::o2mrelation::MANY), 2);
+        EXPECT_EQ(niter.elements(blueprint::o2mrelation::DATA), 6);
 
-        niter.next(blueprint::O2MIndexType::ONE);
-        EXPECT_EQ(niter.elements(blueprint::O2MIndexType::ONE), 3);
-        EXPECT_EQ(niter.elements(blueprint::O2MIndexType::MANY), 2);
-        EXPECT_EQ(niter.elements(blueprint::O2MIndexType::DATA), 6);
+        niter.next(blueprint::o2mrelation::ONE);
+        EXPECT_EQ(niter.elements(blueprint::o2mrelation::ONE), 3);
+        EXPECT_EQ(niter.elements(blueprint::o2mrelation::MANY), 2);
+        EXPECT_EQ(niter.elements(blueprint::o2mrelation::DATA), 6);
     }
 
     { // Next/Previous Tests //
         blueprint::o2mrelation::O2MIterator niter(n);
 
-        EXPECT_EQ(niter.next(blueprint::O2MIndexType::ONE), 0);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::ONE), 1);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::MANY), 1);
+        EXPECT_EQ(niter.next(blueprint::o2mrelation::ONE), 0);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::ONE), 1);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::MANY), 1);
 
-        EXPECT_EQ(niter.next(blueprint::O2MIndexType::ONE), 1);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::ONE), 2);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::MANY), 1);
-        EXPECT_EQ(niter.next(blueprint::O2MIndexType::MANY), 1);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::ONE), 2);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::MANY), 2);
-        EXPECT_EQ(niter.peek_previous(blueprint::O2MIndexType::ONE), 0);
-        EXPECT_EQ(niter.peek_previous(blueprint::O2MIndexType::MANY), 0);
+        EXPECT_EQ(niter.next(blueprint::o2mrelation::ONE), 1);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::ONE), 2);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::MANY), 1);
+        EXPECT_EQ(niter.next(blueprint::o2mrelation::MANY), 1);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::ONE), 2);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::MANY), 2);
+        EXPECT_EQ(niter.peek_previous(blueprint::o2mrelation::ONE), 0);
+        EXPECT_EQ(niter.peek_previous(blueprint::o2mrelation::MANY), 0);
 
-        EXPECT_EQ(niter.previous(blueprint::O2MIndexType::ONE), 0);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::ONE), 1);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::MANY), 2);
-        EXPECT_EQ(niter.previous(blueprint::O2MIndexType::MANY), 0);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::ONE), 1);
-        EXPECT_EQ(niter.peek_next(blueprint::O2MIndexType::MANY), 1);
+        EXPECT_EQ(niter.previous(blueprint::o2mrelation::ONE), 0);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::ONE), 1);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::MANY), 2);
+        EXPECT_EQ(niter.previous(blueprint::o2mrelation::MANY), 0);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::ONE), 1);
+        EXPECT_EQ(niter.peek_next(blueprint::o2mrelation::MANY), 1);
     }
 
     { // Next/Previous Edge Case Tests //


### PR DESCRIPTION
The changes in this pull request add the `blueprint::o2mrelation::O2MIterator` type to Conduit-Blueprint, which facilitates Conduit-style iteration over one-to-many index spaces.

This pull request builds off of #563 and should not be merged until that pull request is finalized. Additionally, this pull request shouldn't be merged until the interface design for the `blueprint::o2mrelation::O2MIterator` type is finalized (see #565 for details).