### PR TITLE
fix minor bug in default argument of 'Node::to_string_stream'

### DIFF
--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -3497,7 +3497,7 @@ public:
                                          const std::string &eoe="\n") const;
 
     void                to_string_stream(const std::string &stream_path,
-                                         const std::string &protocol="json",
+                                         const std::string &protocol="yaml",
                                          index_t indent=2, 
                                          index_t depth=0,
                                          const std::string &pad=" ",


### PR DESCRIPTION
The changes in this pull request fix a minor bug wherein `conduit::Node::to_string_stream(const std::string&, ...)` was being output to the JSON format instead of the YAML format by default.