### PR TITLE
Node: set_external(const T*)

### DIFF
--- a/src/libs/conduit/conduit_generator.cpp
+++ b/src/libs/conduit/conduit_generator.cpp
@@ -196,7 +196,7 @@ public:
 
     static void    walk_json_schema(Node   *node,
                                     Schema *schema,
-                                    void   *data,
+                                    const void *data,
                                     const rapidjson::Value &jvalue,
                                     index_t curr_offset);
     
@@ -1208,7 +1208,7 @@ Generator::Parser::JSON::walk_pure_json_schema(Node *node,
 void 
 Generator::Parser::JSON::walk_json_schema(Node   *node,
                                           Schema *schema,
-                                          void   *data,
+                                          const void *data,
                                           const rapidjson::Value &jvalue,
                                           index_t curr_offset)
 {
@@ -2114,7 +2114,7 @@ Generator::Generator()
 //---------------------------------------------------------------------------//
 Generator::Generator(const std::string &schema,
                      const std::string &protocol,
-                     void *data)
+                     const void *data)
 :m_schema(schema),
  m_protocol(protocol),
  m_data(data)
@@ -2136,7 +2136,7 @@ Generator::set_protocol(const std::string &protocol)
 
 //---------------------------------------------------------------------------//
 void
-Generator::set_data_ptr(void *data_ptr)
+Generator::set_data_ptr(const void *data_ptr)
 {
     m_data = data_ptr;
 }
@@ -2156,7 +2156,7 @@ Generator::protocol() const
 }
 
 //---------------------------------------------------------------------------//
-void *
+const void *
 Generator::data_ptr() const
 {
     return m_data;

--- a/src/libs/conduit/conduit_generator.hpp
+++ b/src/libs/conduit/conduit_generator.hpp
@@ -105,16 +105,16 @@ public:
     ///
     Generator(const std::string &schema,
               const std::string &protocol = std::string("conduit_json"),
-              void *data = NULL);
+              const void *data = NULL);
 
 
     void set_schema(const std::string &schema);
     void set_protocol(const std::string &protocol);
-    void set_data_ptr(void *);
+    void set_data_ptr(const void *);
 
     const std::string &schema() const;
     const std::string &protocol()   const;
-    void *data_ptr() const;
+    const void *data_ptr() const;
 
 
 //-----------------------------------------------------------------------------
@@ -144,7 +144,7 @@ private:
     /// holds the parsing protocol
     std::string  m_protocol;
     /// optional external data pointer
