### PR TITLE
add property queries for new types of matsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### Blueprint
 - Added support for sparse one-to-many relationships with the new `blueprint::o2mrelation` protocol. See the `blueprint::o2mrelation::examples::uniform` example for details.
-- Added sparse one-to-many and uni-buffer specification support to Material sets. See the Material sets documentation
+- Added sparse one-to-many, uni-buffer, and material-dominant specification support to Material sets. See the Material sets documentation
 (https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#material-sets) for more details.
 - Added support for Adjacency sets for Structured Mesh Topologies. See the `blueprint::mesh::examples::adjset_uniform` example.
 - Added `blueprint::mesh::examples::julia_nestsets_simple` and `blueprint::mesh::examples::julia_nestsets_complex` examples represent Julia set fractals using patch-based AMR meshes and the Mesh Blueprint Nesting Set protocol. See the Julia AMR Blueprint docs

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -4012,6 +4012,34 @@ mesh::matset::verify(const Node &matset,
     return res;
 }
 
+//-------------------------------------------------------------------------
+bool
+mesh::matset::is_multi_buffer(const Node &matset)
+{
+    return matset.child("volume_fractions").dtype().is_object();
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::matset::is_uni_buffer(const Node &matset)
+{
+    return matset.child("volume_fractions").dtype().is_number();
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::matset::is_element_dominant(const Node &matset)
+{
+    return !matset.has_child("element_ids");
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::matset::is_material_dominant(const Node &matset)
+{
+    return matset.has_child("element_ids");
+}
+
 //-----------------------------------------------------------------------------
 // blueprint::mesh::matset::index protocol interface
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -429,6 +429,18 @@ namespace matset
                                       conduit::Node &info);
 
     //-------------------------------------------------------------------------
+    bool CONDUIT_BLUEPRINT_API is_multi_buffer(const conduit::Node &n);
+
+    //-------------------------------------------------------------------------
+    bool CONDUIT_BLUEPRINT_API is_uni_buffer(const conduit::Node &n);
+
+    //-------------------------------------------------------------------------
+    bool CONDUIT_BLUEPRINT_API is_element_dominant(const conduit::Node &n);
+
+    //-------------------------------------------------------------------------
+    bool CONDUIT_BLUEPRINT_API is_material_dominant(const conduit::Node &n);
+
+    //-------------------------------------------------------------------------
     // blueprint::mesh::matset::index protocol interface
     //-------------------------------------------------------------------------
     namespace index


### PR DESCRIPTION
The changes in this pull request directly address #567 by adding property query functions to the `blueprint::mesh::matset` namespace corresponding to the new material set types introduced in #553 and #563.