### PR TITLE
clarify `nestsets` documentation to indicate local coordinates requirement

### DIFF
--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -669,18 +669,20 @@ The Blueprint schema for each entry in the ``nestsets`` section matches the foll
 
    .. code:: cpp
 
-       conduit::Node &global_origin = // path to nestset/windows/window/origin
+       // 'window_origin': starts out as a global index, but is transformed into
+       // a domain-local index through this procedure
+       conduit::Node &window_origin = // path to nestset/windows/window/origin
        conduit::Node &topo_origin = // loaded from client code; {i, j, k} structure
 
-       conduit::NodeIterator origin_it = global_origin.children();
+       conduit::NodeIterator origin_it = window_origin.children();
        while(origin_it.has_next())
        {
-           conduit::Node &global_dim = origin_it.next();
+           conduit::Node &window_dim = origin_it.next();
            conduit::Node &topo_dim = topo_origin[origin_it.name()];
 
-           conduit::int64 new_dim_val = global_dim.to_int64() - topo_dim.to_int64();
+           conduit::int64 new_dim_val = window_dim.to_int64() - topo_dim.to_int64();
            conduit::Node &new_dim(conduit::DataType::int64(1), &new_dim_val, true);
-           new_dim.to_data_type(global_dim.dtype().id(), global_dim);
+           new_dim.to_data_type(window_dim.dtype().id(), window_dim);
        }
 
 Each domain that contains a Nesting Sets section must also update its State section to include the domain's global nesting level.

--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -632,14 +632,13 @@ Species Sets
 Species Sets are a means of representing multi-dimensional per-material quantities, most commonly per-material substance fractions.
 
 Individual Species Sets are entries in the ``specsets`` section of the Blueprint hierarchy, and these entries are formatted in much the same way as ``fields`` entries that describe per-material, multi-dimensional fields.
-Just as with this class of ``fields`` entries, each ``specsets`` entry must specify the material set over which it is defined and enumerate its values within an **mcarray** that's organized in material-major and component-minor order.
+Just as with this class of ``fields`` entries, each ``specsets`` entry must specify the material set over which it is defined and enumerate its values within an **mcarray** that's organized first by materials (shallower level of nesting) and then by species components (deeper level of nesting).
 Additionally, like ``field`` entries, each ``specsets`` item must indicate a volumetric scaling type (e.g. volume-dependent, volume-independent).
 To put it in short, each entry in the ``specsets`` section of the Blueprint hierarchy must be an *Object* that follows this template:
 
  * specsets/specset/volume_dependent: "true" | "false"
  * specsets/specset/matset: "matset"
  * specsets/specset/matset_values: (mcarray)
-
 
 
 Nesting Sets
@@ -649,7 +648,7 @@ Nesting Sets are used to represent the nesting relationships between different d
 
 Each entry in the Nesting Sets section contains an independent set of nesting relationships between domains in the described mesh.
 On an individual basis, a nesting set contains a source topology, an element association, and a list of nesting windows.
-The windows for a particular nesting set describe the topological nesting pattern for a paired set of domains, which includes the ID of the partnered domain, the type of the partnered domain (parent or child), and the self-relative origin and dimensions of the nesting relationship.
+The windows for a particular nesting set describe the topological nesting pattern for a paired set of domains, which includes the ID of the partnered domain, the type of the partnered domain (parent or child), the per-dimension zone ratios of this domain relative to the partnered domain, and the self-relative dimensions and origin (provided in terms of local domain coordinates) of the nesting relationship.
 The Blueprint schema for each entry in the ``nestsets`` section matches the following template:
 
    * nestsets/nestset/association: "vertex" | "element"
@@ -659,6 +658,30 @@ The Blueprint schema for each entry in the ``nestsets`` section matches the foll
    * nestsets/nestset/windows/window/ratio/{i, j, k}
    * nestsets/nestset/windows/window/origin/{i, j, k}
    * nestsets/nestset/windows/window/dims/{i, j, k}
+
+.. note::
+   Many structured AMR codes use global coordinate identifiers when specifying
+   each window's ``origin``. Such coordinates must be transformed to domain-local
+   coordinates to be Blueprint-compliant. Given the global structured origin of
+   a window's associated topology ``topo_origin`` (which isn't in the Blueprint,
+   but is likely stored somewhere in the client code), the global origin can be
+   transformed into a local origin like so:
+
+   .. code:: cpp
+
+       conduit::Node &global_origin = // path to nestset/windows/window/origin
+       conduit::Node &topo_origin = // loaded from client code; {i, j, k} structure
+
+       conduit::NodeIterator origin_it = global_origin.children();
+       while(origin_it.has_next())
+       {
+           conduit::Node &global_dim = origin_it.next();
+           conduit::Node &topo_dim = topo_origin[origin_it.name()];
+
+           conduit::int64 new_dim_val = global_dim.to_int64() - topo_dim.to_int64();
+           conduit::Node &new_dim(conduit::DataType::int64(1), &new_dim_val, true);
+           new_dim.to_data_type(global_dim.dtype().id(), global_dim);
+       }
 
 Each domain that contains a Nesting Sets section must also update its State section to include the domain's global nesting level.
 This additional requirement adds the follow constraint to the ``state`` section:


### PR DESCRIPTION
The changes in this pull request clarify the "Nesting Sets" section of the Conduit Blueprint documentation so that it properly indicates that local coordinates as assumed for values provided in window origins (i.e. `nestsets/nestset/windows/window/origin`), addressing #678. This pull request also tidies up some of the language in this section of the documentation.

The following is a preview of the new documentation:

![nestsets_preview](https://user-images.githubusercontent.com/17277866/108435186-cfafc680-71fd-11eb-97b8-ffdec38e67fe.png)