### PR TITLE
update blt and test option for mpi imported targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added several more methods to Python DataType interface
 
 
+### Changed
+
+#### General
+- Updated to newer version of BLT to leverage CMake's FindMPI defined targets when using CMake 3.15 or newer.
+
 
 #### Relay
 - Added Relay HDF5 support for reading and writing to an HDF5 dataset with offset.

--- a/hashes.txt
+++ b/hashes.txt
@@ -1,1 +1,1 @@
-blt  branch='task/2021_04_find_mpi_fixes' commit='46ca290987e99d1b10de272cf9f4110ee8b9565a'
+blt  branch='task/2021_04_find_mpi_fixes' commit='72a26eee41a6b8ab82144cf0c0892a035c06bf95'

--- a/hashes.txt
+++ b/hashes.txt
@@ -1,1 +1,1 @@
-blt  branch='develop' commit='86a7d6b5ee93d8b7b3233a3e54a4f06f8d8308d3'
+blt  branch='task/2021_04_find_mpi_fixes' commit='46ca290987e99d1b10de272cf9f4110ee8b9565a'

--- a/hashes.txt
+++ b/hashes.txt
@@ -1,1 +1,1 @@
-blt  branch='task/2021_04_find_mpi_fixes' commit='72a26eee41a6b8ab82144cf0c0892a035c06bf95'
+blt  branch='develop' commit='68c98b7306e0b1f19cb383ac6af210d6f75627fc'

--- a/src/cmake/SetupBLT.cmake
+++ b/src/cmake/SetupBLT.cmake
@@ -23,6 +23,15 @@ if(NOT ENABLE_FOLDERS)
     set(ENABLE_FOLDERS TRUE CACHE STRING "")
 endif()
 
+
+################################################################
+# if using newer CMake, prefer using MPI as imported targets
+################################################################
+if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.15.0" )
+    set(BLT_USE_MPI_IMPORTED_TARGETS TRUE CACHE BOOL "")
+endif()
+
+
 ################################################################
 # init blt using BLT_SOURCE_DIR
 ################################################################

--- a/src/cmake/SetupBLT.cmake
+++ b/src/cmake/SetupBLT.cmake
@@ -28,7 +28,7 @@ endif()
 # if using newer CMake, prefer using MPI as imported targets
 ################################################################
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.15.0" )
-    set(BLT_USE_MPI_IMPORTED_TARGETS TRUE CACHE BOOL "")
+    set(BLT_USE_FIND_MPI_TARGETS TRUE CACHE BOOL "")
 endif()
 
 

--- a/src/config/conduit_setup_deps.cmake
+++ b/src/config/conduit_setup_deps.cmake
@@ -142,6 +142,21 @@ if(CONDUIT_HDF5_DIR)
         list(REMOVE_ITEM HDF5_LIBRARIES ${HDF5_HL_LIB})
     endif()
 
+    message(STATUS "HDF5 is parallel:  ${HDF5_IS_PARALLEL}")
+    # if HDF5 was built with parallel support, we need to find MPI
+    # to make sure the targets propgate correctly.
+    # in other cases, folks will 
+    if(HDF5_IS_PARALLEL AND NOT MPI_FOUND)
+        find_package(MPI)
+    endif()
+
+    if(HDF5_IS_PARALLEL)
+        if(NOT MPI_FOUND)
+             MESSAGE(FATAL_ERROR "Cannot find MPI, but the HDF5 Conduit is linked to requires MPI support."
+                                 " (HDF5_IS_PARALLEL == TRUE). ")
+        endif()
+    endif()
+
 else()
     message(STATUS "Conduit was NOT built with HDF5 Support")
 endif()


### PR DESCRIPTION
use mpi imported targets to avoid cuda trap. 