### PR TITLE
Record buffer length needed for face data

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -1201,7 +1201,7 @@ struct TopologyMetadata
                 dim_buffer.insert(dim_buffer.end(), entity_indices.begin(), entity_indices.end());
                 dim_entity_map[entity] = dim_offset++;
 
-                if (dim_shape.is_polygonal())
+                if (dim_shape.dim == 2)
                 {
                   dim_size.push_back(entity.size());
                 }


### PR DESCRIPTION
The blueprint mesh representation uses a helper class, `TopologyMetadata`, to find and record the relations from element to faces and nodes.  There was a test in that computation that was too restrictive, resulting in a segfault in test t_blueprint_mesh_verify when it was compiled Debug on Windows by either MSVC or Intel 19 compilers.