### PR TITLE
Fix include on case-sensitive-fs

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -52,7 +52,7 @@
 #define NOMINMAX
 #undef min
 #undef max
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -52,7 +52,7 @@
 #define NOMINMAX
 #undef min
 #undef max
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_julia.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_julia.cpp
@@ -52,7 +52,7 @@
 #define NOMINMAX
 #undef min
 #undef max
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -52,7 +52,7 @@
 #define NOMINMAX
 #undef min
 #undef max
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
+++ b/src/libs/blueprint/conduit_blueprint_o2mrelation_iterator.hpp
@@ -93,7 +93,7 @@ typedef enum
 ///  General purpose iterator for 'o2mrelation' Nodes.
 ///
 //-----------------------------------------------------------------------------
-class CONDUIT_API O2MIterator
+class CONDUIT_BLUEPRINT_API O2MIterator
 {
 public:
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -60,7 +60,7 @@
 #define NOMINMAX
 #undef min
 #undef max
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_utils.cpp
+++ b/src/libs/conduit/conduit_utils.cpp
@@ -57,7 +57,7 @@
 // for sleep funcs
 #if defined(CONDUIT_PLATFORM_WINDOWS)
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 #include <direct.h>
 #if (_MSC_VER && _MSC_VER < 1900)
     #define snprintf _snprintf

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -218,6 +218,9 @@ if(ZFP_FOUND)
     list(APPEND conduit_relay_deps zfp)
 endif()
 
+if (MINGW)
+  list(APPEND conduit_relay_deps ws2_32)
+endif ()
 
 add_compiled_library(NAME conduit_relay
                      EXPORT conduit

--- a/src/tests/blueprint/t_blueprint_mesh_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate.cpp
@@ -52,7 +52,7 @@
 #define NOMINMAX
 #undef min
 #undef max
-#include "Windows.h"
+#include "windows.h"
 #endif
 
 #include "conduit.hpp"

--- a/src/tests/thirdparty/CMakeLists.txt
+++ b/src/tests/thirdparty/CMakeLists.txt
@@ -71,6 +71,10 @@ if(UNIX AND NOT APPLE)
 endif()
 
 
+if (MINGW)
+  list(APPEND civet_test_deps ws2_32)
+endif ()
+
 add_cpp_test(TEST t_civetweb_smoke
              SOURCES $<TARGET_OBJECTS:conduit_civetweb>
              DEPENDS_ON ${civet_test_deps}


### PR DESCRIPTION
It must be lowercase on case-sensitive file-systems, eg when cross compiling