### PR TITLE
fix indentation problems with `to_json("conduit_json", ...)`

### DIFF
--- a/src/libs/conduit/conduit_data_type.cpp
+++ b/src/libs/conduit/conduit_data_type.cpp
@@ -1289,25 +1289,25 @@ DataType::to_json_stream(std::ostream &os,
     os << eoe;
     utils::indent(os,indent,depth,pad);
     os << "{" << eoe;
-    utils::indent(os,indent,depth,pad);
+    utils::indent(os,indent,depth+1,pad);
     os << "\"dtype\":" << "\"" << id_to_name(m_id) << "\"";
 
     if(is_number() || is_string())
     {
         os << "," << eoe;
-        utils::indent(os,indent,depth,pad);
+        utils::indent(os,indent,depth+1,pad);
         os << "\"number_of_elements\": " << m_num_ele;
 
         os << "," << eoe;
-        utils::indent(os,indent,depth,pad);
+        utils::indent(os,indent,depth+1,pad);
         os << "\"offset\": " << m_offset;
 
         os << "," << eoe;
-        utils::indent(os,indent,depth,pad);
+        utils::indent(os,indent,depth+1,pad);
         os << "\"stride\": " << m_stride;
 
         os << "," << eoe;
-        utils::indent(os,indent,depth,pad);
+        utils::indent(os,indent,depth+1,pad);
         os << "\"element_bytes\": " << m_ele_bytes;
 
         std::string endian_str;
@@ -1322,7 +1322,7 @@ DataType::to_json_stream(std::ostream &os,
         }
 
         os << "," << eoe;
-        utils::indent(os,indent,depth,pad);
+        utils::indent(os,indent,depth+1,pad);
         os << "\"endianness\": \"" << endian_str << "\"";
     }
     os << eoe;

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -12262,17 +12262,25 @@ Node::to_json_generic(std::ostream &os,
     {
         if(detailed)
         {
-            std::string dtype_json = dtype().to_json();
-            std::string dtype_open;
-            std::string dtype_rest;
+            std::string dtype_json = dtype().to_json(indent, depth, pad, eoe);
+            std::string dtype_content;
+            std::string dtype_unused;
 
-            // trim the last "}"
+            // trim the last "}" and whitspace
             utils::split_string(dtype_json,
                                 "}",
-                                dtype_open,
-                                dtype_rest);
-            os<< dtype_open;
-            os << ", \"value\": ";
+                                dtype_content,
+                                dtype_unused);
+            dtype_json = dtype_content;
+            utils::rsplit_string(dtype_json,
+                                "\"",
+                                dtype_unused,
+                                dtype_content);
+
+            os << dtype_content;
+            os << "\"," << eoe;
+            utils::indent(os,indent,depth+1,pad);
+            os << "\"value\": ";
         }
 
         switch(dtype().id())
@@ -12326,6 +12334,8 @@ Node::to_json_generic(std::ostream &os,
         if(detailed)
         {
             // complete json entry
+            os << eoe;
+            utils::indent(os,indent,depth,pad);
             os << "}";
         }
     }

--- a/src/tests/conduit/t_conduit_node.cpp
+++ b/src/tests/conduit/t_conduit_node.cpp
@@ -11,6 +11,7 @@
 #include "conduit.hpp"
 
 #include <iostream>
+#include <regex>
 #include "gtest/gtest.h"
 #include "rapidjson/document.h"
 using namespace conduit;
@@ -1143,6 +1144,84 @@ TEST(conduit_node, to_string_and_parse_all_protos)
 
     n2.parse(txt_cases[7],"conduit_base64_json");
     EXPECT_FALSE(n.diff(n2,info));
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_node, to_string_and_indent_check_all_protos)
+{
+    Node n;
+
+    n["a/b/c"] = (int64) 10;
+    n["a/b/d"] = (float64) 42.2;
+    n["a/b/e"] = " string !";
+
+    const std::map<std::string, index_t> schema_key_depths =
+        {{"a", 0}, {"b", 1}, {"c", 2}, {"d", 2}, {"e", 2}};
+
+    std::ostringstream oss;
+
+    std::vector<std::string> txt_cases, txt_types;
+    txt_cases.push_back(n.to_string()); // yaml
+    txt_types.push_back("yaml");
+    txt_cases.push_back(n.to_string_default()); // yaml
+    txt_types.push_back("yaml");
+
+    n.to_string_stream(oss);
+    txt_cases.push_back(oss.str()); // yaml
+    txt_types.push_back("yaml");
+
+    txt_cases.push_back(n.to_string("yaml"));
+    txt_types.push_back("yaml");
+
+    oss.str("");
+    n.to_string_stream(oss,"json");
+    txt_cases.push_back(oss.str()); // json
+    txt_types.push_back("json");
+
+    txt_cases.push_back(n.to_string("json"));
+    txt_types.push_back("json");
+    txt_cases.push_back(n.to_string("conduit_json"));
+    txt_types.push_back("json");
+    // TODO: Eventually should test this case, but it's too different at present.
+    // txt_cases.push_back(n.to_string("conduit_base64_json"));
+    // txt_types.push_back("json");
+
+    for(index_t ti = 0; ti < (index_t)txt_cases.size(); ti++)
+    {
+        const std::string& txt_case = txt_cases[ti];
+        const std::string& txt_type = txt_types[ti];
+
+        for(const auto& key_pair : schema_key_depths)
+        {
+            const std::string& key_string = key_pair.first;
+            const index_t key_depth = key_pair.second + ((txt_type == "json") ? 1 : 0);
+
+            std::regex key_regex;
+            {
+                std::ostringstream oss;
+                oss << "([ ]*)(";
+                if(txt_type == "json")
+                {
+                    oss << "\"";
+                }
+                oss << key_string;
+                if(txt_type == "json")
+                {
+                    oss << "\"";
+                }
+                oss << "):\s*";
+                key_regex = std::regex(oss.str());
+            }
+
+            std::smatch key_match;
+            ASSERT_TRUE(std::regex_search(txt_case, key_match, key_regex));
+
+            const std::string schema_padding = key_match[1].str();
+            const std::string expected_padding(2 * key_depth, ' ');
+            ASSERT_EQ(schema_padding, expected_padding);
+        }
+    }
 }
 
 


### PR DESCRIPTION
The changes in this pull request address an issue that was causing indentation problems in the outputs of `conduit::Node::to_json("conduit_json", ...)`. The pre-fix and post-fix outputs are detailed below. This pull request also includes a new regression test to validate proper indentation levels for the outputs of the `conduit::Node::to_*` functions.

#### Pre-Fix Output ####

```
{
  "a":
  {
    "dtype":
{
"dtype":"char8_str",
"number_of_elements": 6,
"offset": 0,
"stride": 1,
"element_bytes": 1,
"endianness": "little"
, "value": "int32"},
...
```

#### Post-Fix Output ####

```
{
  "a":
  {
    "dtype":
    {
      "dtype":"char8_str",
      "number_of_elements": 6,
      "offset": 0,
      "stride": 1,
      "element_bytes": 1,
      "endianness": "little",
      "value": "int32"
    },
...
```