### PR TITLE
fix bug in `blueprint::mesh::utils::TopologyMetadata` for polyhedral inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### General
 - Avoid compile issue with using `_Pragma()` with Python 3.8 on Windows
 
+#### Blueprint
+- Fixed a bug that was causing the `conduit::blueprint::mesh::topology::unstructured::generate_*` functions to produce bad results for polyhedral input topologies with heterogeneous elements (e.g. tets and hexs).
+
 
 ## [0.7.2] - Released 2021-05-19
 


### PR DESCRIPTION
The changes in this PR fix a bug in the `blueprint::mesh::utils::TopologyMetadata` constructor that was causing polyhedral inputs to use incorrect sizes for derived polygonal faces, which resulted in downstream errors for heterogeneous polyhedral geometries. This fix enables heterogeneous polyhedral geometries to work properly when provided as inputs to functions using `blueprint::mesh::utils::TopologyMetadata` (e.g. `blueprint::mesh::topology::unstructured::generate_*`).