-    void        *m_data;
+    const void  *m_data;
 
 };
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -180,7 +180,7 @@ Node::Node(const Schema &schema)
 
 //---------------------------------------------------------------------------//
 Node::Node(const Generator &gen,
-           bool external)
+           const bool external)
 {
     init_defaults();
     if(external)
@@ -196,8 +196,8 @@ Node::Node(const Generator &gen,
 
 //---------------------------------------------------------------------------//
 Node::Node(const std::string &schema,
-           void *data,
-           bool external)
+           const void *data,
+           const bool external)
 {
     init_defaults(); 
     Generator g(schema,"conduit_json",data);
@@ -222,11 +222,11 @@ Node::Node(const DataType &dtype)
 
 //---------------------------------------------------------------------------//
 Node::Node(const Schema &schema,
-           void *data,
-           bool external)
+           const void *data,
+           const bool external)
 {
     init_defaults();
-    std::string json_schema =schema.to_json(); 
+    std::string json_schema = schema.to_json();
     Generator g(json_schema,"conduit_json",data);
     if(external)
     {
@@ -241,8 +241,8 @@ Node::Node(const Schema &schema,
 
 //---------------------------------------------------------------------------//
 Node::Node(const DataType &dtype,
-           void *data,
-           bool external)
+           const void *data,
+           const bool external)
 {    
     init_defaults();
     if(external)
@@ -295,7 +295,7 @@ Node::generate_external(const Generator &gen)
 void
 Node::generate(const std::string &schema,
                const std::string &protocol,
-               void *data)
+               const void *data)
                
 {
     Generator g(schema,protocol,data);
@@ -306,7 +306,7 @@ Node::generate(const std::string &schema,
 void
 Node::generate_external(const std::string &schema,
                         const std::string &protocol,
-                        void *data)
+                        const void *data)
                
 {
     Generator g(schema,protocol,data);
@@ -581,7 +581,7 @@ Node::set(const Schema &schema)
 //---------------------------------------------------------------------------//
 void
 Node::set_data_using_schema(const Schema &schema,
-                            void *data)
+                            const void *data)
 {
     release();
     m_schema->set(schema);   
@@ -595,7 +595,7 @@ Node::set_data_using_schema(const Schema &schema,
 //---------------------------------------------------------------------------//
 void
 Node::set(const Schema &schema,
-          void *data)
+          const void *data)
 {
     set_data_using_schema(schema,data);
 }
@@ -603,7 +603,7 @@ Node::set(const Schema &schema,
 //---------------------------------------------------------------------------//
 void
 Node::set_data_using_dtype(const DataType &dtype,
-                           void *data)
+                           const void *data)
 {
     release();
     m_schema->set(dtype);
@@ -614,7 +614,7 @@ Node::set_data_using_dtype(const DataType &dtype,
 
 //---------------------------------------------------------------------------//
 void
-Node::set(const DataType &dtype, void *data)
+Node::set(const DataType &dtype, const void *data)
 {
     set_data_using_dtype(dtype,data);
 }
@@ -629,7 +629,7 @@ Node::set(const DataType &dtype, void *data)
 
 //---------------------------------------------------------------------------//
 void
-Node::set_int8(int8 data)
+Node::set_int8(const int8 data)
 {
     init(DataType::int8());
     // TODO IMP: use element_ptr() ?
@@ -638,14 +638,14 @@ Node::set_int8(int8 data)
 
 //---------------------------------------------------------------------------//
 void
-Node::set(int8 data)
+Node::set(const int8 data)
 {
     set_int8(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_int16(int16 data)
+Node::set_int16(const int16 data)
 {
     init(DataType::int16());
     *(int16*)((char*)m_data + schema().element_index(0)) = data;
@@ -653,14 +653,14 @@ Node::set_int16(int16 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(int16 data)
+Node::set(const int16 data)
 {
     set_int16(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_int32(int32 data)
+Node::set_int32(const int32 data)
 {
     init(DataType::int32());
     *(int32*)((char*)m_data + schema().element_index(0)) = data;
@@ -668,14 +668,14 @@ Node::set_int32(int32 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(int32 data)
+Node::set(const int32 data)
 {
     set_int32(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_int64(int64 data)
+Node::set_int64(const int64 data)
 {
     init(DataType::int64());
     *(int64*)((char*)m_data + schema().element_index(0)) = data;
@@ -683,7 +683,7 @@ Node::set_int64(int64 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(int64 data)
+Node::set(const int64 data)
 {
     set_int64(data);
 }
@@ -694,7 +694,7 @@ Node::set(int64 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_uint8(uint8 data)
+Node::set_uint8(const uint8 data)
 {
     init(DataType::uint8());
     *(uint8*)((char*)m_data + schema().element_index(0)) = data;
@@ -702,14 +702,14 @@ Node::set_uint8(uint8 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(uint8 data)
+Node::set(const uint8 data)
 {
     set_uint8(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_uint16(uint16 data)
+Node::set_uint16(const uint16 data)
 {
     init(DataType::uint16());
     *(uint16*)((char*)m_data + schema().element_index(0)) = data;
@@ -717,14 +717,14 @@ Node::set_uint16(uint16 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(uint16 data)
+Node::set(const uint16 data)
 {
     set_uint16(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_uint32(uint32 data)
+Node::set_uint32(const uint32 data)
 {
     init(DataType::uint32());
     *(uint32*)((char*)m_data + schema().element_index(0)) = data;
@@ -732,14 +732,14 @@ Node::set_uint32(uint32 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(uint32 data)
+Node::set(const uint32 data)
 {
     set_uint32(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_uint64(uint64 data)
+Node::set_uint64(const uint64 data)
 {
     init(DataType::uint64());
     *(uint64*)((char*)m_data + schema().element_index(0)) = data;
@@ -747,7 +747,7 @@ Node::set_uint64(uint64 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(uint64 data)
+Node::set(const uint64 data)
 {
     set_uint64(data);
 }
@@ -758,7 +758,7 @@ Node::set(uint64 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_float32(float32 data)
+Node::set_float32(const float32 data)
 {
     init(DataType::float32());
     *(float32*)((char*)m_data + schema().element_index(0)) = data;
@@ -766,14 +766,14 @@ Node::set_float32(float32 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(float32 data)
+Node::set(const float32 data)
 {
     set_float32(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_float64(float64 data)
+Node::set_float64(const float64 data)
 {
     init(DataType::float64());
     *(float64*)((char*)m_data + schema().element_index(0)) = data;
@@ -781,7 +781,7 @@ Node::set_float64(float64 data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set(float64 data)
+Node::set(const float64 data)
 {
     set_float64(data);
 }
@@ -793,7 +793,7 @@ Node::set(float64 data)
 
 //-----------------------------------------------------------------------------
 void
-Node::set(char data)
+Node::set(const char data)
 {
     set((CONDUIT_NATIVE_CHAR)data);
 }
@@ -803,14 +803,14 @@ Node::set(char data)
 #ifndef CONDUIT_USE_CHAR
 //-----------------------------------------------------------------------------
 void
-Node::set(signed char data)
+Node::set(const signed char data)
 {
     set((CONDUIT_NATIVE_SIGNED_CHAR)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set(unsigned char data)
+Node::set(const unsigned char data)
 {
     set((CONDUIT_NATIVE_UNSIGNED_CHAR)data);
 }
@@ -822,14 +822,14 @@ Node::set(unsigned char data)
 #ifndef CONDUIT_USE_SHORT
 //-----------------------------------------------------------------------------
 void
-Node::set(short data)
+Node::set(const short data)
 {
     set((CONDUIT_NATIVE_SHORT)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set(unsigned short data)
+Node::set(const unsigned short data)
 {
     set((CONDUIT_NATIVE_UNSIGNED_SHORT)data);
 }
@@ -841,14 +841,14 @@ Node::set(unsigned short data)
 #ifndef CONDUIT_USE_INT
 //-----------------------------------------------------------------------------
 void
-Node::set(int data)
+Node::set(const int data)
 {
     set((CONDUIT_NATIVE_INT)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set(unsigned int data)
+Node::set(const unsigned int data)
 {
     set((CONDUIT_NATIVE_UNSIGNED_INT)data);
 }
@@ -860,14 +860,14 @@ Node::set(unsigned int data)
 #ifndef CONDUIT_USE_LONG
 //-----------------------------------------------------------------------------
 void
-Node::set(long data)
+Node::set(const long data)
 {
     set((CONDUIT_NATIVE_LONG)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set(unsigned long data)
+Node::set(const unsigned long data)
 {
     set((CONDUIT_NATIVE_UNSIGNED_LONG)data);
 }
@@ -879,14 +879,14 @@ Node::set(unsigned long data)
 #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
 //-----------------------------------------------------------------------------
 void
-Node::set(long long data)
+Node::set(const long long data)
 {
     set((CONDUIT_NATIVE_LONG_LONG)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set(unsigned long long data)
+Node::set(const unsigned long long data)
 {
     set((CONDUIT_NATIVE_UNSIGNED_LONG_LONG)data);
 }
@@ -898,7 +898,7 @@ Node::set(unsigned long long data)
 #ifndef CONDUIT_USE_FLOAT
 //-----------------------------------------------------------------------------
 void
-Node::set(float data)
+Node::set(const float data)
 {
     set((CONDUIT_NATIVE_FLOAT)data);
 }
@@ -910,7 +910,7 @@ Node::set(float data)
 #ifndef CONDUIT_USE_DOUBLE
 //-----------------------------------------------------------------------------
 void
-Node::set(double data)
+Node::set(const double data)
 {
     set((CONDUIT_NATIVE_DOUBLE)data);
 }
@@ -2240,7 +2240,7 @@ Node::set_path(const std::string &path,
 void
 Node::set_path_data_using_schema(const std::string &path,
                                  const Schema &schema,
-                                 void *data)
+                                 const void *data)
 {
     fetch(path).set_data_using_schema(schema,data);
 }
@@ -2249,7 +2249,7 @@ Node::set_path_data_using_schema(const std::string &path,
 void
 Node::set_path(const std::string &path,
                const Schema &schema,
-               void *data)
+               const void *data)
 {
     set_path_data_using_schema(path,schema,data);
 }
@@ -2258,7 +2258,7 @@ Node::set_path(const std::string &path,
 void
 Node::set_path_data_using_dtype(const std::string &path,
                                 const DataType &dtype,
-                                void *data)
+                                const void *data)
 {
     fetch(path).set_data_using_dtype(dtype,data);
 }
@@ -2267,7 +2267,7 @@ Node::set_path_data_using_dtype(const std::string &path,
 void
 Node::set_path(const std::string &path,
                const DataType &dtype,
-               void *data)
+               const void *data)
 {
     set_path_data_using_dtype(path,dtype,data);
 }
@@ -2283,7 +2283,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_int8(const std::string &path,
-                    int8 data)
+                    const int8 data)
 {
     fetch(path).set_int8(data);
 }
@@ -2291,7 +2291,7 @@ Node::set_path_int8(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               int8 data)
+               const int8 data)
 {
     set_path_int8(path,data);
 }
@@ -2299,7 +2299,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_int16(const std::string &path,
-                     int16 data)
+                     const int16 data)
 {
     fetch(path).set_int16(data);
 }
@@ -2307,7 +2307,7 @@ Node::set_path_int16(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               int16 data)
+               const int16 data)
 {
     set_path_int16(path,data);
 }
@@ -2316,7 +2316,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_int32(const std::string &path,
-                     int32 data)
+                     const int32 data)
 {
     fetch(path).set_int32(data);
 }
@@ -2324,7 +2324,7 @@ Node::set_path_int32(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               int32 data)
+               const int32 data)
 {
     set_path_int32(path,data);
 }
@@ -2332,7 +2332,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_int64(const std::string &path,
-                     int64 data)
+                     const int64 data)
 {
     fetch(path).set_int64(data);
 }
@@ -2340,7 +2340,7 @@ Node::set_path_int64(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               int64 data)
+               const int64 data)
 {
     fetch(path).set(data);
 }
@@ -2352,7 +2352,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_uint8(const std::string &path,
-                     uint8 data)
+                     const uint8 data)
 {
     fetch(path).set_uint8(data);
 }
@@ -2360,7 +2360,7 @@ Node::set_path_uint8(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               uint8 data)
+               const uint8 data)
 {
     set_path_uint8(path,data);
 }
@@ -2368,7 +2368,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_uint16(const std::string &path,
-                      uint16 data)
+                      const uint16 data)
 {
     fetch(path).set_uint16(data);
 }
@@ -2376,7 +2376,7 @@ Node::set_path_uint16(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               uint16 data)
+               const uint16 data)
 {
     set_path_uint16(path,data);
 }
@@ -2384,7 +2384,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_uint32(const std::string &path,
-                      uint32 data)
+                      const uint32 data)
 {
     fetch(path).set_uint32(data);
 }
@@ -2392,7 +2392,7 @@ Node::set_path_uint32(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               uint32 data)
+               const uint32 data)
 {
     set_path_uint32(path,data);
 }
@@ -2400,7 +2400,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_uint64(const std::string &path,
-                      uint64 data)
+                      const uint64 data)
 {
     fetch(path).set_uint64(data);
 }
@@ -2408,7 +2408,7 @@ Node::set_path_uint64(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               uint64 data)
+               const uint64 data)
 {
     set_path_uint64(path,data);
 }
@@ -2420,7 +2420,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_float32(const std::string &path,
-                       float32 data)
+                       const float32 data)
 {
     fetch(path).set_float32(data);
 }
@@ -2428,7 +2428,7 @@ Node::set_path_float32(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               float32 data)
+               const float32 data)
 {
     set_path_float32(path,data);
 }
@@ -2436,7 +2436,7 @@ Node::set_path(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_float64(const std::string &path,
-                       float64 data)
+                       const float64 data)
 {
     fetch(path).set_float64(data);
 }
@@ -2444,7 +2444,7 @@ Node::set_path_float64(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path(const std::string &path,
-               float64 data)
+               const float64 data)
 {
     set_path_float64(path,data);
 }
@@ -2455,7 +2455,7 @@ Node::set_path(const std::string &path,
 
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, char data)
+Node::set_path(const std::string &path, const char data)
 {
     set_path(path,(CONDUIT_NATIVE_CHAR)data);
 }
@@ -2464,14 +2464,14 @@ Node::set_path(const std::string &path, char data)
 #ifndef CONDUIT_USE_CHAR
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, signed char data)
+Node::set_path(const std::string &path, const signed char data)
 {
     set_path(path,(CONDUIT_NATIVE_SIGNED_CHAR)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, unsigned char data)
+Node::set_path(const std::string &path, const unsigned char data)
 {
     set_path(path,(CONDUIT_NATIVE_UNSIGNED_CHAR)data);
 }
@@ -2483,14 +2483,14 @@ Node::set_path(const std::string &path, unsigned char data)
 #ifndef CONDUIT_USE_SHORT
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, short data)
+Node::set_path(const std::string &path, const short data)
 {
     set_path(path,(CONDUIT_NATIVE_SHORT)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, unsigned short data)
+Node::set_path(const std::string &path, const unsigned short data)
 {
     set_path(path,(CONDUIT_NATIVE_UNSIGNED_SHORT)data);
 }
@@ -2502,14 +2502,14 @@ Node::set_path(const std::string &path, unsigned short data)
 #ifndef CONDUIT_USE_INT
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, int data)
+Node::set_path(const std::string &path, const int data)
 {
     set_path(path,(CONDUIT_NATIVE_INT)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, unsigned int data)
+Node::set_path(const std::string &path, const unsigned int data)
 {
     set_path(path,(CONDUIT_NATIVE_UNSIGNED_INT)data);
 }
@@ -2521,14 +2521,14 @@ Node::set_path(const std::string &path, unsigned int data)
 #ifndef CONDUIT_USE_LONG
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, long data)
+Node::set_path(const std::string &path, const long data)
 {
     set_path(path,(CONDUIT_NATIVE_LONG)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, unsigned long data)
+Node::set_path(const std::string &path, const unsigned long data)
 {
     set_path(path,(CONDUIT_NATIVE_UNSIGNED_LONG)data);
 }
@@ -2540,14 +2540,14 @@ Node::set_path(const std::string &path, unsigned long data)
 #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, long long data)
+Node::set_path(const std::string &path, const long long data)
 {
     set_path(path,(CONDUIT_NATIVE_LONG_LONG)data);
 }
 
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, unsigned long long data)
+Node::set_path(const std::string &path, const unsigned long long data)
 {
     set_path(path,(CONDUIT_NATIVE_UNSIGNED_LONG_LONG)data);
 }
@@ -2559,7 +2559,7 @@ Node::set_path(const std::string &path, unsigned long long data)
 #ifndef CONDUIT_USE_FLOAT
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, float data)
+Node::set_path(const std::string &path, const float data)
 {
     set_path(path,(CONDUIT_NATIVE_FLOAT)data);
 }
@@ -2571,7 +2571,7 @@ Node::set_path(const std::string &path, float data)
 #ifndef CONDUIT_USE_DOUBLE
 //-----------------------------------------------------------------------------
 void
-Node::set_path(const std::string &path, double data)
+Node::set_path(const std::string &path, const double data)
 {
     set_path(path, (CONDUIT_NATIVE_DOUBLE)data);
 }
@@ -3943,7 +3943,7 @@ Node::set_external(const Node &node)
 //---------------------------------------------------------------------------//
 void
 Node::set_external_data_using_schema(const Schema &schema,
-                                     void *data)
+                                     const void *data)
 {
     reset();
     m_schema->set(schema);
@@ -3953,7 +3953,7 @@ Node::set_external_data_using_schema(const Schema &schema,
 //---------------------------------------------------------------------------//
 void
 Node::set_external(const Schema &schema,
-                   void *data)
+                   const void *data)
 {
     set_external_data_using_schema(schema,data);
 }
@@ -3961,7 +3961,7 @@ Node::set_external(const Schema &schema,
 //---------------------------------------------------------------------------//
 void
 Node::set_external_data_using_dtype(const DataType &dtype,
-                                    void *data)
+                                    const void *data)
 {
     reset();
     m_data    = data;
@@ -3971,7 +3971,7 @@ Node::set_external_data_using_dtype(const DataType &dtype,
 //---------------------------------------------------------------------------//
 void
 Node::set_external(const DataType &dtype,
-                   void *data)
+                   const void *data)
 {
     set_external_data_using_dtype(dtype,data);
 }
@@ -3986,7 +3986,7 @@ Node::set_external(const DataType &dtype,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int8_ptr(int8 *data,
+Node::set_external_int8_ptr(const int8 *data,
                             index_t num_elements,
                             index_t offset,
                             index_t stride,
@@ -4004,7 +4004,7 @@ Node::set_external_int8_ptr(int8 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(int8 *data,
+Node::set_external(const int8 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4021,7 +4021,7 @@ Node::set_external(int8 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int16_ptr(int16 *data,
+Node::set_external_int16_ptr(const int16 *data,
                              index_t num_elements,
                              index_t offset,
                              index_t stride,
@@ -4039,7 +4039,7 @@ Node::set_external_int16_ptr(int16 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(int16 *data,
+Node::set_external(const int16 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4057,7 +4057,7 @@ Node::set_external(int16 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int32_ptr(int32 *data,
+Node::set_external_int32_ptr(const int32 *data,
                              index_t num_elements,
                              index_t offset,
                              index_t stride,
@@ -4075,7 +4075,7 @@ Node::set_external_int32_ptr(int32 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(int32 *data,
+Node::set_external(const int32 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4092,7 +4092,7 @@ Node::set_external(int32 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int64_ptr(int64 *data,
+Node::set_external_int64_ptr(const int64 *data,
                              index_t num_elements,
                              index_t offset,
                              index_t stride,
@@ -4110,7 +4110,7 @@ Node::set_external_int64_ptr(int64 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(int64 *data,
+Node::set_external(const int64 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4132,7 +4132,7 @@ Node::set_external(int64 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint8_ptr(uint8 *data,
+Node::set_external_uint8_ptr(const uint8 *data,
                              index_t num_elements,
                              index_t offset,
                              index_t stride,
@@ -4150,7 +4150,7 @@ Node::set_external_uint8_ptr(uint8 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(uint8 *data,
+Node::set_external(const uint8 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4169,7 +4169,7 @@ Node::set_external(uint8 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint16_ptr(uint16 *data,
+Node::set_external_uint16_ptr(const uint16 *data,
                               index_t num_elements,
                               index_t offset,
                               index_t stride,
@@ -4188,7 +4188,7 @@ Node::set_external_uint16_ptr(uint16 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(uint16 *data,
+Node::set_external(const uint16 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4205,7 +4205,7 @@ Node::set_external(uint16 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint32_ptr(uint32 *data,
+Node::set_external_uint32_ptr(const uint32 *data,
                              index_t num_elements,
                              index_t offset,
                              index_t stride,
@@ -4224,7 +4224,7 @@ Node::set_external_uint32_ptr(uint32 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(uint32 *data,
+Node::set_external(const uint32 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4241,7 +4241,7 @@ Node::set_external(uint32 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint64_ptr(uint64 *data,
+Node::set_external_uint64_ptr(const uint64 *data,
                               index_t num_elements,
                               index_t offset,
                               index_t stride,
@@ -4260,7 +4260,7 @@ Node::set_external_uint64_ptr(uint64 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(uint64 *data,
+Node::set_external(const uint64 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4280,7 +4280,7 @@ Node::set_external(uint64 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_float32_ptr(float32 *data,
+Node::set_external_float32_ptr(const float32 *data,
                                index_t num_elements,
                                index_t offset,
                                index_t stride,
@@ -4298,7 +4298,7 @@ Node::set_external_float32_ptr(float32 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(float32 *data,
+Node::set_external(const float32 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4315,7 +4315,7 @@ Node::set_external(float32 *data,
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_float64_ptr(float64 *data,
+Node::set_external_float64_ptr(const float64 *data,
                                index_t num_elements,
                                index_t offset,
                                index_t stride,
@@ -4333,7 +4333,7 @@ Node::set_external_float64_ptr(float64 *data,
     
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(float64 *data,
+Node::set_external(const float64 *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4352,7 +4352,7 @@ Node::set_external(float64 *data,
 // set pointer gap methods for c-native types
 //-----------------------------------------------------------------------------
 void
-Node::set_external_char_ptr(char *data,
+Node::set_external_char_ptr(const char *data,
                             index_t num_elements,
                             index_t offset,
                             index_t stride,
@@ -4373,7 +4373,7 @@ Node::set_external_char_ptr(char *data,
 #ifndef CONDUIT_USE_CHAR
 //-----------------------------------------------------------------------------
 void
-Node::set_external(signed char *data,
+Node::set_external(const signed char *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4391,7 +4391,7 @@ Node::set_external(signed char *data,
 
 //-----------------------------------------------------------------------------
 void
-Node::set_external(unsigned char *data,
+Node::set_external(const unsigned char *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4414,7 +4414,7 @@ Node::set_external(unsigned char *data,
 #ifndef CONDUIT_USE_SHORT
 //-----------------------------------------------------------------------------
 void
-Node::set_external(short *data,
+Node::set_external(const short *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4432,7 +4432,7 @@ Node::set_external(short *data,
 
 //-----------------------------------------------------------------------------
 void
-Node::set_external(unsigned short *data,
+Node::set_external(const unsigned short *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4455,7 +4455,7 @@ Node::set_external(unsigned short *data,
 #ifndef CONDUIT_USE_INT
 //-----------------------------------------------------------------------------
 void
-Node::set_external(int *data,
+Node::set_external(const int *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4473,7 +4473,7 @@ Node::set_external(int *data,
 
 //-----------------------------------------------------------------------------
 void
-Node::set_external(unsigned int *data,
+Node::set_external(const unsigned int *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4496,7 +4496,7 @@ Node::set_external(unsigned int *data,
 #ifndef CONDUIT_USE_LONG
 //-----------------------------------------------------------------------------
 void
-Node::set_external(long *data,
+Node::set_external(const long *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4514,7 +4514,7 @@ Node::set_external(long *data,
 
 //-----------------------------------------------------------------------------
 void
-Node::set_external(unsigned long *data,
+Node::set_external(const unsigned long *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4538,7 +4538,7 @@ Node::set_external(unsigned long *data,
 #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
 //-----------------------------------------------------------------------------
 void
-Node::set_external(long long *data,
+Node::set_external(const long long *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4556,7 +4556,7 @@ Node::set_external(long long *data,
 
 //-----------------------------------------------------------------------------
 void
-Node::set_external(unsigned long long *data,
+Node::set_external(const unsigned long long *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4579,7 +4579,7 @@ Node::set_external(unsigned long long *data,
 #ifndef CONDUIT_USE_FLOAT
 //-----------------------------------------------------------------------------
 void
-Node::set_external(float *data,
+Node::set_external(const float *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4602,7 +4602,7 @@ Node::set_external(float *data,
 #ifndef CONDUIT_USE_DOUBLE
 //-----------------------------------------------------------------------------
 void
-Node::set_external(double *data,
+Node::set_external(const double *data,
                    index_t num_elements,
                    index_t offset,
                    index_t stride,
@@ -4801,7 +4801,7 @@ Node::set_external(const float64_array &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_char8_str(char *data)
+Node::set_external_char8_str(const char *data)
 {
     release();
     
@@ -4988,7 +4988,7 @@ Node::set_external(const double_array &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int8_vector(std::vector<int8> &data)
+Node::set_external_int8_vector(const std::vector<int8> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -4999,14 +4999,14 @@ Node::set_external_int8_vector(std::vector<int8> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<int8> &data)
+Node::set_external(const std::vector<int8> &data)
 {
     set_external_int8_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int16_vector(std::vector<int16> &data)
+Node::set_external_int16_vector(const std::vector<int16> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5017,14 +5017,14 @@ Node::set_external_int16_vector(std::vector<int16> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<int16> &data)
+Node::set_external(const std::vector<int16> &data)
 {
     set_external_int16_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int32_vector(std::vector<int32> &data)
+Node::set_external_int32_vector(const std::vector<int32> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5035,14 +5035,14 @@ Node::set_external_int32_vector(std::vector<int32> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<int32> &data)
+Node::set_external(const std::vector<int32> &data)
 {
     set_external_int32_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_int64_vector(std::vector<int64> &data)
+Node::set_external_int64_vector(const std::vector<int64> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5053,7 +5053,7 @@ Node::set_external_int64_vector(std::vector<int64> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<int64> &data)
+Node::set_external(const std::vector<int64> &data)
 {
     set_external_int64_vector(data);
 }
@@ -5064,7 +5064,7 @@ Node::set_external(std::vector<int64> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint8_vector(std::vector<uint8> &data)
+Node::set_external_uint8_vector(const std::vector<uint8> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5075,14 +5075,14 @@ Node::set_external_uint8_vector(std::vector<uint8> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<uint8> &data)
+Node::set_external(const std::vector<uint8> &data)
 {
     set_external_uint8_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint16_vector(std::vector<uint16> &data)
+Node::set_external_uint16_vector(const std::vector<uint16> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5093,14 +5093,14 @@ Node::set_external_uint16_vector(std::vector<uint16> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<uint16> &data)
+Node::set_external(const std::vector<uint16> &data)
 {
     set_external_uint16_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint32_vector(std::vector<uint32> &data)
+Node::set_external_uint32_vector(const std::vector<uint32> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5111,14 +5111,14 @@ Node::set_external_uint32_vector(std::vector<uint32> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<uint32> &data)
+Node::set_external(const std::vector<uint32> &data)
 {
     set_external_uint32_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_uint64_vector(std::vector<uint64> &data)
+Node::set_external_uint64_vector(const std::vector<uint64> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5129,7 +5129,7 @@ Node::set_external_uint64_vector(std::vector<uint64> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<uint64> &data)
+Node::set_external(const std::vector<uint64> &data)
 {
     set_external_uint64_vector(data);
 }
@@ -5140,7 +5140,7 @@ Node::set_external(std::vector<uint64> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_float32_vector(std::vector<float32> &data)
+Node::set_external_float32_vector(const std::vector<float32> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5151,14 +5151,14 @@ Node::set_external_float32_vector(std::vector<float32> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<float32> &data)
+Node::set_external(const std::vector<float32> &data)
 {
     set_external_float32_vector(data);
 }
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external_float64_vector(std::vector<float64> &data)
+Node::set_external_float64_vector(const std::vector<float64> &data)
 {
     release();
     index_t data_num_ele = (index_t)data.size();
@@ -5169,7 +5169,7 @@ Node::set_external_float64_vector(std::vector<float64> &data)
 
 //---------------------------------------------------------------------------//
 void 
-Node::set_external(std::vector<float64> &data)
+Node::set_external(const std::vector<float64> &data)
 {
     set_external_float64_vector(data);
 }
@@ -5398,7 +5398,7 @@ Node::set_path_external(const std::string &path,
 void
 Node::set_path_external_data_using_schema(const std::string &path,
                                           const Schema &schema,
-                                          void *data)
+                                          const void *data)
 {
     fetch(path).set_external_data_using_schema(schema,data);
 }
@@ -5407,7 +5407,7 @@ Node::set_path_external_data_using_schema(const std::string &path,
 void
 Node::set_path_external(const std::string &path,
                         const Schema &schema,
-                        void *data)
+                        const void *data)
 {
     set_path_external_data_using_schema(path,schema,data);
 }
@@ -5416,7 +5416,7 @@ Node::set_path_external(const std::string &path,
 void
 Node::set_path_external_data_using_dtype(const std::string &path,
                                          const DataType &dtype,
-                                         void *data)
+                                         const void *data)
 {
     fetch(path).set_external_data_using_dtype(dtype,data);
 }
@@ -5425,7 +5425,7 @@ Node::set_path_external_data_using_dtype(const std::string &path,
 void
 Node::set_path_external(const std::string &path,
                         const DataType &dtype,
-                        void *data)
+                        const void *data)
 {
     set_path_external_data_using_dtype(path,dtype,data);
 }
@@ -5441,7 +5441,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int8_ptr(const std::string &path,
-                                 int8  *data,
+                                 const int8  *data,
                                  index_t num_elements,
                                  index_t offset,
                                  index_t stride,
@@ -5459,7 +5459,7 @@ Node::set_path_external_int8_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        int8  *data,
+                        const int8  *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5478,7 +5478,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int16_ptr(const std::string &path,
-                                  int16 *data, 
+                                  const int16 *data,
                                   index_t num_elements,
                                   index_t offset,
                                   index_t stride,
@@ -5496,7 +5496,7 @@ Node::set_path_external_int16_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        int16 *data, 
+                        const int16 *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5515,7 +5515,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int32_ptr(const std::string &path,
-                                  int32 *data,
+                                  const int32 *data,
                                   index_t num_elements,
                                   index_t offset,
                                   index_t stride,
@@ -5533,7 +5533,7 @@ Node::set_path_external_int32_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-           int32 *data,
+           const int32 *data,
            index_t num_elements,
            index_t offset,
            index_t stride,
@@ -5552,7 +5552,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int64_ptr(const std::string &path,
-                                  int64 *data,
+                                  const int64 *data,
                                   index_t num_elements,
                                   index_t offset,
                                   index_t stride,
@@ -5570,7 +5570,7 @@ Node::set_path_external_int64_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        int64 *data,
+                        const int64 *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5593,7 +5593,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint8_ptr(const std::string &path,
-                                  uint8  *data,
+                                  const uint8  *data,
                                   index_t num_elements,
                                   index_t offset,
                                   index_t stride,
@@ -5610,7 +5610,7 @@ Node::set_path_external_uint8_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        uint8  *data,
+                        const uint8  *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5629,7 +5629,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint16_ptr(const std::string &path,
-                                   uint16 *data,
+                                   const uint16 *data,
                                    index_t num_elements,
                                    index_t offset,
                                    index_t stride,
@@ -5647,7 +5647,7 @@ Node::set_path_external_uint16_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        uint16 *data,
+                        const uint16 *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5666,7 +5666,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint32_ptr(const std::string &path,
-                                   uint32 *data, 
+                                   const uint32 *data,
                                    index_t num_elements,
                                    index_t offset,
                                    index_t stride,
@@ -5684,7 +5684,7 @@ Node::set_path_external_uint32_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        uint32 *data, 
+                        const uint32 *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5704,7 +5704,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint64_ptr(const std::string &path,
-                                   uint64 *data,
+                                   const uint64 *data,
                                    index_t num_elements,
                                    index_t offset,
                                    index_t stride,
@@ -5722,7 +5722,7 @@ Node::set_path_external_uint64_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        uint64 *data,
+                        const uint64 *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5745,7 +5745,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_float32_ptr(const std::string &path,
-                                    float32 *data,
+                                    const float32 *data,
                                     index_t num_elements,
                                     index_t offset,
                                     index_t stride,
@@ -5763,7 +5763,7 @@ Node::set_path_external_float32_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                       float32 *data,
+                       const float32 *data,
                        index_t num_elements,
                        index_t offset,
                        index_t stride,
@@ -5784,7 +5784,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_float64_ptr(const std::string &path,
-                                    float64 *data, 
+                                    const float64 *data,
                                     index_t num_elements,
                                     index_t offset,
                                     index_t stride,
@@ -5803,7 +5803,7 @@ Node::set_path_external_float64_ptr(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        float64 *data, 
+                        const float64 *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5825,7 +5825,7 @@ Node::set_path_external(const std::string &path,
 
 void
 Node::set_path_external_char_ptr(const std::string &path,
-                                 char *data,
+                                 const char *data,
                                  index_t num_elements,
                                  index_t offset,
                                  index_t stride,
@@ -5846,7 +5846,7 @@ Node::set_path_external_char_ptr(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        signed char *data,
+                        const signed char *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5864,7 +5864,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        unsigned char *data,
+                        const unsigned char *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5887,7 +5887,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        short *data,
+                        const short *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5905,7 +5905,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        unsigned short *data,
+                        const unsigned short *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5928,7 +5928,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        int *data,
+                        const int *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5946,7 +5946,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        unsigned int *data,
+                        const unsigned int *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5969,7 +5969,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        long *data,
+                        const long *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -5987,7 +5987,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        unsigned long *data,
+                        const unsigned long *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -6010,7 +6010,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        long long *data,
+                        const long long *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -6028,7 +6028,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        unsigned long long *data,
+                        const unsigned long long *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -6051,7 +6051,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        float *data,
+                        const float *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -6074,7 +6074,7 @@ Node::set_path_external(const std::string &path,
 //-----------------------------------------------------------------------------
 void
 Node::set_path_external(const std::string &path,
-                        double *data,
+                        const double *data,
                         index_t num_elements,
                         index_t offset,
                         index_t stride,
@@ -6229,7 +6229,7 @@ Node::set_path_external_uint64_array(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                       const uint64_array &data)
+                        const uint64_array &data)
 {
     set_path_external_uint64_array(path,data);
 }
@@ -6423,7 +6423,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_char8_str(const std::string &path,
-                                 char *data)
+                                  const char *data)
 {
     fetch(path).set_external_char8_str(data);
 }
@@ -6439,7 +6439,7 @@ Node::set_path_external_char8_str(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int8_vector(const std::string &path,
-                                   std::vector<int8> &data)
+                                    const std::vector<int8> &data)
 {
     fetch(path).set_external_int8_vector(data);
 }
@@ -6447,7 +6447,7 @@ Node::set_path_external_int8_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<int8> &data)
+                        const std::vector<int8> &data)
 {
     set_path_external_int8_vector(path,data);
 }
@@ -6455,7 +6455,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int16_vector(const std::string &path,
-                                     std::vector<int16> &data)
+                                     const std::vector<int16> &data)
 {
     fetch(path).set_external_int16_vector(data);
 }
@@ -6463,7 +6463,7 @@ Node::set_path_external_int16_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<int16> &data)
+                        const std::vector<int16> &data)
 {
     set_path_external_int16_vector(path,data);
 }
@@ -6471,7 +6471,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int32_vector(const std::string &path,
-                                     std::vector<int32> &data)
+                                     const std::vector<int32> &data)
 {
     fetch(path).set_external_int32_vector(data);
 }
@@ -6479,7 +6479,7 @@ Node::set_path_external_int32_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<int32> &data)
+                        const std::vector<int32> &data)
 {
     set_path_external_int32_vector(path,data);
 }
@@ -6487,7 +6487,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_int64_vector(const std::string &path,
-                        std::vector<int64> &data)
+                                     const std::vector<int64> &data)
 {
     fetch(path).set_external_int64_vector(data);
 }
@@ -6495,7 +6495,7 @@ Node::set_path_external_int64_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<int64> &data)
+                        const std::vector<int64> &data)
 {
     set_path_external_int64_vector(path,data);
 }
@@ -6507,7 +6507,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint8_vector(const std::string &path,
-                                     std::vector<uint8> &data)
+                                     const std::vector<uint8> &data)
 {
     fetch(path).set_external_uint8_vector(data);
 }
@@ -6515,7 +6515,7 @@ Node::set_path_external_uint8_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<uint8> &data)
+                        const std::vector<uint8> &data)
 {
     set_path_external_uint8_vector(path,data);
 }
@@ -6523,7 +6523,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint16_vector(const std::string &path,
-                                      std::vector<uint16> &data)
+                                      const std::vector<uint16> &data)
 {
     fetch(path).set_external_uint16_vector(data);
 }
@@ -6531,7 +6531,7 @@ Node::set_path_external_uint16_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<uint16> &data)
+                        const std::vector<uint16> &data)
 {
     set_path_external_uint16_vector(path,data);
 }
@@ -6539,7 +6539,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint32_vector(const std::string &path,
-                                      std::vector<uint32> &data)
+                                      const std::vector<uint32> &data)
 {
     fetch(path).set_external_uint32_vector(data);
 }
@@ -6547,7 +6547,7 @@ Node::set_path_external_uint32_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<uint32> &data)
+                        const std::vector<uint32> &data)
 {
     set_path_external_uint32_vector(path,data);
 }
@@ -6556,7 +6556,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_uint64_vector(const std::string &path,
-                                      std::vector<uint64> &data)
+                                      const std::vector<uint64> &data)
 {
     fetch(path).set_external_uint64_vector(data);
 }
@@ -6564,7 +6564,7 @@ Node::set_path_external_uint64_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<uint64> &data)
+                        const std::vector<uint64> &data)
 {
     set_path_external_uint64_vector(path,data);
 }
@@ -6576,7 +6576,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_float32_vector(const std::string &path,
-                                       std::vector<float32> &data)
+                                       const std::vector<float32> &data)
 {
     fetch(path).set_external_float32_vector(data);
 }
@@ -6584,7 +6584,7 @@ Node::set_path_external_float32_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<float32> &data)
+                        const std::vector<float32> &data)
 {
     set_path_external_float32_vector(path,data);
 }
@@ -6592,7 +6592,7 @@ Node::set_path_external(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external_float64_vector(const std::string &path,
-                                       std::vector<float64> &data)
+                                       const std::vector<float64> &data)
 {
     fetch(path).set_external_float64_vector(data);
 }
@@ -6600,7 +6600,7 @@ Node::set_path_external_float64_vector(const std::string &path,
 //---------------------------------------------------------------------------//
 void
 Node::set_path_external(const std::string &path,
-                        std::vector<float64> &data)
+                        const std::vector<float64> &data)
 {
     set_path_external_float64_vector(path,data);
 }
@@ -6804,7 +6804,7 @@ Node::operator=(const Schema &schema)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(int8 data)
+Node::operator=(const int8 data)
 {
     set(data);
     return *this;
@@ -6812,7 +6812,7 @@ Node::operator=(int8 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(int16 data)
+Node::operator=(const int16 data)
 {
     set(data);
     return *this;
@@ -6820,7 +6820,7 @@ Node::operator=(int16 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(int32 data)
+Node::operator=(const int32 data)
 {
     set(data);
     return *this;
@@ -6828,7 +6828,7 @@ Node::operator=(int32 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(int64 data)
+Node::operator=(const int64 data)
 {
     set(data);
     return *this;
@@ -6841,7 +6841,7 @@ Node::operator=(int64 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(uint8 data)
+Node::operator=(const uint8 data)
 {
     set(data);
     return *this;
@@ -6849,7 +6849,7 @@ Node::operator=(uint8 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(uint16 data)
+Node::operator=(const uint16 data)
 {
     set(data);
     return *this;
@@ -6857,7 +6857,7 @@ Node::operator=(uint16 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(uint32 data)
+Node::operator=(const uint32 data)
 {
     set(data);
     return *this;
@@ -6865,7 +6865,7 @@ Node::operator=(uint32 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(uint64 data)
+Node::operator=(const uint64 data)
 {
     set(data);
     return *this;
@@ -6877,7 +6877,7 @@ Node::operator=(uint64 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(float32 data)
+Node::operator=(const float32 data)
 {
     set(data);
     return *this;
@@ -6885,7 +6885,7 @@ Node::operator=(float32 data)
 
 //---------------------------------------------------------------------------//
 Node &
-Node::operator=(float64 data)
+Node::operator=(const float64 data)
 {
     set(data);
     return *this;
@@ -6897,7 +6897,7 @@ Node::operator=(float64 data)
 
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(char data)
+Node::operator=(const char data)
 {
     set(data);
     return *this;
@@ -6907,7 +6907,7 @@ Node::operator=(char data)
 #ifndef CONDUIT_USE_CHAR
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(signed char data)
+Node::operator=(const signed char data)
 {
     set(data);
     return *this;
@@ -6929,7 +6929,7 @@ Node::operator=(unsigned char data)
 #ifndef CONDUIT_USE_SHORT
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(short data)
+Node::operator=(const short data)
 {
     set(data);
     return *this;
@@ -6937,7 +6937,7 @@ Node::operator=(short data)
 
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(unsigned short data)
+Node::operator=(const unsigned short data)
 {
     set(data);
     return *this;
@@ -6950,7 +6950,7 @@ Node::operator=(unsigned short data)
 #ifndef CONDUIT_USE_INT
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(int data)
+Node::operator=(const int data)
 {
     set(data);
     return *this;
@@ -6958,7 +6958,7 @@ Node::operator=(int data)
 
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(unsigned int data)
+Node::operator=(const unsigned int data)
 {
     set(data);
     return *this;
@@ -6971,7 +6971,7 @@ Node::operator=(unsigned int data)
 #ifndef CONDUIT_USE_LONG
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(long data)
+Node::operator=(const long data)
 {
     set(data);
     return *this;
@@ -6979,7 +6979,7 @@ Node::operator=(long data)
 
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(unsigned long data)
+Node::operator=(const unsigned long data)
 {
     set(data);
     return *this;
@@ -6992,7 +6992,7 @@ Node::operator=(unsigned long data)
 #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(long long data)
+Node::operator=(const long long data)
 {
     set(data);
     return *this;
@@ -7000,7 +7000,7 @@ Node::operator=(long long data)
 
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(unsigned long long data)
+Node::operator=(const unsigned long long data)
 {
     set(data);
     return *this;
@@ -7013,7 +7013,7 @@ Node::operator=(unsigned long long data)
 #ifndef CONDUIT_USE_FLOAT
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(float data)
+Node::operator=(const float data)
 {
     set(data);
     return *this;
@@ -7026,7 +7026,7 @@ Node::operator=(float data)
 #ifndef CONDUIT_USE_DOUBLE
 //-----------------------------------------------------------------------------
 Node &
-Node::operator=(double data)
+Node::operator=(const double data)
 {
     set(data);
     return *this;
@@ -7552,7 +7552,7 @@ Node::operator=(const std::vector<double> &data)
 
 //---------------------------------------------------------------------------//
 void
-Node::serialize(std::vector<uint8> &data) const
+Node::serialize(const std::vector<uint8> &data) const
 {
     data = std::vector<uint8>((size_t)total_bytes_compact(),0);
     serialize(&data[0],0);
@@ -14486,7 +14486,7 @@ Node::set_schema_ptr(Schema *schema_ptr)
 
 //---------------------------------------------------------------------------//
 void
-Node::set_data_ptr(void *data)
+Node::set_data_ptr(const void *data)
 {
     /// TODO: We need to audit where we actually need release
     //release();
@@ -14901,7 +14901,7 @@ Node::identify_protocol(const std::string &path,
 void 
 Node::walk_schema(Node   *node, 
                   Schema *schema,
-                  void   *data)
+                  const void   *data)
 {
     // we can have an object, list, or leaf
     node->set_data_ptr(data);

--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -153,19 +153,19 @@ public:
     /// in these methods the `external` param controls if we use copy or
     /// external semantics.
     Node(const Generator &gen,
-         bool external);
+         const bool external);
 
     Node(const std::string &json_schema,
-         void *data,
-         bool external);
+         const void *data,
+         const bool external);
    
     Node(const Schema &schema,
-         void *data,
-         bool external);
+         const void *data,
+         const bool external);
 
     Node(const DataType &dtype,
-         void *data,
-         bool external);
+         const void *data,
+         const bool external);
 
 //-----------------------------------------------------------------------------
 ///@}
@@ -220,11 +220,11 @@ public:
 //-----------------------------------------------------------------------------
     void generate(const std::string &schema,
                   const std::string &protocol = std::string("conduit_json"),
-                  void *data = NULL);
+                  const void *data = NULL);
 
     void generate_external(const std::string &schema,
                            const std::string &protocol,
-                           void *data);
+                           const void *data);
 
 //-----------------------------------------------------------------------------
 ///@}
@@ -292,47 +292,47 @@ public:
     void set_schema(const Schema &schema);    
     void set(const Schema &schema);
 
-    void set_data_using_schema(const Schema &schema, void *data);
-    void set(const Schema &schema, void *data);
+    void set_data_using_schema(const Schema &schema, const void *data);
+    void set(const Schema &schema, const void *data);
 
-    void set_data_using_dtype(const DataType &dtype, void *data);
-    void set(const DataType &dtype, void *data);
+    void set_data_using_dtype(const DataType &dtype, const void *data);
+    void set(const DataType &dtype, const void *data);
 
 //-----------------------------------------------------------------------------
 // -- set for bitwidth style scalar types ---
 //-----------------------------------------------------------------------------
     // signed integer scalar types
-    void set_int8(int8 data);
-    void set(int8 data);
+    void set_int8(const int8 data);
+    void set(const int8 data);
 
-    void set_int16(int16 data);
-    void set(int16 data);
+    void set_int16(const int16 data);
+    void set(const int16 data);
     
-    void set_int32(int32 data);
-    void set(int32 data);
+    void set_int32(const int32 data);
+    void set(const int32 data);
     
-    void set_int64(int64 data);
-    void set(int64 data);
+    void set_int64(const int64 data);
+    void set(const int64 data);
 
     // unsigned integer scalar types
-    void set_uint8(uint8 data);
-    void set(uint8 data);
+    void set_uint8(const uint8 data);
+    void set(const uint8 data);
     
-    void set_uint16(uint16 data);
-    void set(uint16 data);
+    void set_uint16(const uint16 data);
+    void set(const uint16 data);
 
-    void set_uint32(uint32 data);
-    void set(uint32 data);
+    void set_uint32(const uint32 data);
+    void set(const uint32 data);
     
-    void set_uint64(uint64 data);
-    void set(uint64 data);
+    void set_uint64(const uint64 data);
+    void set(const uint64 data);
 
     // floating point scalar types
-    void set_float32(float32 data);
-    void set(float32 data);
+    void set_float32(const float32 data);
+    void set(const float32 data);
     
-    void set_float64(float64 data);
-    void set(float64 data);
+    void set_float64(const float64 data);
+    void set(const float64 data);
 
 //-----------------------------------------------------------------------------
 //  set scalar gap methods for c-native types
@@ -349,39 +349,39 @@ public:
 //  selected as int32, Visual Studio needs an explicit method to disambiguate 
 //  the long case.
 //-----------------------------------------------------------------------------
-    void set(char data);
+    void set(const char data);
 
     #ifndef CONDUIT_USE_CHAR
-        void set(signed char data);
-        void set(unsigned char data);
+        void set(const signed char data);
+        void set(const unsigned char data);
     #endif
 
     #ifndef CONDUIT_USE_SHORT
-        void set(short data);
-        void set(unsigned short data);
+        void set(const short data);
+        void set(const unsigned short data);
     #endif
 
     #ifndef CONDUIT_USE_INT
-        void set(int data);
-        void set(unsigned int data);
+        void set(const int data);
+        void set(const unsigned int data);
     #endif
 
     #ifndef CONDUIT_USE_LONG
-        void set(long data);
-        void set(unsigned long data);
+        void set(const long data);
+        void set(const unsigned long data);
     #endif
 
 #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
-        void set(long long data);
-        void set(unsigned long long data);
+        void set(const long long data);
+        void set(const unsigned long long data);
 #endif
 
     #ifndef CONDUIT_USE_FLOAT
-        void set(float data);
+        void set(const float data);
     #endif
 
     #ifndef CONDUIT_USE_DOUBLE
-        void set(double data);
+        void set(const double data);
     #endif
 
 
@@ -879,20 +879,20 @@ public:
     //-------------------------------------------------------------------------
     void set_path_data_using_schema(const std::string &path,
                                     const Schema &schema,
-                                    void *data);              
+                                    const void *data);              
 
     void set_path(const std::string &path,
                   const Schema &schema,
-                  void *data);
+                  const void *data);
 
     //-------------------------------------------------------------------------
     void set_path_data_using_dtype(const std::string &path,
                                    const DataType &dtype,
-                                   void *data);
+                                   const void *data);
 
     void set_path(const std::string &path,
                   const DataType &dtype,
-                  void *data);
+                  const void *data);
 
 //-----------------------------------------------------------------------------
 // -- set_path for bitwidth style scalar types ---
@@ -1585,17 +1585,17 @@ public:
 
     //-------------------------------------------------------------------------
     void set_external_data_using_schema(const Schema &schema,
-                                        void *data);
+                                        const void *data);
 
     void set_external(const Schema &schema,
-                      void *data);
+                      const void *data);
 
     //-------------------------------------------------------------------------
     void set_external_data_using_dtype(const DataType &dtype,
-                                       void *data);
+                                       const void *data);
 
     void set_external(const DataType &dtype,
-                      void *data);
+                      const void *data);
 
 //-----------------------------------------------------------------------------
 // -- set_external via bitwidth style pointers (scalar and array types) -- 
@@ -1603,14 +1603,14 @@ public:
     //-------------------------------------------------------------------------
     // signed integer pointer cases
     //-------------------------------------------------------------------------
-    void set_external_int8_ptr(int8  *data,
+    void set_external_int8_ptr(const int8  *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(conduit::int8),
                                index_t element_bytes = sizeof(conduit::int8),
                                index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(int8  *data,
+    void set_external(const int8  *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::int8),
@@ -1618,14 +1618,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
     
     //-------------------------------------------------------------------------
-    void set_external_int16_ptr(int16 *data, 
+    void set_external_int16_ptr(const int16 *data,
                                 index_t num_elements = 1,
                                 index_t offset = 0,
                                 index_t stride = sizeof(conduit::int16),
                                 index_t element_bytes = sizeof(conduit::int16),
                                 index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(int16 *data, 
+    void set_external(const int16 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::int16),
@@ -1633,14 +1633,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
     
     //-------------------------------------------------------------------------
-    void set_external_int32_ptr(int32 *data,
+    void set_external_int32_ptr(const int32 *data,
                                 index_t num_elements = 1,
                                 index_t offset = 0,
                                 index_t stride = sizeof(conduit::int32),
                                 index_t element_bytes = sizeof(conduit::int32),
                                 index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(int32 *data,
+    void set_external(const int32 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::int32),
@@ -1648,14 +1648,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
     
     //-------------------------------------------------------------------------
-    void set_external_int64_ptr(int64 *data,
+    void set_external_int64_ptr(const int64 *data,
                                 index_t num_elements = 1,
                                 index_t offset = 0,
                                 index_t stride = sizeof(conduit::int64),
                                 index_t element_bytes = sizeof(conduit::int64),
                                 index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(int64 *data,
+    void set_external(const int64 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::int64),
@@ -1665,14 +1665,14 @@ public:
     //-------------------------------------------------------------------------
     // unsigned integer pointer cases
     //-------------------------------------------------------------------------
-    void set_external_uint8_ptr(uint8  *data,
+    void set_external_uint8_ptr(const uint8  *data,
                                 index_t num_elements = 1,
                                 index_t offset = 0,
                                 index_t stride = sizeof(conduit::uint8),
                                 index_t element_bytes = sizeof(conduit::uint8),
                                 index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(uint8  *data,
+    void set_external(const uint8  *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::uint8),
@@ -1680,14 +1680,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
 
     //-------------------------------------------------------------------------
-    void set_external_uint16_ptr(uint16 *data,
+    void set_external_uint16_ptr(const uint16 *data,
                                  index_t num_elements = 1,
                                  index_t offset = 0,
                                  index_t stride = sizeof(conduit::uint16),
                                  index_t element_bytes = sizeof(conduit::uint16),
                                  index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(uint16 *data,
+    void set_external(const uint16 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::uint16),
@@ -1695,14 +1695,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
 
     //-------------------------------------------------------------------------
-    void set_external_uint32_ptr(uint32 *data, 
+    void set_external_uint32_ptr(const uint32 *data, 
                                  index_t num_elements = 1,
                                  index_t offset = 0,
                                  index_t stride = sizeof(conduit::uint32),
                                  index_t element_bytes = sizeof(conduit::uint32),
                                  index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(uint32 *data, 
+    void set_external(const uint32 *data, 
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::uint32),
@@ -1710,14 +1710,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
                       
     //-------------------------------------------------------------------------
-    void set_external_uint64_ptr(uint64 *data,
+    void set_external_uint64_ptr(const uint64 *data,
                                  index_t num_elements = 1,
                                  index_t offset = 0,
                                  index_t stride = sizeof(conduit::uint64),
                                  index_t element_bytes = sizeof(conduit::uint64),
                                  index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(uint64 *data,
+    void set_external(const uint64 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::uint64),
@@ -1727,14 +1727,14 @@ public:
     //-------------------------------------------------------------------------
     // floating point pointer cases
     //-------------------------------------------------------------------------
-    void set_external_float32_ptr(float32 *data,
+    void set_external_float32_ptr(const float32 *data,
                                   index_t num_elements = 1,
                                   index_t offset = 0,
                                   index_t stride = sizeof(conduit::float32),
                                   index_t element_bytes = sizeof(conduit::float32),
                                   index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(float32 *data,
+    void set_external(const float32 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::float32),
@@ -1742,14 +1742,14 @@ public:
                       index_t endianness = Endianness::DEFAULT_ID);
 
     //-------------------------------------------------------------------------
-    void set_external_float64_ptr(float64 *data, 
+    void set_external_float64_ptr(const float64 *data,
                                   index_t num_elements = 1,
                                   index_t offset = 0,
                                   index_t stride = sizeof(conduit::float64),
                                   index_t element_bytes = sizeof(conduit::float64),
                                   index_t endianness = Endianness::DEFAULT_ID);
 
-    void set_external(float64 *data, 
+    void set_external(const float64 *data,
                       index_t num_elements = 1,
                       index_t offset = 0,
                       index_t stride = sizeof(conduit::float64),
@@ -1759,7 +1759,7 @@ public:
 //-----------------------------------------------------------------------------
 //  set via pointer gap methods for c-native types
 //-----------------------------------------------------------------------------
-    void set_external_char_ptr(char *data,
+    void set_external_char_ptr(const char *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_CHAR),
@@ -1767,14 +1767,14 @@ public:
                                index_t endianness = Endianness::DEFAULT_ID);
 
     #ifndef CONDUIT_USE_CHAR
-        void set_external(signed char *data,
+        void set_external(const signed char *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_SIGNED_CHAR),
                           index_t element_bytes = sizeof(CONDUIT_NATIVE_SIGNED_CHAR),
                           index_t endianness = Endianness::DEFAULT_ID);
 
-        void set_external(unsigned char *data,
+        void set_external(const unsigned char *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_CHAR),
@@ -1783,14 +1783,14 @@ public:
     #endif
 
     #ifndef CONDUIT_USE_SHORT
-        void set_external(short *data,
+        void set_external(const short *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_SHORT),
                           index_t element_bytes = sizeof(CONDUIT_NATIVE_SHORT),
                           index_t endianness = Endianness::DEFAULT_ID);
 
-        void set_external(unsigned short *data,
+        void set_external(const unsigned short *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_SHORT),
@@ -1799,14 +1799,14 @@ public:
     #endif
 
     #ifndef CONDUIT_USE_INT
-        void set_external(int *data,
+        void set_external(const int *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_INT),
                           index_t element_bytes = sizeof(CONDUIT_NATIVE_INT),
                           index_t endianness = Endianness::DEFAULT_ID);
 
-        void set_external(unsigned int *data,
+        void set_external(const unsigned int *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_INT),
@@ -1815,14 +1815,14 @@ public:
     #endif
 
     #ifndef CONDUIT_USE_LONG
-        void set_external(long *data,
+        void set_external(const long *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_LONG),
                           index_t element_bytes = sizeof(CONDUIT_NATIVE_LONG),
                           index_t endianness = Endianness::DEFAULT_ID);
 
-        void set_external(unsigned long *data,
+        void set_external(const unsigned long *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_LONG),
@@ -1831,14 +1831,14 @@ public:
     #endif
 
     #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
-        void set_external(long long *data,
+        void set_external(const long long *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_LONG_LONG),
                           index_t element_bytes = sizeof(CONDUIT_NATIVE_LONG_LONG),
                           index_t endianness = Endianness::DEFAULT_ID);
 
-        void set_external(unsigned long long *data,
+        void set_external(const unsigned long long *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_LONG_LONG),
@@ -1847,7 +1847,7 @@ public:
     #endif
 
     #ifndef CONDUIT_USE_FLOAT
-        void set_external(float *data,
+        void set_external(const float *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_FLOAT),
@@ -1856,7 +1856,7 @@ public:
     #endif
 
     #ifndef CONDUIT_USE_DOUBLE
-        void set_external(double *data,
+        void set_external(const double *data,
                           index_t num_elements = 1,
                           index_t offset = 0,
                           index_t stride = sizeof(CONDUIT_NATIVE_DOUBLE),
@@ -1957,7 +1957,7 @@ public:
 //-----------------------------------------------------------------------------
 // -- set_external for string types ---
 //-----------------------------------------------------------------------------
-    void set_external_char8_str(char *data);
+    void set_external_char8_str(const char *data);
 
 //-----------------------------------------------------------------------------
 // -- set_external for bitwidth style std::vector types ---
@@ -1966,48 +1966,48 @@ public:
     //-------------------------------------------------------------------------
     // signed integer array types via std::vector
     //-------------------------------------------------------------------------
-    void set_external_int8_vector(std::vector<int8> &data);
-    void set_external(std::vector<int8> &data);
+    void set_external_int8_vector(const std::vector<int8> &data);
+    void set_external(const std::vector<int8> &data);
 
     //-------------------------------------------------------------------------
-    void set_external_int16_vector(std::vector<int16> &data);
-    void set_external(std::vector<int16> &data);
+    void set_external_int16_vector(const std::vector<int16> &data);
+    void set_external(const std::vector<int16> &data);
 
     //-------------------------------------------------------------------------
-    void set_external_int32_vector(std::vector<int32> &data);
-    void set_external(std::vector<int32> &data);
+    void set_external_int32_vector(const std::vector<int32> &data);
+    void set_external(const std::vector<int32> &data);
     
     //-------------------------------------------------------------------------
-    void set_external_int64_vector(std::vector<int64> &data);
-    void set_external(std::vector<int64> &data);
+    void set_external_int64_vector(const std::vector<int64> &data);
+    void set_external(const std::vector<int64> &data);
 
     //-------------------------------------------------------------------------
     // unsigned integer array types via std::vector
     //-------------------------------------------------------------------------
-    void set_external_uint8_vector(std::vector<uint8> &data);
-    void set_external(std::vector<uint8> &data);
+    void set_external_uint8_vector(const std::vector<uint8> &data);
+    void set_external(const std::vector<uint8> &data);
     
     //-------------------------------------------------------------------------
-    void set_external_uint16_vector(std::vector<uint16> &data);
-    void set_external(std::vector<uint16> &data);
+    void set_external_uint16_vector(const std::vector<uint16> &data);
+    void set_external(const std::vector<uint16> &data);
     
     //-------------------------------------------------------------------------
-    void set_external_uint32_vector(std::vector<uint32> &data);
-    void set_external(std::vector<uint32> &data);
+    void set_external_uint32_vector(const std::vector<uint32> &data);
+    void set_external(const std::vector<uint32> &data);
     
     //-------------------------------------------------------------------------
-    void set_external_uint64_vector(std::vector<uint64> &data);
-    void set_external(std::vector<uint64> &data);
+    void set_external_uint64_vector(const std::vector<uint64> &data);
+    void set_external(const std::vector<uint64> &data);
 
     //-------------------------------------------------------------------------
     // floating point array types via std::vector
     //-------------------------------------------------------------------------
-    void set_external_float32_vector(std::vector<float32> &data);
-    void set_external(std::vector<float32> &data);
+    void set_external_float32_vector(const std::vector<float32> &data);
+    void set_external(const std::vector<float32> &data);
 
     //-------------------------------------------------------------------------
-    void set_external_float64_vector(std::vector<float64> &data);
-    void set_external(std::vector<float64> &data);
+    void set_external_float64_vector(const std::vector<float64> &data);
+    void set_external(const std::vector<float64> &data);
 
 //-----------------------------------------------------------------------------
 //  set_external vector gap methods for c-native types
@@ -2105,7 +2105,7 @@ public:
     // signed integer pointer cases
     //-------------------------------------------------------------------------
     void set_path_external_int8_ptr(const std::string &path,
-                                    int8 *data,
+                                    const int8 *data,
                                     index_t num_elements = 1,
                                     index_t offset = 0,
                                     index_t stride = sizeof(conduit::int8),
@@ -2113,7 +2113,7 @@ public:
                                     index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           int8 *data,
+                           const int8 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::int8),
@@ -2122,7 +2122,7 @@ public:
 
     //-------------------------------------------------------------------------
     void set_path_external_int16_ptr(const std::string &path,
-                                     int16 *data, 
+                                     const int16 *data,
                                      index_t num_elements = 1,
                                      index_t offset = 0,
                                      index_t stride = sizeof(conduit::int16),
@@ -2131,7 +2131,7 @@ public:
 
 
     void set_path_external(const std::string &path,
-                           int16 *data, 
+                           const int16 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::int16),
@@ -2140,7 +2140,7 @@ public:
  
     //-------------------------------------------------------------------------
     void set_path_external_int32_ptr(const std::string &path,
-                                     int32 *data,
+                                     const int32 *data,
                                      index_t num_elements = 1,
                                      index_t offset = 0,
                                      index_t stride = sizeof(conduit::int32),
@@ -2148,7 +2148,7 @@ public:
                                      index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           int32 *data,
+                           const int32 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::int32),
@@ -2157,7 +2157,7 @@ public:
 
     //-------------------------------------------------------------------------
     void set_path_external_int64_ptr(const std::string &path,
-                                     int64 *data,
+                                     const int64 *data,
                                      index_t num_elements = 1,
                                      index_t offset = 0,
                                      index_t stride = sizeof(conduit::int64),
@@ -2165,7 +2165,7 @@ public:
                                      index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           int64 *data,
+                           const int64 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::int64),
@@ -2176,7 +2176,7 @@ public:
     // unsigned integer pointer cases
     //-------------------------------------------------------------------------
     void set_path_external_uint8_ptr(const std::string &path,
-                                     uint8  *data,
+                                     const uint8  *data,
                                      index_t num_elements = 1,
                                      index_t offset = 0,
                                      index_t stride = sizeof(conduit::uint8),
@@ -2184,7 +2184,7 @@ public:
                                      index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           uint8  *data,
+                           const uint8  *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::uint8),
@@ -2193,7 +2193,7 @@ public:
 
     //-------------------------------------------------------------------------
     void set_path_external_uint16_ptr(const std::string &path,
-                                      uint16 *data,
+                                      const uint16 *data,
                                       index_t num_elements = 1,
                                       index_t offset = 0,
                                       index_t stride = sizeof(conduit::uint16),
@@ -2201,7 +2201,7 @@ public:
                                       index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           uint16 *data,
+                           const uint16 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::uint16),
@@ -2210,7 +2210,7 @@ public:
 
     //-------------------------------------------------------------------------
     void set_path_external_uint32_ptr(const std::string &path,
-                                      uint32 *data, 
+                                      const uint32 *data,
                                       index_t num_elements = 1,
                                       index_t offset = 0,
                                       index_t stride = sizeof(conduit::uint32),
@@ -2218,7 +2218,7 @@ public:
                                       index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           uint32 *data, 
+                           const uint32 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::uint32),
@@ -2227,7 +2227,7 @@ public:
 
     //-------------------------------------------------------------------------
     void set_path_external_uint64_ptr(const std::string &path,
-                                      uint64 *data,
+                                      const uint64 *data,
                                       index_t num_elements = 1,
                                       index_t offset = 0,
                                       index_t stride = sizeof(conduit::uint64),
@@ -2235,7 +2235,7 @@ public:
                                       index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           uint64 *data,
+                           const uint64 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::uint64),
@@ -2246,7 +2246,7 @@ public:
     // floating point pointer cases
     //-------------------------------------------------------------------------
     void set_path_external_float32_ptr(const std::string &path,
-                                       float32 *data,
+                                       const float32 *data,
                                        index_t num_elements = 1,
                                        index_t offset = 0,
                                        index_t stride = sizeof(conduit::float32),
@@ -2254,7 +2254,7 @@ public:
                                        index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           float32 *data,
+                           const float32 *data,
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::float32),
@@ -2263,7 +2263,7 @@ public:
 
     //-------------------------------------------------------------------------
     void set_path_external_float64_ptr(const std::string &path,
-                                       float64 *data, 
+                                       const float64 *data, 
                                        index_t num_elements = 1,
                                        index_t offset = 0,
                                        index_t stride = sizeof(conduit::float64),
@@ -2271,7 +2271,7 @@ public:
                                        index_t endianness = Endianness::DEFAULT_ID);
 
     void set_path_external(const std::string &path,
-                           float64 *data, 
+                           const float64 *data, 
                            index_t num_elements = 1,
                            index_t offset = 0,
                            index_t stride = sizeof(conduit::float64),
@@ -2282,7 +2282,7 @@ public:
 //  set via pointer gap methods for c-native types
 //-----------------------------------------------------------------------------
     void set_path_external_char_ptr(const std::string &path,
-                                    char *data,
+                                    const char *data,
                                     index_t num_elements = 1,
                                     index_t offset = 0,
                                     index_t stride = sizeof(CONDUIT_NATIVE_CHAR),
@@ -2291,7 +2291,7 @@ public:
 
     #ifndef CONDUIT_USE_CHAR
         void set_path_external(const std::string &path,
-                               signed char *data,
+                               const signed char *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_SIGNED_CHAR),
@@ -2299,7 +2299,7 @@ public:
                                index_t endianness = Endianness::DEFAULT_ID);
 
         void set_path_external(const std::string &path,
-                               unsigned char *data,
+                               const unsigned char *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_CHAR),
@@ -2309,7 +2309,7 @@ public:
 
     #ifndef CONDUIT_USE_SHORT
         void set_path_external(const std::string &path,
-                               short *data,
+                               const short *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_SHORT),
@@ -2317,7 +2317,7 @@ public:
                                index_t endianness = Endianness::DEFAULT_ID);
 
         void set_path_external(const std::string &path,
-                               unsigned short *data,
+                               const unsigned short *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_SHORT),
@@ -2327,7 +2327,7 @@ public:
 
     #ifndef CONDUIT_USE_INT
         void set_path_external(const std::string &path,
-                               int *data,
+                               const int *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_INT),
@@ -2335,7 +2335,7 @@ public:
                                index_t endianness = Endianness::DEFAULT_ID);
 
         void set_path_external(const std::string &path,
-                               unsigned int *data,
+                               const unsigned int *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_INT),
@@ -2345,7 +2345,7 @@ public:
 
     #ifndef CONDUIT_USE_LONG
         void set_path_external(const std::string &path,
-                               long *data,
+                               const long *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_LONG),
@@ -2353,7 +2353,7 @@ public:
                                index_t endianness = Endianness::DEFAULT_ID);
 
         void set_path_external(const std::string &path,
-                               unsigned long *data,
+                               const unsigned long *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_LONG),
@@ -2363,7 +2363,7 @@ public:
    
     #if defined(CONDUIT_HAS_LONG_LONG) && !defined(CONDUIT_USE_LONG_LONG)
         void set_path_external(const std::string &path,
-                               long long *data,
+                               const long long *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_LONG_LONG),
@@ -2371,7 +2371,7 @@ public:
                                index_t endianness = Endianness::DEFAULT_ID);
 
         void set_path_external(const std::string &path,
-                               unsigned long long *data,
+                               const unsigned long long *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_UNSIGNED_LONG_LONG),
@@ -2381,7 +2381,7 @@ public:
   
     #ifndef CONDUIT_USE_FLOAT
         void set_path_external(const std::string &path,
-                               float *data,
+                               const float *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_FLOAT),
@@ -2391,7 +2391,7 @@ public:
 
     #ifndef CONDUIT_USE_DOUBLE
         void set_path_external(const std::string &path,
-                               double *data,
+                               const double *data,
                                index_t num_elements = 1,
                                index_t offset = 0,
                                index_t stride = sizeof(CONDUIT_NATIVE_DOUBLE),
@@ -2541,7 +2541,7 @@ public:
 //-----------------------------------------------------------------------------
 // -- set_external for string types ---
 //-----------------------------------------------------------------------------
-    void set_path_external_char8_str(const std::string &path, char *data);
+    void set_path_external_char8_str(const std::string &path, const char *data);
 
 //-----------------------------------------------------------------------------
 // -- set_path_external for bitwidth style std::vector types ---
@@ -2551,77 +2551,77 @@ public:
     // signed integer array types via std::vector
     //-------------------------------------------------------------------------
     void set_path_external_int8_vector(const std::string &path,
-                                       std::vector<int8> &data);
+                                       const std::vector<int8> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<int8> &data);
+                           const std::vector<int8> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_int16_vector(const std::string &path,
-                                        std::vector<int16> &data);
+                                        const std::vector<int16> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<int16> &data);
+                           const std::vector<int16> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_int32_vector(const std::string &path,
-                                        std::vector<int32> &data);
+                                        const std::vector<int32> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<int32> &data);
+                           const std::vector<int32> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_int64_vector(const std::string &path,
-                                        std::vector<int64> &data);
+                                        const std::vector<int64> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<int64> &data);
+                           const std::vector<int64> &data);
 
     //-------------------------------------------------------------------------
     // unsigned integer array types via std::vector
     //-------------------------------------------------------------------------
     void set_path_external_uint8_vector(const std::string &path,
-                                        std::vector<uint8> &data);
+                                        const std::vector<uint8> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<uint8> &data);
+                           const std::vector<uint8> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_uint16_vector(const std::string &path,
-                                         std::vector<uint16> &data);
+                                         const std::vector<uint16> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<uint16> &data);
+                           const std::vector<uint16> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_uint32_vector(const std::string &path,
-                                         std::vector<uint32> &data);
+                                         const std::vector<uint32> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<uint32> &data);
+                           const std::vector<uint32> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_uint64_vector(const std::string &path,
-                                         std::vector<uint64> &data);
+                                         const std::vector<uint64> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<uint64> &data);
+                           const std::vector<uint64> &data);
 
     //-------------------------------------------------------------------------
     // floating point array types via std::vector
     //-------------------------------------------------------------------------
     void set_path_external_float32_vector(const std::string &path,
-                                          std::vector<float32> &data);
+                                          const std::vector<float32> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<float32> &data);
+                           const std::vector<float32> &data);
 
     //-------------------------------------------------------------------------
     void set_path_external_float64_vector(const std::string &path,
-                                          std::vector<float64> &data);
+                                          const std::vector<float64> &data);
 
     void set_path_external(const std::string &path,
-                           std::vector<float64> &data);
+                           const std::vector<float64> &data);
 
 //-----------------------------------------------------------------------------
 //  set_path_external vector gap methods for c-native types
@@ -3809,10 +3809,10 @@ public:
     index_t          mmaped_bytes() const
                         {return m_mmaped ? m_data_size : 0;}
 
-    void  *element_ptr(index_t idx)
-        {return static_cast<char*>(m_data) + dtype().element_index(idx);};
+    const void  *element_ptr(index_t idx)
+        {return static_cast<const char*>(m_data) + dtype().element_index(idx);};
     const void  *element_ptr(index_t idx) const 
-        {return static_cast<char*>(m_data) + dtype().element_index(idx);};
+        {return static_cast<const char*>(m_data) + dtype().element_index(idx);};
 
 //-----------------------------------------------------------------------------
 /// description:
@@ -4032,7 +4032,7 @@ private:
 /// description:
 /// these methods are used for construction by the Node & Generator classes.
 //-----------------------------------------------------------------------------
-    void             set_data_ptr(void *data_ptr);
+    void             set_data_ptr(const void *data_ptr);
     ///
     /// Note: set_schema_ptr is *only* used in the case were we have 
     /// a schema pointer that is owned by a parent schema. Using it to set a 
@@ -4118,7 +4118,7 @@ private:
     // work horse for complex node hierarchical setup
     static void      walk_schema(Node   *node,
                                  Schema *schema,
-                                 void   *data);
+                                 const void   *data);
 
     static void      mirror_node(Node *node,
                                  Schema *schema,
@@ -4320,7 +4320,7 @@ private:
 
     // TODO: DataContainer?
     // pointer to the node's data
-    void     *m_data;
+    const void           *m_data;
     // size of the allocated or mmaped data point
     index_t   m_data_size;
 


### PR DESCRIPTION
Fix #577: Adds const-correctness to passed pointer data. This is mainly needed since users might pass a `const T*` that cannot be casted to a `T*` (but vice versa is possible). Also expresses actual (read-only) intent in the API :)

While on it, this improves general [const-correctness](https://isocpp.org/wiki/faq/const-correctness) for related overloads of the interface.