### PR TITLE
fix format of 'blueprint::mesh::examples::venn' sparse per-material fields

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -4105,7 +4105,7 @@ mesh::field::verify(const Node &field,
     else if(has_matset && has_matset_values)
     {
         res &= verify_string_field(protocol, field, info, "matset");
-        res &= verify_mlarray_field(protocol, field, info, "matset_values", 1, 2, false);
+        res &= verify_mlarray_field(protocol, field, info, "matset_values", 0, 2, false);
     }
 
     // TODO(JRC): Enable 'volume_dependent' once it's confirmed to be a required

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -411,8 +411,8 @@ void venn_sparse_by_element_matset(Node &res)
 
     // The matset values (for fields that have them) get built up
     // in the same way as the sparse fields, into "one big array."
-    res["fields/area/matset_values/values"].set(DataType::float64(vfcount));
-    res["fields/importance/matset_values/values"].set(DataType::float64(vfcount));
+    res["fields/area/matset_values"].set(DataType::float64(vfcount));
+    res["fields/importance/matset_values"].set(DataType::float64(vfcount));
 
     // The actual fields
     res["fields/area/values"].set(DataType::float64(elements));
@@ -422,8 +422,8 @@ void venn_sparse_by_element_matset(Node &res)
     int32_array id = res["matsets/matset/material_ids"].value();
     int32_array sizes = res["matsets/matset/sizes"].value();
     int32_array offsets = res["matsets/matset/offsets"].value();
-    float64_array matset_area = res["fields/area/matset_values/values"].value();
-    float64_array matset_impt = res["fields/importance/matset_values/values"].value();
+    float64_array matset_area = res["fields/area/matset_values"].value();
+    float64_array matset_impt = res["fields/importance/matset_values"].value();
     float64_array field_area = res["fields/area/values"].value();
     float64_array field_impt = res["fields/importance/values"].value();
 


### PR DESCRIPTION
The changes in this pull request address the issues outlined in #575. The new JSON schema for `blueprint::mesh::examples::venn("sparse_by_element", ...)` is:

```
{
  "coordsets": 
  {
    "coords": 
    {
      "type": {"dtype":"char8_str", "number_of_elements": 12, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "values": 
      {
        "x": {"dtype":"float64", "number_of_elements": 101, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"},
        "y": {"dtype":"float64", "number_of_elements": 101, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"}
      },
      "params": 
      {
        "nx": {"dtype":"int64", "number_of_elements": 1, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"},
        "ny": {"dtype":"int64", "number_of_elements": 1, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"}
      }
    }
  },
  "topologies": 
  {
    "topo": 
    {
      "type": {"dtype":"char8_str", "number_of_elements": 12, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "coordset": {"dtype":"char8_str", "number_of_elements": 7, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"}
    }
  },
  "fields": 
  {
    // ... //
    "area": 
    {
      "association": {"dtype":"char8_str", "number_of_elements": 8, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "topology": {"dtype":"char8_str", "number_of_elements": 5, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "matset": {"dtype":"char8_str", "number_of_elements": 7, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "values": {"dtype":"float64", "number_of_elements": 10000, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"},
      "matset_values": {"dtype":"float64", "number_of_elements": 10939, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"}
    },
    "importance": 
    {
      "association": {"dtype":"char8_str", "number_of_elements": 8, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "topology": {"dtype":"char8_str", "number_of_elements": 5, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "matset": {"dtype":"char8_str", "number_of_elements": 7, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "values": {"dtype":"float64", "number_of_elements": 10000, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"},
      "matset_values": {"dtype":"float64", "number_of_elements": 10939, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"}
    }
    // ... //
  },
  "matsets": 
  {
    "matset": 
    {
      "topology": {"dtype":"char8_str", "number_of_elements": 5, "offset": 0, "stride": 1, "element_bytes": 1, "endianness": "little"},
      "material_map": 
      {
        "cir_a": {"dtype":"int32", "number_of_elements": 1, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"},
        "cir_b": {"dtype":"int32", "number_of_elements": 1, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"},
        "cir_c": {"dtype":"int32", "number_of_elements": 1, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"},
        "bg": {"dtype":"int32", "number_of_elements": 1, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"}
      },
      "volume_fractions": {"dtype":"float64", "number_of_elements": 10939, "offset": 0, "stride": 8, "element_bytes": 8, "endianness": "little"},
      "material_ids": {"dtype":"int32", "number_of_elements": 10939, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"},
      "sizes": {"dtype":"int32", "number_of_elements": 10000, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"},
      "offsets": {"dtype":"int32", "number_of_elements": 10000, "offset": 0, "stride": 4, "element_bytes": 4, "endianness": "little"}
    }
  }
}
```