### PR TITLE
has_consistent_validity check fix in t_blueprint_mesh_verify

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -729,7 +729,7 @@ bool verify_poly_node(bool is_mixed_topo,
             elems_res &= subnode_res;
         }
     }
-
+    node_res &= elems_res;
     return node_res;
 }
 


### PR DESCRIPTION
For polygonal topology, propagate `elements` field's `valid` info to parent.

Related to https://github.com/LLNL/conduit/issues/635

The `has_consistent_validity` check (from https://github.com/LLNL/conduit/issues/277 and  https://github.com/LLNL/conduit/pull/283) was failing because the `info` node was inconsistent - topmost `valid` state was `true` despite a subtree (in this case, `elements`) being in a `valid` state of `false`. 