### PR TITLE
Fix the FindMPI command so that it includes both the C and CXX

### DIFF
--- a/src/config/conduit_setup_deps.cmake
+++ b/src/config/conduit_setup_deps.cmake
@@ -147,7 +147,7 @@ if(CONDUIT_HDF5_DIR)
     # to make sure the targets propgate correctly.
     # in other cases, folks will 
     if(HDF5_IS_PARALLEL AND NOT MPI_FOUND)
-        find_package(MPI)
+        find_package(MPI COMPONENTS CXX)
     endif()
 
     if(HDF5_IS_PARALLEL)


### PR DESCRIPTION
compiler and linker components.