### PR TITLE
Generate sides and map fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Blueprint
 - Added the `blueprint::mesh::examples::polychain` example. It is an example of a polyhedral mesh. See Mesh Blueprint Examples docs (https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#polychain) for more details.
 - Fixed a bug that was causing the `conduit::blueprint::mesh::topology::unstructured::generate_*` functions to produce bad results for polyhedral input topologies with heterogeneous elements (e.g. tets and hexs).
-- Added `blueprint::mesh::topology::unstructured::map_fields_to_generated_sides`, a companion function to `generate_sides` that takes fields from the topology before `generate_sides` and maps it onto the new topology.
+- Added a new function signature for `blueprint::mesh::topology::unstructured::generated_sides`, which performs the same task as the original and also takes fields from the original topology and maps them onto the new topology.
 
 ## [0.7.2] - Released 2021-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Blueprint
 - Added the `blueprint::mesh::examples::polychain` example. It is an example of a polyhedral mesh. See Mesh Blueprint Examples docs (https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#polychain) for more details.
 - Fixed a bug that was causing the `conduit::blueprint::mesh::topology::unstructured::generate_*` functions to produce bad results for polyhedral input topologies with heterogeneous elements (e.g. tets and hexs).
+- Added `blueprint::mesh::topology::unstructured::map_fields_to_generated_sides`, a companion function to `generate_sides` that takes fields from the topology before `generate_sides` and maps it onto the new topology.
 
 ## [0.7.2] - Released 2021-05-19
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3015,6 +3015,10 @@ map_fields_specific(const Node &poly_mesh,
             {
                 CONDUIT_ERROR("Vertex associated fields are not supported.");
             }
+        }
+
+        if (field.has_child("volume_dependent"))
+        {
             if (field["volume_dependent"].as_string() != "false")
             {
                 CONDUIT_ERROR("Volume dependent fields are not supported.");

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3114,7 +3114,6 @@ namespace detail
 
 void
 mesh::topology::unstructured::generate_sides(const conduit::Node &topo_src,
-                                             const conduit::Node &fields_src,
                                              conduit::Node &topo_dest,
                                              conduit::Node &coordset_dest,
                                              conduit::Node &fields_dest,
@@ -3124,6 +3123,7 @@ mesh::topology::unstructured::generate_sides(const conduit::Node &topo_src,
 {
     std::string field_prefix = "";
     std::vector<std::string> field_names;
+    const Node &fields_src = (*(topo_src.parent()->parent()))["fields"];
 
     // check for existence of field prefix
     if (options.has_child("field_prefix"))

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2963,10 +2963,10 @@ mesh::topology::unstructured::generate_sides(const Node &topo,
 //-----------------------------------------------------------------------------
 template<typename T, typename U> 
 void 
-map_field(Node &field_out, 
-          const Node &field, 
-          int num_shapes, 
-          const U *tri_to_poly)
+map_field_to_generated_sides(Node &field_out, 
+                             const Node &field, 
+                             int num_shapes, 
+                             const U *tri_to_poly)
 {
     T* values_array = field_out["values"].value();
     const T* poly_field_data = field["values"].value();
@@ -2979,10 +2979,10 @@ map_field(Node &field_out,
 
 template<typename T>
 void 
-map_fields_specific(const Node &poly_mesh,
-                    const Node &d2smap,
-                    Node &side_mesh,
-                    std::string topology)
+map_fields_to_generated_sides_template(const Node &poly_mesh,
+                                       const Node &d2smap,
+                                       Node &side_mesh,
+                                       std::string topology)
 {
     NodeConstIterator fields_itr = poly_mesh["fields"].children();
 
@@ -3040,32 +3040,32 @@ map_fields_specific(const Node &poly_mesh,
         if (field["values"].dtype().is_uint64())
         {
             field_out["values"].set(conduit::DataType::uint64(num_shapes));
-            map_field<uint64, T>(field_out, field, num_shapes, tri_to_poly);
+            map_field_to_generated_sides<uint64, T>(field_out, field, num_shapes, tri_to_poly);
         }
         else if (field["values"].dtype().is_uint32())
         {
             field_out["values"].set(conduit::DataType::uint32(num_shapes));
-            map_field<uint32, T>(field_out, field, num_shapes, tri_to_poly);
+            map_field_to_generated_sides<uint32, T>(field_out, field, num_shapes, tri_to_poly);
         }
         else if (field["values"].dtype().is_int64())
         {
             field_out["values"].set(conduit::DataType::int64(num_shapes));
-            map_field<int64, T>(field_out, field, num_shapes, tri_to_poly);
+            map_field_to_generated_sides<int64, T>(field_out, field, num_shapes, tri_to_poly);
         }
         else if (field["values"].dtype().is_int32())
         {
             field_out["values"].set(conduit::DataType::int32(num_shapes));
-            map_field<int32, T>(field_out, field, num_shapes, tri_to_poly);
+            map_field_to_generated_sides<int32, T>(field_out, field, num_shapes, tri_to_poly);
         }
         else if (field["values"].dtype().is_float64())
         {
             field_out["values"].set(conduit::DataType::float64(num_shapes));
-            map_field<float64, T>(field_out, field, num_shapes, tri_to_poly);
+            map_field_to_generated_sides<float64, T>(field_out, field, num_shapes, tri_to_poly);
         }
         else if (field["values"].dtype().is_float32())
         {
             field_out["values"].set(conduit::DataType::float32(num_shapes));
-            map_field<float32, T>(field_out, field, num_shapes, tri_to_poly);
+            map_field_to_generated_sides<float32, T>(field_out, field, num_shapes, tri_to_poly);
         }
         else
         {
@@ -3082,26 +3082,26 @@ map_fields_specific(const Node &poly_mesh,
 }
 
 void 
-mesh::topology::unstructured::map_fields(const Node &poly_mesh,
+mesh::topology::unstructured::map_fields_to_generated_sides(const Node &poly_mesh,
                                          const Node &d2smap,
                                          Node &side_mesh,
-                                         std::string topology)
+                                         const std::string &topology)
 {
     if (d2smap["values"].dtype().is_uint64())
     {
-        map_fields_specific<uint64>(poly_mesh, d2smap, side_mesh, topology);
+        map_fields_to_generated_sides_template<uint64>(poly_mesh, d2smap, side_mesh, topology);
     }
     else if (d2smap["values"].dtype().is_uint32())
     {
-        map_fields_specific<uint32>(poly_mesh, d2smap, side_mesh, topology);
+        map_fields_to_generated_sides_template<uint32>(poly_mesh, d2smap, side_mesh, topology);
     }
     else if (d2smap["values"].dtype().is_int64())
     {
-        map_fields_specific<int64>(poly_mesh, d2smap, side_mesh, topology);
+        map_fields_to_generated_sides_template<int64>(poly_mesh, d2smap, side_mesh, topology);
     }
     else if (d2smap["values"].dtype().is_int32())
     {
-        map_fields_specific<int32>(poly_mesh, d2smap, side_mesh, topology);
+        map_fields_to_generated_sides_template<int32>(poly_mesh, d2smap, side_mesh, topology);
     }
     else
     {
@@ -3109,10 +3109,11 @@ mesh::topology::unstructured::map_fields(const Node &poly_mesh,
     }
 }
 
+// may want a prefix for the generated fields (a string name)
 void 
 mesh::topology::unstructured::generate_sides_and_map_fields(const Node &poly_mesh,
                                                             Node &side_mesh,
-                                                            std::string topology)
+                                                            const std::string &topology)
 {
     Node s2dmap, d2smap;
     Node &side_coords = side_mesh["coordsets/coords"];
@@ -3122,7 +3123,7 @@ mesh::topology::unstructured::generate_sides_and_map_fields(const Node &poly_mes
                                                             side_coords, 
                                                             s2dmap, 
                                                             d2smap);
-    map_fields(poly_mesh, d2smap, side_mesh, topology);
+    map_fields_to_generated_sides(poly_mesh, d2smap, side_mesh, topology);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3010,7 +3010,7 @@ namespace detail
         {
             const Node &field = fields_itr.next();
             std::string field_name = fields_itr.name();
-            Node &field_out = side_mesh["fields"][field_name];
+            Node &field_out = side_mesh["fields"][field_prefix + field_name];
 
             if (field.has_child("association"))
             {

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2998,7 +2998,7 @@ map_fields_specific(const Node &poly_mesh,
     }
     else
     {
-        CONDUIT_ERROR(((std::string) "Bad shape in ").append(poly_mesh["topologies/" + topology + "/elements/shape"].as_string()));
+        CONDUIT_ERROR(((std::string) "Bad shape in ").append(side_mesh["topologies/" + topology + "/elements/shape"].as_string()));
     }
     
     const T *tri_to_poly = d2smap["values"].value();

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2982,10 +2982,10 @@ namespace detail
     template<typename T>
     void 
     map_fields_to_generated_sides(const Node &poly_mesh,
-                                       const Node &d2smap,
-                                       Node &side_mesh,
-                                       std::string topology,
-                                       const std::string &field_prefix)
+                                  const Node &d2smap,
+                                  Node &side_mesh,
+                                  std::string topology,
+                                  const std::string &field_prefix)
     {
         NodeConstIterator fields_itr = poly_mesh["fields"].children();
 
@@ -3088,10 +3088,10 @@ namespace detail
 // may want a prefix for the generated fields (a string name)
 void 
 mesh::topology::unstructured::map_fields_to_generated_sides(const Node &poly_mesh,
-                                         const Node &d2smap,
-                                         Node &side_mesh,
-                                         const std::string &topology,
-                                         const std::string &field_prefix)
+                                                            const Node &d2smap,
+                                                            Node &side_mesh,
+                                                            const std::string &topology,
+                                                            const std::string &field_prefix)
 {
     if (d2smap["values"].dtype().is_uint64())
     {

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3014,7 +3014,7 @@ namespace detail
 
             // check that the field is one of the selected fields specified in the options node
             bool found;
-            for (int i = 0; i < field_names.size(); i ++)
+            for (uint64 i = 0; i < field_names.size(); i ++)
             {
                 if (field_names[i] == field_name)
                 {
@@ -3168,14 +3168,14 @@ mesh::topology::unstructured::generate_sides(const conduit::Node &topo_src,
     }
 
     // check that the discovered field names exist in the target fields
-    for (int i = 0; i < field_names.size(); i ++)
+    for (uint64 i = 0; i < field_names.size(); i ++)
     {
         bool found = false;
         NodeConstIterator itr = fields_src.children();
         std::string cld_name = "";
         while (itr.has_next() && !found)
         {
-            const Node &cld = itr.next();
+            itr.next();
             cld_name = itr.name();
             if (cld_name == field_names[i])
             {

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3170,19 +3170,7 @@ mesh::topology::unstructured::generate_sides(const conduit::Node &topo_src,
     // check that the discovered field names exist in the target fields
     for (uint64 i = 0; i < field_names.size(); i ++)
     {
-        bool found = false;
-        NodeConstIterator itr = fields_src.children();
-        std::string cld_name = "";
-        while (itr.has_next() && !found)
-        {
-            itr.next();
-            cld_name = itr.name();
-            if (cld_name == field_names[i])
-            {
-                found = true;
-            }
-        }
-        if (!found)
+        if (! fields_src.has_child(field_names[i]))
         {
             CONDUIT_ERROR("field " + field_names[i] + " not found in target.");
         }

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2980,7 +2980,7 @@ map_field(Node &field_out,
 template<typename T>
 void 
 map_fields_specific(const Node &poly_mesh,
-                    const Node &s2t_map,
+                    const Node &d2smap,
                     Node &side_mesh,
                     std::string topology)
 {
@@ -3001,7 +3001,7 @@ map_fields_specific(const Node &poly_mesh,
         CONDUIT_ERROR(((std::string) "Bad shape in ").append(poly_mesh["topologies/" + topology + "/elements/shape"].as_string()));
     }
     
-    const T *tri_to_poly = s2t_map["values"].value();
+    const T *tri_to_poly = d2smap["values"].value();
 
     while(fields_itr.has_next())
     {
@@ -3078,34 +3078,34 @@ map_fields_specific(const Node &poly_mesh,
     original_elements["association"] = "element";
     original_elements["volume_dependent"] = "false";
 
-    s2t_map["values"].to_uint32_array(original_elements["values"]);
+    d2smap["values"].to_uint32_array(original_elements["values"]);
 }
 
 void 
 mesh::topology::unstructured::map_fields(const Node &poly_mesh,
-                                         const Node &s2t_map,
+                                         const Node &d2smap,
                                          Node &side_mesh,
                                          std::string topology)
 {
-    if (s2t_map["values"].dtype().is_uint64())
+    if (d2smap["values"].dtype().is_uint64())
     {
-        map_fields_specific<uint64>(poly_mesh, s2t_map, side_mesh, topology);
+        map_fields_specific<uint64>(poly_mesh, d2smap, side_mesh, topology);
     }
-    else if (s2t_map["values"].dtype().is_uint32())
+    else if (d2smap["values"].dtype().is_uint32())
     {
-        map_fields_specific<uint32>(poly_mesh, s2t_map, side_mesh, topology);
+        map_fields_specific<uint32>(poly_mesh, d2smap, side_mesh, topology);
     }
-    else if (s2t_map["values"].dtype().is_int64())
+    else if (d2smap["values"].dtype().is_int64())
     {
-        map_fields_specific<int64>(poly_mesh, s2t_map, side_mesh, topology);
+        map_fields_specific<int64>(poly_mesh, d2smap, side_mesh, topology);
     }
-    else if (s2t_map["values"].dtype().is_int32())
+    else if (d2smap["values"].dtype().is_int32())
     {
-        map_fields_specific<int32>(poly_mesh, s2t_map, side_mesh, topology);
+        map_fields_specific<int32>(poly_mesh, d2smap, side_mesh, topology);
     }
     else
     {
-        CONDUIT_ERROR("Unsupported field type in " << s2t_map["values"].dtype().to_yaml());
+        CONDUIT_ERROR("Unsupported field type in " << d2smap["values"].dtype().to_yaml());
     }
 }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2990,6 +2990,7 @@ namespace detail
     {
         NodeConstIterator fields_itr = fields_src.children();
         std::string topo = topo_dest.name();
+        bool no_field_names = field_names.empty();
         int num_shapes;
 
         if (topo_dest["elements/shape"].as_string() == "tet")
@@ -3013,13 +3014,21 @@ namespace detail
             std::string field_name = fields_itr.name();
 
             // check that the field is one of the selected fields specified in the options node
-            bool found;
-            for (uint64 i = 0; i < field_names.size(); i ++)
+            bool found = false;
+            if (no_field_names)
             {
-                if (field_names[i] == field_name)
+                // we want to copy all fields if no field names were provided
+                found = true;
+            }
+            else
+            {
+                for (uint64 i = 0; i < field_names.size(); i ++)
                 {
-                    found = true;
-                    break;
+                    if (field_names[i] == field_name)
+                    {
+                        found = true;
+                        break;
+                    }
                 }
             }
 
@@ -3093,10 +3102,10 @@ namespace detail
             }
             else
             {
-                // if we couldn't find the field in the specified field_names, then we don't care
+                // if we couldn't find the field in the specified field_names, then we don't care;
                 // but if it was found, and we are here, then that means that the field we want
                 // uses the wrong topology
-                if (found)
+                if (! no_field_names && found)
                 {
                     CONDUIT_ERROR("field " + field_name + " does not use " + topo + ".");
                 }

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2981,27 +2981,28 @@ namespace detail
 
     template<typename T>
     void 
-    map_fields_to_generated_sides(const Node &poly_mesh,
+    map_fields_to_generated_sides(const Node &fields_src,
                                   const Node &d2smap,
-                                  Node &side_mesh,
-                                  std::string topology,
+                                  const Node &topo_dest,
+                                  Node &fields_dest,
+                                  const std::vector<std::string> &field_names,
                                   const std::string &field_prefix)
     {
-        NodeConstIterator fields_itr = poly_mesh["fields"].children();
-
+        NodeConstIterator fields_itr = fields_src.children();
+        std::string topo = topo_dest.name();
         int num_shapes;
 
-        if (side_mesh["topologies/" + topology + "/elements/shape"].as_string() == "tet")
+        if (topo_dest["elements/shape"].as_string() == "tet")
         {
-            num_shapes = side_mesh["topologies/" + topology + "/elements/connectivity"].dtype().number_of_elements() / 4;
+            num_shapes = topo_dest["elements/connectivity"].dtype().number_of_elements() / 4;
         }
-        else if (side_mesh["topologies/" + topology + "/elements/shape"].as_string() == "tri")
+        else if (topo_dest["elements/shape"].as_string() == "tri")
         {
-            num_shapes = side_mesh["topologies/" + topology + "/elements/connectivity"].dtype().number_of_elements() / 3;
+            num_shapes = topo_dest["elements/connectivity"].dtype().number_of_elements() / 3;
         }
         else
         {
-            CONDUIT_ERROR(((std::string) "Bad shape in ").append(side_mesh["topologies/" + topology + "/elements/shape"].as_string()));
+            CONDUIT_ERROR(((std::string) "Bad shape in ").append(topo_dest["elements/shape"].as_string()));
         }
         
         const T *tri_to_poly = d2smap["values"].value();
@@ -3010,74 +3011,100 @@ namespace detail
         {
             const Node &field = fields_itr.next();
             std::string field_name = fields_itr.name();
-            Node &field_out = side_mesh["fields"][field_prefix + field_name];
 
-            if (field.has_child("association"))
+            // check that the field is one of the selected fields specified in the options node
+            bool found;
+            for (int i = 0; i < field_names.size(); i ++)
             {
-                if (field["association"].as_string() != "element")
+                if (field_names[i] == field_name)
                 {
-                    CONDUIT_ERROR("Vertex associated fields are not supported.");
+                    found = true;
+                    break;
                 }
             }
 
-            if (field.has_child("volume_dependent"))
+            // check that the current field uses the chosen topology
+            if (found && field["topology"].as_string() == topo)
             {
-                if (field["volume_dependent"].as_string() != "false")
+                Node &field_out = fields_dest[field_prefix + field_name];
+
+                if (field.has_child("association"))
                 {
-                    CONDUIT_ERROR("Volume dependent fields are not supported.");
+                    if (field["association"].as_string() != "element")
+                    {
+                        CONDUIT_ERROR("Vertex associated fields are not supported.");
+                    }
                 }
-            }
 
-            NodeConstIterator itr = field.children();
-            while (itr.has_next())
-            {
-                const Node &cld = itr.next();
-                std::string cld_name = itr.name();
-
-                if (cld_name != "values")
+                if (field.has_child("volume_dependent"))
                 {
-                    field_out[cld_name] = cld;
+                    if (field["volume_dependent"].as_string() != "false")
+                    {
+                        CONDUIT_ERROR("Volume dependent fields are not supported.");
+                    }
                 }
-            }
 
-            if (field["values"].dtype().is_uint64())
-            {
-                field_out["values"].set(conduit::DataType::uint64(num_shapes));
-                map_field_to_generated_sides<uint64, T>(field_out, field, num_shapes, tri_to_poly);
-            }
-            else if (field["values"].dtype().is_uint32())
-            {
-                field_out["values"].set(conduit::DataType::uint32(num_shapes));
-                map_field_to_generated_sides<uint32, T>(field_out, field, num_shapes, tri_to_poly);
-            }
-            else if (field["values"].dtype().is_int64())
-            {
-                field_out["values"].set(conduit::DataType::int64(num_shapes));
-                map_field_to_generated_sides<int64, T>(field_out, field, num_shapes, tri_to_poly);
-            }
-            else if (field["values"].dtype().is_int32())
-            {
-                field_out["values"].set(conduit::DataType::int32(num_shapes));
-                map_field_to_generated_sides<int32, T>(field_out, field, num_shapes, tri_to_poly);
-            }
-            else if (field["values"].dtype().is_float64())
-            {
-                field_out["values"].set(conduit::DataType::float64(num_shapes));
-                map_field_to_generated_sides<float64, T>(field_out, field, num_shapes, tri_to_poly);
-            }
-            else if (field["values"].dtype().is_float32())
-            {
-                field_out["values"].set(conduit::DataType::float32(num_shapes));
-                map_field_to_generated_sides<float32, T>(field_out, field, num_shapes, tri_to_poly);
+                NodeConstIterator itr = field.children();
+                while (itr.has_next())
+                {
+                    const Node &cld = itr.next();
+                    std::string cld_name = itr.name();
+
+                    if (cld_name != "values")
+                    {
+                        field_out[cld_name] = cld;
+                    }
+                }
+
+                if (field["values"].dtype().is_uint64())
+                {
+                    field_out["values"].set(conduit::DataType::uint64(num_shapes));
+                    map_field_to_generated_sides<uint64, T>(field_out, field, num_shapes, tri_to_poly);
+                }
+                else if (field["values"].dtype().is_uint32())
+                {
+                    field_out["values"].set(conduit::DataType::uint32(num_shapes));
+                    map_field_to_generated_sides<uint32, T>(field_out, field, num_shapes, tri_to_poly);
+                }
+                else if (field["values"].dtype().is_int64())
+                {
+                    field_out["values"].set(conduit::DataType::int64(num_shapes));
+                    map_field_to_generated_sides<int64, T>(field_out, field, num_shapes, tri_to_poly);
+                }
+                else if (field["values"].dtype().is_int32())
+                {
+                    field_out["values"].set(conduit::DataType::int32(num_shapes));
+                    map_field_to_generated_sides<int32, T>(field_out, field, num_shapes, tri_to_poly);
+                }
+                else if (field["values"].dtype().is_float64())
+                {
+                    field_out["values"].set(conduit::DataType::float64(num_shapes));
+                    map_field_to_generated_sides<float64, T>(field_out, field, num_shapes, tri_to_poly);
+                }
+                else if (field["values"].dtype().is_float32())
+                {
+                    field_out["values"].set(conduit::DataType::float32(num_shapes));
+                    map_field_to_generated_sides<float32, T>(field_out, field, num_shapes, tri_to_poly);
+                }
+                else
+                {
+                    CONDUIT_ERROR("Unsupported field type in " << field["values"].dtype().to_yaml());
+                }
             }
             else
             {
-                CONDUIT_ERROR("Unsupported field type in " << field["values"].dtype().to_yaml());
+                // if we couldn't find the field in the specified field_names, then we don't care
+                // but if it was found, and we are here, then that means that the field we want
+                // uses the wrong topology
+                if (found)
+                {
+                    CONDUIT_ERROR("field " + field_name + " does not use " + topo + ".");
+                }
             }
         }
 
-        Node &original_elements = side_mesh["fields/original_element_ids"];
-        original_elements["topology"] = topology;
+        Node &original_elements = fields_dest["original_element_ids"];
+        original_elements["topology"] = topo;
         original_elements["association"] = "element";
         original_elements["volume_dependent"] = "false";
 
@@ -3085,29 +3112,101 @@ namespace detail
     }
 }
 
-// may want a prefix for the generated fields (a string name)
-void 
-mesh::topology::unstructured::map_fields_to_generated_sides(const Node &poly_mesh,
-                                                            const Node &d2smap,
-                                                            Node &side_mesh,
-                                                            const std::string &topology,
-                                                            const std::string &field_prefix)
+void
+mesh::topology::unstructured::generate_sides(const conduit::Node &topo_src,
+                                             const conduit::Node &fields_src,
+                                             conduit::Node &topo_dest,
+                                             conduit::Node &coordset_dest,
+                                             conduit::Node &fields_dest,
+                                             conduit::Node &s2dmap,
+                                             conduit::Node &d2smap,
+                                             const conduit::Node &options)
 {
+    std::string field_prefix = "";
+    std::vector<std::string> field_names;
+
+    // check for existence of field prefix
+    if (options.has_child("field_prefix"))
+    {
+        if (options["field_prefix"].dtype().is_string())
+        {
+            field_prefix = options["field_prefix"].as_string();
+        }
+        else
+        {
+            CONDUIT_ERROR("field_prefix must be a string.");
+        }
+    }
+
+    // check for target field names
+    if (options.has_child("field_names"))
+    {
+        if (options["field_names"].dtype().is_string())
+        {
+            field_names.push_back(options["field_names"].as_string());
+        }
+        else if (options["field_names"].dtype().is_list())
+        {
+            NodeConstIterator itr = options["field_names"].children();
+            while (itr.has_next())
+            {
+                const Node &cld = itr.next();
+                if (cld.dtype().is_string())
+                {
+                    field_names.push_back(cld.as_string());
+                }
+                else
+                {
+                    CONDUIT_ERROR("field_names must be a string or a list of strings.");
+                }
+            }
+        }
+        else
+        {
+            CONDUIT_ERROR("field_names must be a string or a list of strings.");
+        }
+    }
+
+    // check that the discovered field names exist in the target fields
+    for (int i = 0; i < field_names.size(); i ++)
+    {
+        bool found = false;
+        NodeConstIterator itr = fields_src.children();
+        std::string cld_name = "";
+        while (itr.has_next() && !found)
+        {
+            const Node &cld = itr.next();
+            cld_name = itr.name();
+            if (cld_name == field_names[i])
+            {
+                found = true;
+            }
+        }
+        if (!found)
+        {
+            CONDUIT_ERROR("field " + field_names[i] + " not found in target.");
+        }
+    }
+
+    // generate sides as usual
+    generate_sides(topo_src, topo_dest, coordset_dest, s2dmap, d2smap);
+
+    // now map fields
     if (d2smap["values"].dtype().is_uint64())
     {
-        detail::map_fields_to_generated_sides<uint64>(poly_mesh, d2smap, side_mesh, topology, field_prefix);
+        detail::map_fields_to_generated_sides<uint64>(fields_src, d2smap, topo_dest, fields_dest, field_names, field_prefix);
     }
     else if (d2smap["values"].dtype().is_uint32())
     {
-        detail::map_fields_to_generated_sides<uint32>(poly_mesh, d2smap, side_mesh, topology, field_prefix);
+        detail::map_fields_to_generated_sides<uint32>(fields_src, d2smap, topo_dest, fields_dest, field_names, field_prefix);
     }
     else if (d2smap["values"].dtype().is_int64())
     {
-        detail::map_fields_to_generated_sides<int64>(poly_mesh, d2smap, side_mesh, topology, field_prefix);
+        detail::map_fields_to_generated_sides<int64>(fields_src, d2smap, topo_dest, fields_dest, field_names, field_prefix);
     }
     else if (d2smap["values"].dtype().is_int32())
     {
-        detail::map_fields_to_generated_sides<int32>(poly_mesh, d2smap, side_mesh, topology, field_prefix);
+        detail::map_fields_to_generated_sides<int32>(fields_src, d2smap, topo_dest, fields_dest, field_names, field_prefix);
     }
     else
     {

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -352,11 +352,14 @@ namespace topology
                                                   conduit::Node &d2smap);
 
         //---------------------------------------------------------------------
-        void CONDUIT_BLUEPRINT_API map_fields_to_generated_sides(const conduit::Node &poly_mesh,
-                                                                 const conduit::Node &d2smap,
-                                                                 conduit::Node &side_mesh,
-                                                                 const std::string &topology,
-                                                                 const std::string &field_prefix = "");
+        void CONDUIT_BLUEPRINT_API generate_sides(const conduit::Node &topo_src,
+                                                  const conduit::Node &fields_src,
+                                                  conduit::Node &topo_dest,
+                                                  conduit::Node &coordset_dest,
+                                                  conduit::Node &fields_dest,
+                                                  conduit::Node &s2dmap,
+                                                  conduit::Node &d2smap,
+                                                  const conduit::Node &options);
 
         //---------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_corners(const conduit::Node &n,

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -353,7 +353,6 @@ namespace topology
 
         //---------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_sides(const conduit::Node &topo_src,
-                                                  const conduit::Node &fields_src,
                                                   conduit::Node &topo_dest,
                                                   conduit::Node &coordset_dest,
                                                   conduit::Node &fields_dest,

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -352,6 +352,13 @@ namespace topology
                                                   conduit::Node &d2smap);
 
         //---------------------------------------------------------------------
+        // this variant of the function call will also map the fields specified in
+        // the options node. The options node can have a child "field_prefix", 
+        // which should be a string that allows the user to specify a prefix
+        // to insert into the names of the fields stored in fields_dest. The options
+        // node can also have a child "field_names", which should be a string or list
+        // of strings that allow the user to specify which fields they want to be 
+        // mapped from the original set of fields.
         void CONDUIT_BLUEPRINT_API generate_sides(const conduit::Node &topo_src,
                                                   conduit::Node &topo_dest,
                                                   conduit::Node &coordset_dest,

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -352,6 +352,17 @@ namespace topology
                                                   conduit::Node &d2smap);
 
         //---------------------------------------------------------------------
+        void CONDUIT_BLUEPRINT_API map_fields(const conduit::Node &poly_mesh,
+                                              const conduit::Node &s2t_map,
+                                              conduit::Node &side_mesh,
+                                              std::string topology);
+
+        //---------------------------------------------------------------------
+        void CONDUIT_BLUEPRINT_API generate_sides_and_map_fields(const conduit::Node &poly_mesh,
+                                                                 conduit::Node &side_mesh,
+                                                                 std::string topology);
+
+        //---------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_corners(const conduit::Node &n,
                                                     conduit::Node &dest,
                                                     conduit::Node &cdest,

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -355,12 +355,8 @@ namespace topology
         void CONDUIT_BLUEPRINT_API map_fields_to_generated_sides(const conduit::Node &poly_mesh,
                                                                  const conduit::Node &d2smap,
                                                                  conduit::Node &side_mesh,
-                                                                 const std::string &topology);
-
-        //---------------------------------------------------------------------
-        void CONDUIT_BLUEPRINT_API generate_sides_and_map_fields(const conduit::Node &poly_mesh,
-                                                                 conduit::Node &side_mesh,
-                                                                 const std::string &topology);
+                                                                 const std::string &topology,
+                                                                 const std::string &field_prefix = "");
 
         //---------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_corners(const conduit::Node &n,

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -352,15 +352,15 @@ namespace topology
                                                   conduit::Node &d2smap);
 
         //---------------------------------------------------------------------
-        void CONDUIT_BLUEPRINT_API map_fields(const conduit::Node &poly_mesh,
-                                              const conduit::Node &s2t_map,
-                                              conduit::Node &side_mesh,
-                                              std::string topology);
+        void CONDUIT_BLUEPRINT_API map_fields_to_generated_sides(const conduit::Node &poly_mesh,
+                                                                 const conduit::Node &d2smap,
+                                                                 conduit::Node &side_mesh,
+                                                                 const std::string &topology);
 
         //---------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_sides_and_map_fields(const conduit::Node &poly_mesh,
                                                                  conduit::Node &side_mesh,
-                                                                 std::string topology);
+                                                                 const std::string &topology);
 
         //---------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_corners(const conduit::Node &n,

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -3422,7 +3422,7 @@ adjset_uniform(Node &res)
 }
 
 //-----------------------------------------------------------------------------
-void 
+void
 polychain(const index_t length, // how long the chain ought to be
           Node &res)
 {

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -3422,7 +3422,7 @@ adjset_uniform(Node &res)
 }
 
 //-----------------------------------------------------------------------------
-void
+void 
 polychain(const index_t length, // how long the chain ought to be
           Node &res)
 {

--- a/src/tests/blueprint/CMakeLists.txt
+++ b/src/tests/blueprint/CMakeLists.txt
@@ -19,6 +19,7 @@ set(BLUEPRINT_TESTS t_blueprint_smoke
                     t_blueprint_mesh_query
                     t_blueprint_mesh_relay
                     t_blueprint_mesh_generate
+                    t_blueprint_mesh_generate_map_fields
                     t_blueprint_mesh_examples
                     t_blueprint_mesh_matset_xforms)
 

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+//-----------------------------------------------------------------------------
+///
+/// file: t_blueprint_mesh_generate_map_fields.cpp
+///
+//-----------------------------------------------------------------------------
+
+#if defined(CONDUIT_PLATFORM_WINDOWS)
+#define NOMINMAX
+#undef min
+#undef max
+#include "windows.h"
+#endif
+
+#include <string>
+#include "conduit_blueprint.hpp"
+#include "gtest/gtest.h"
+
+using namespace conduit;
+using namespace conduit::blueprint::mesh;
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_2D)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    topology::unstructured::generate_sides_and_map_fields(n, side_mesh, "topo");
+    EXPECT_TRUE(verify(side_mesh, info));
+
+    EXPECT_EQ(side_mesh["fields/level/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/level/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/level/volume_dependent"].as_string(), "false");
+
+    index_t num_field_values = 56;
+    index_t num_polygons = 9;
+    EXPECT_EQ(side_mesh["fields/level/values"].dtype().number_of_elements(), num_field_values);
+
+    uint32 *level_values = side_mesh["fields/level/values"].value();
+
+    for (int i = 0; i < num_field_values; i ++)
+    {
+        if (i < 8)
+        {
+            EXPECT_EQ(level_values[i], 1);
+        }
+        else
+        {
+            EXPECT_EQ(level_values[i], 2);
+        }
+    }
+
+    EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
+
+    EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
+
+    uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
+    
+    int i = 0;
+    for (int j = 0; j < num_polygons; j ++)
+    {
+        if (j % 2)
+        {
+            EXPECT_EQ(id_values[i], j);
+            EXPECT_EQ(id_values[i + 1], j);
+            EXPECT_EQ(id_values[i + 2], j);
+            EXPECT_EQ(id_values[i + 3], j);
+            i += 4;
+        }
+        else
+        {
+            EXPECT_EQ(id_values[i], j);
+            EXPECT_EQ(id_values[i + 1], j);
+            EXPECT_EQ(id_values[i + 2], j);
+            EXPECT_EQ(id_values[i + 3], j);
+            EXPECT_EQ(id_values[i + 4], j);
+            EXPECT_EQ(id_values[i + 5], j);
+            EXPECT_EQ(id_values[i + 6], j);
+            EXPECT_EQ(id_values[i + 7], j);
+            i += 8;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_3D)
+{
+    index_t length = 1;
+    Node n, side_mesh, info;
+
+    // create a polychain of length 1
+    examples::polychain(length, n);
+    EXPECT_TRUE(verify(n, info));
+
+    topology::unstructured::generate_sides_and_map_fields(n, side_mesh, "topo");
+    EXPECT_TRUE(verify(side_mesh, info));
+
+    EXPECT_EQ(side_mesh["fields/chain/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/chain/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/chain/volume_dependent"].as_string(), "false");
+
+    index_t num_tets_in_hex = 24;
+    index_t num_tets_in_triprism = 18;
+
+    index_t num_field_values = num_tets_in_hex + 2 * num_tets_in_triprism;
+    EXPECT_EQ(side_mesh["fields/chain/values"].dtype().number_of_elements(), num_field_values);
+
+    int64 *chain_values = side_mesh["fields/chain/values"].value();
+
+    for (int i = 0; i < num_field_values; i ++)
+    {
+        if (i < num_tets_in_hex)
+        {
+            EXPECT_EQ(chain_values[i], 0);
+        }
+        else
+        {
+            EXPECT_EQ(chain_values[i], 1);
+        }
+    }
+
+    EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
+
+    EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
+
+    uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
+
+    for (int i = 0; i < num_field_values; i ++)
+    {
+        if (i < num_tets_in_hex)
+        {
+            EXPECT_EQ(id_values[i], 0);
+        }
+        else if (i < num_tets_in_hex + num_tets_in_triprism)
+        {
+            EXPECT_EQ(id_values[i], 1);
+        }
+        else
+        {
+            EXPECT_EQ(id_values[i], 2);
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exceptions)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+
+    // catch float64 error
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+                                                            side_topo, 
+                                                            side_coords, 
+                                                            s2dmap, 
+                                                            d2smap);
+    d2smap["values"].set(conduit::DataType::float64(1));
+    try
+    {
+        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Unsupported field type in dtype: \"float64\"";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+
+    // catch if shape is not tet or tri
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+                                                            side_topo, 
+                                                            side_coords, 
+                                                            s2dmap, 
+                                                            d2smap);
+    side_mesh["topologies/topo/elements/shape"] = "strange_shape";
+    try
+    {
+        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Bad shape in strange_shape";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+
+    // catch if field is vertex associated
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+                                                            side_topo, 
+                                                            side_coords, 
+                                                            s2dmap, 
+                                                            d2smap);
+    n["fields/level/association"] = "vertex";
+    try
+    {
+        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Vertex associated fields are not supported.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+    n["fields/level/association"] = "element";
+
+    // catch if field is volume dependent
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+                                                            side_topo, 
+                                                            side_coords, 
+                                                            s2dmap, 
+                                                            d2smap);
+    n["fields/level/volume_dependent"] = "true";
+    try
+    {
+        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Volume dependent fields are not supported.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+
+    // next error to catch is on line 3072
+}

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -34,12 +34,19 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_2D)
     Node s2dmap, d2smap;
     Node &side_coords = side_mesh["coordsets/coords"];
     Node &side_topo = side_mesh["topologies/topo"];
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"] = "level";
+
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                            n["fields"],
+                                                            side_topo,
+                                                            side_coords,
+                                                            side_fields,
+                                                            s2dmap,
+                                                            d2smap,
+                                                            options);
+
     EXPECT_TRUE(verify(side_mesh, info));
 
     EXPECT_EQ(side_mesh["fields/level/topology"].as_string(), "topo");
@@ -98,184 +105,184 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_2D)
     }
 }
 
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_3D)
-{
-    index_t length = 1;
-    Node n, side_mesh, info;
+// //-----------------------------------------------------------------------------
+// TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_3D)
+// {
+//     index_t length = 1;
+//     Node n, side_mesh, info;
 
-    // create a polychain of length 1
-    examples::polychain(length, n);
-    EXPECT_TRUE(verify(n, info));
+//     // create a polychain of length 1
+//     examples::polychain(length, n);
+//     EXPECT_TRUE(verify(n, info));
 
-    Node s2dmap, d2smap;
-    Node &side_coords = side_mesh["coordsets/coords"];
-    Node &side_topo = side_mesh["topologies/topo"];
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-    EXPECT_TRUE(verify(side_mesh, info));
+//     Node s2dmap, d2smap;
+//     Node &side_coords = side_mesh["coordsets/coords"];
+//     Node &side_topo = side_mesh["topologies/topo"];
+//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+//                                                             side_topo, 
+//                                                             side_coords, 
+//                                                             s2dmap, 
+//                                                             d2smap);
+//     topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+//     EXPECT_TRUE(verify(side_mesh, info));
 
-    EXPECT_EQ(side_mesh["fields/chain/topology"].as_string(), "topo");
-    EXPECT_EQ(side_mesh["fields/chain/association"].as_string(), "element");
-    EXPECT_EQ(side_mesh["fields/chain/volume_dependent"].as_string(), "false");
+//     EXPECT_EQ(side_mesh["fields/chain/topology"].as_string(), "topo");
+//     EXPECT_EQ(side_mesh["fields/chain/association"].as_string(), "element");
+//     EXPECT_EQ(side_mesh["fields/chain/volume_dependent"].as_string(), "false");
 
-    index_t num_tets_in_hex = 24;
-    index_t num_tets_in_triprism = 18;
+//     index_t num_tets_in_hex = 24;
+//     index_t num_tets_in_triprism = 18;
 
-    index_t num_field_values = num_tets_in_hex + 2 * num_tets_in_triprism;
-    EXPECT_EQ(side_mesh["fields/chain/values"].dtype().number_of_elements(), num_field_values);
+//     index_t num_field_values = num_tets_in_hex + 2 * num_tets_in_triprism;
+//     EXPECT_EQ(side_mesh["fields/chain/values"].dtype().number_of_elements(), num_field_values);
 
-    int64 *chain_values = side_mesh["fields/chain/values"].value();
+//     int64 *chain_values = side_mesh["fields/chain/values"].value();
 
-    for (int i = 0; i < num_field_values; i ++)
-    {
-        if (i < num_tets_in_hex)
-        {
-            EXPECT_EQ(chain_values[i], 0);
-        }
-        else
-        {
-            EXPECT_EQ(chain_values[i], 1);
-        }
-    }
+//     for (int i = 0; i < num_field_values; i ++)
+//     {
+//         if (i < num_tets_in_hex)
+//         {
+//             EXPECT_EQ(chain_values[i], 0);
+//         }
+//         else
+//         {
+//             EXPECT_EQ(chain_values[i], 1);
+//         }
+//     }
 
-    EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
-    EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
-    EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
+//     EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
+//     EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
+//     EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
 
-    EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
+//     EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
 
-    uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
+//     uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
 
-    for (int i = 0; i < num_field_values; i ++)
-    {
-        if (i < num_tets_in_hex)
-        {
-            EXPECT_EQ(id_values[i], 0);
-        }
-        else if (i < num_tets_in_hex + num_tets_in_triprism)
-        {
-            EXPECT_EQ(id_values[i], 1);
-        }
-        else
-        {
-            EXPECT_EQ(id_values[i], 2);
-        }
-    }
-}
+//     for (int i = 0; i < num_field_values; i ++)
+//     {
+//         if (i < num_tets_in_hex)
+//         {
+//             EXPECT_EQ(id_values[i], 0);
+//         }
+//         else if (i < num_tets_in_hex + num_tets_in_triprism)
+//         {
+//             EXPECT_EQ(id_values[i], 1);
+//         }
+//         else
+//         {
+//             EXPECT_EQ(id_values[i], 2);
+//         }
+//     }
+// }
 
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exceptions)
-{
-    index_t nlevels = 2;
-    Node n, side_mesh, info;
+// //-----------------------------------------------------------------------------
+// TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exceptions)
+// {
+//     index_t nlevels = 2;
+//     Node n, side_mesh, info;
 
-    // create polytessalation with two levels
-    examples::polytess(nlevels, n);
-    EXPECT_TRUE(verify(n, info));
+//     // create polytessalation with two levels
+//     examples::polytess(nlevels, n);
+//     EXPECT_TRUE(verify(n, info));
 
-    Node s2dmap, d2smap;
-    Node &side_coords = side_mesh["coordsets/coords"];
-    Node &side_topo = side_mesh["topologies/topo"];
+//     Node s2dmap, d2smap;
+//     Node &side_coords = side_mesh["coordsets/coords"];
+//     Node &side_topo = side_mesh["topologies/topo"];
 
-    // catch float64 error
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    d2smap["values"].set(conduit::DataType::float64(1));
-    try
-    {
-        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-        FAIL();
-    }
-    catch(const std::exception& err)
-    {
-        std::string msg = "Unsupported field type in dtype: \"float64\"";
-        std::string actual = err.what();
-        EXPECT_TRUE(actual.find(msg) != std::string::npos);
-    }
+//     // catch float64 error
+//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+//                                                             side_topo, 
+//                                                             side_coords, 
+//                                                             s2dmap, 
+//                                                             d2smap);
+//     d2smap["values"].set(conduit::DataType::float64(1));
+//     try
+//     {
+//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+//         FAIL();
+//     }
+//     catch(const std::exception& err)
+//     {
+//         std::string msg = "Unsupported field type in dtype: \"float64\"";
+//         std::string actual = err.what();
+//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
+//     }
 
-    // catch if shape is not tet or tri
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    side_mesh["topologies/topo/elements/shape"] = "strange_shape";
-    try
-    {
-        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-        FAIL();
-    }
-    catch(const std::exception& err)
-    {
-        std::string msg = "Bad shape in strange_shape";
-        std::string actual = err.what();
-        EXPECT_TRUE(actual.find(msg) != std::string::npos);
-    }
+//     // catch if shape is not tet or tri
+//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+//                                                             side_topo, 
+//                                                             side_coords, 
+//                                                             s2dmap, 
+//                                                             d2smap);
+//     side_mesh["topologies/topo/elements/shape"] = "strange_shape";
+//     try
+//     {
+//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+//         FAIL();
+//     }
+//     catch(const std::exception& err)
+//     {
+//         std::string msg = "Bad shape in strange_shape";
+//         std::string actual = err.what();
+//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
+//     }
 
-    // catch if field is vertex associated
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    n["fields/level/association"] = "vertex";
-    try
-    {
-        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-        FAIL();
-    }
-    catch(const std::exception& err)
-    {
-        std::string msg = "Vertex associated fields are not supported.";
-        std::string actual = err.what();
-        EXPECT_TRUE(actual.find(msg) != std::string::npos);
-    }
-    n["fields/level/association"] = "element";
+//     // catch if field is vertex associated
+//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+//                                                             side_topo, 
+//                                                             side_coords, 
+//                                                             s2dmap, 
+//                                                             d2smap);
+//     n["fields/level/association"] = "vertex";
+//     try
+//     {
+//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+//         FAIL();
+//     }
+//     catch(const std::exception& err)
+//     {
+//         std::string msg = "Vertex associated fields are not supported.";
+//         std::string actual = err.what();
+//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
+//     }
+//     n["fields/level/association"] = "element";
 
-    // catch if field is volume dependent
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    n["fields/level/volume_dependent"] = "true";
-    try
-    {
-        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-        FAIL();
-    }
-    catch(const std::exception& err)
-    {
-        std::string msg = "Volume dependent fields are not supported.";
-        std::string actual = err.what();
-        EXPECT_TRUE(actual.find(msg) != std::string::npos);
-    }
-    n["fields/level/volume_dependent"] = "false";
+//     // catch if field is volume dependent
+//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+//                                                             side_topo, 
+//                                                             side_coords, 
+//                                                             s2dmap, 
+//                                                             d2smap);
+//     n["fields/level/volume_dependent"] = "true";
+//     try
+//     {
+//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+//         FAIL();
+//     }
+//     catch(const std::exception& err)
+//     {
+//         std::string msg = "Volume dependent fields are not supported.";
+//         std::string actual = err.what();
+//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
+//     }
+//     n["fields/level/volume_dependent"] = "false";
 
-    // catch if field has wrong data type
-    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-                                                            side_topo, 
-                                                            side_coords, 
-                                                            s2dmap, 
-                                                            d2smap);
-    n["fields/level/values"].set(conduit::DataType::int8(1));
-    try
-    {
-        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-        FAIL();
-    }
-    catch(const std::exception& err)
-    {
-        std::string msg = "Unsupported field type in dtype: \"int8\"";
-        std::string actual = err.what();
-        EXPECT_TRUE(actual.find(msg) != std::string::npos);
-    }
-}
+//     // catch if field has wrong data type
+//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
+//                                                             side_topo, 
+//                                                             side_coords, 
+//                                                             s2dmap, 
+//                                                             d2smap);
+//     n["fields/level/values"].set(conduit::DataType::int8(1));
+//     try
+//     {
+//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
+//         FAIL();
+//     }
+//     catch(const std::exception& err)
+//     {
+//         std::string msg = "Unsupported field type in dtype: \"int8\"";
+//         std::string actual = err.what();
+//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
+//     }
+// }

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -292,3 +292,155 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_field_datatype_ex)
         EXPECT_TRUE(actual.find(msg) != std::string::npos);
     }
 }
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_options_field_prefix_ex)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_prefix"] = 123;
+    options["field_names"] = "level";
+
+    // catch if field_prefix is not a string
+    try
+    {
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "field_prefix must be a string.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_options_field_name_ex1)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"] = 1;
+
+    // catch if field_names is not a string
+    try
+    {
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "field_names must be a string or a list of strings.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_options_field_name_ex2)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"].append().set(1);
+    options["field_names"].append().set(2);
+    options["field_names"].append().set(3);
+
+    // catch if field_names is not a string
+    try
+    {
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "field_names must be a string or a list of strings.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_options_field_name_ex3)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"].append().set("level");
+    options["field_names"].append().set("level2");
+
+    // catch if field_names is not a string
+    try
+    {
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "field level2 not found in target.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -39,7 +39,6 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_2D)
     options["field_names"] = "level";
 
     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
-                                                            n["fields"],
                                                             side_topo,
                                                             side_coords,
                                                             side_fields,
@@ -123,7 +122,6 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_3D)
     options["field_names"] = "chain";
 
     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
-                                                            n["fields"],
                                                             side_topo,
                                                             side_coords,
                                                             side_fields,
@@ -203,7 +201,6 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_vertex_ex)
     {
         n["fields/level/association"] = "vertex";
         blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
-                                                                n["fields"],
                                                                 side_topo,
                                                                 side_coords,
                                                                 side_fields,
@@ -242,7 +239,6 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_vol_dep_ex)
     {
         n["fields/level/volume_dependent"] = "true";
         blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
-                                                                n["fields"],
                                                                 side_topo,
                                                                 side_coords,
                                                                 side_fields,
@@ -281,13 +277,12 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_field_datatype_ex)
     {
         n["fields/level/values"].set(conduit::DataType::int8(1));
         blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
-                                                                        n["fields"],
-                                                                        side_topo,
-                                                                        side_coords,
-                                                                        side_fields,
-                                                                        s2dmap,
-                                                                        d2smap,
-                                                                        options);
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
         FAIL();
     }
     catch(const std::exception& err)

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -22,7 +22,7 @@ using namespace conduit;
 using namespace conduit::blueprint::mesh;
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_2D)
+TEST(conduit_blueprint_generate_unstructured, generate_sides_2D)
 {
     index_t nlevels = 2;
     Node n, side_mesh, info;
@@ -105,184 +105,195 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_2D)
     }
 }
 
-// //-----------------------------------------------------------------------------
-// TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_3D)
-// {
-//     index_t length = 1;
-//     Node n, side_mesh, info;
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_3D)
+{
+    index_t length = 1;
+    Node n, side_mesh, info;
 
-//     // create a polychain of length 1
-//     examples::polychain(length, n);
-//     EXPECT_TRUE(verify(n, info));
+    // create a polychain of length 1
+    examples::polychain(length, n);
+    EXPECT_TRUE(verify(n, info));
 
-//     Node s2dmap, d2smap;
-//     Node &side_coords = side_mesh["coordsets/coords"];
-//     Node &side_topo = side_mesh["topologies/topo"];
-//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-//     EXPECT_TRUE(verify(side_mesh, info));
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"] = "chain";
 
-//     EXPECT_EQ(side_mesh["fields/chain/topology"].as_string(), "topo");
-//     EXPECT_EQ(side_mesh["fields/chain/association"].as_string(), "element");
-//     EXPECT_EQ(side_mesh["fields/chain/volume_dependent"].as_string(), "false");
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                            n["fields"],
+                                                            side_topo,
+                                                            side_coords,
+                                                            side_fields,
+                                                            s2dmap,
+                                                            d2smap,
+                                                            options);
+    EXPECT_TRUE(verify(side_mesh, info));
 
-//     index_t num_tets_in_hex = 24;
-//     index_t num_tets_in_triprism = 18;
+    EXPECT_EQ(side_mesh["fields/chain/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/chain/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/chain/volume_dependent"].as_string(), "false");
 
-//     index_t num_field_values = num_tets_in_hex + 2 * num_tets_in_triprism;
-//     EXPECT_EQ(side_mesh["fields/chain/values"].dtype().number_of_elements(), num_field_values);
+    index_t num_tets_in_hex = 24;
+    index_t num_tets_in_triprism = 18;
 
-//     int64 *chain_values = side_mesh["fields/chain/values"].value();
+    index_t num_field_values = num_tets_in_hex + 2 * num_tets_in_triprism;
+    EXPECT_EQ(side_mesh["fields/chain/values"].dtype().number_of_elements(), num_field_values);
 
-//     for (int i = 0; i < num_field_values; i ++)
-//     {
-//         if (i < num_tets_in_hex)
-//         {
-//             EXPECT_EQ(chain_values[i], 0);
-//         }
-//         else
-//         {
-//             EXPECT_EQ(chain_values[i], 1);
-//         }
-//     }
+    int64 *chain_values = side_mesh["fields/chain/values"].value();
 
-//     EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
-//     EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
-//     EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
+    for (int i = 0; i < num_field_values; i ++)
+    {
+        if (i < num_tets_in_hex)
+        {
+            EXPECT_EQ(chain_values[i], 0);
+        }
+        else
+        {
+            EXPECT_EQ(chain_values[i], 1);
+        }
+    }
 
-//     EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
+    EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
 
-//     uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
+    EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
 
-//     for (int i = 0; i < num_field_values; i ++)
-//     {
-//         if (i < num_tets_in_hex)
-//         {
-//             EXPECT_EQ(id_values[i], 0);
-//         }
-//         else if (i < num_tets_in_hex + num_tets_in_triprism)
-//         {
-//             EXPECT_EQ(id_values[i], 1);
-//         }
-//         else
-//         {
-//             EXPECT_EQ(id_values[i], 2);
-//         }
-//     }
-// }
+    uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
 
-// //-----------------------------------------------------------------------------
-// TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exceptions)
-// {
-//     index_t nlevels = 2;
-//     Node n, side_mesh, info;
+    for (int i = 0; i < num_field_values; i ++)
+    {
+        if (i < num_tets_in_hex)
+        {
+            EXPECT_EQ(id_values[i], 0);
+        }
+        else if (i < num_tets_in_hex + num_tets_in_triprism)
+        {
+            EXPECT_EQ(id_values[i], 1);
+        }
+        else
+        {
+            EXPECT_EQ(id_values[i], 2);
+        }
+    }
+}
 
-//     // create polytessalation with two levels
-//     examples::polytess(nlevels, n);
-//     EXPECT_TRUE(verify(n, info));
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_vertex_ex)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
 
-//     Node s2dmap, d2smap;
-//     Node &side_coords = side_mesh["coordsets/coords"];
-//     Node &side_topo = side_mesh["topologies/topo"];
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
 
-//     // catch float64 error
-//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     d2smap["values"].set(conduit::DataType::float64(1));
-//     try
-//     {
-//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-//         FAIL();
-//     }
-//     catch(const std::exception& err)
-//     {
-//         std::string msg = "Unsupported field type in dtype: \"float64\"";
-//         std::string actual = err.what();
-//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
-//     }
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"] = "level";
 
-//     // catch if shape is not tet or tri
-//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     side_mesh["topologies/topo/elements/shape"] = "strange_shape";
-//     try
-//     {
-//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-//         FAIL();
-//     }
-//     catch(const std::exception& err)
-//     {
-//         std::string msg = "Bad shape in strange_shape";
-//         std::string actual = err.what();
-//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
-//     }
+    // catch if field is vertex associated
+    try
+    {
+        n["fields/level/association"] = "vertex";
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                n["fields"],
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Vertex associated fields are not supported.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}
 
-//     // catch if field is vertex associated
-//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     n["fields/level/association"] = "vertex";
-//     try
-//     {
-//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-//         FAIL();
-//     }
-//     catch(const std::exception& err)
-//     {
-//         std::string msg = "Vertex associated fields are not supported.";
-//         std::string actual = err.what();
-//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
-//     }
-//     n["fields/level/association"] = "element";
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_vol_dep_ex)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
 
-//     // catch if field is volume dependent
-//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     n["fields/level/volume_dependent"] = "true";
-//     try
-//     {
-//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-//         FAIL();
-//     }
-//     catch(const std::exception& err)
-//     {
-//         std::string msg = "Volume dependent fields are not supported.";
-//         std::string actual = err.what();
-//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
-//     }
-//     n["fields/level/volume_dependent"] = "false";
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
 
-//     // catch if field has wrong data type
-//     blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     n["fields/level/values"].set(conduit::DataType::int8(1));
-//     try
-//     {
-//         blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
-//         FAIL();
-//     }
-//     catch(const std::exception& err)
-//     {
-//         std::string msg = "Unsupported field type in dtype: \"int8\"";
-//         std::string actual = err.what();
-//         EXPECT_TRUE(actual.find(msg) != std::string::npos);
-//     }
-// }
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"] = "level";
+
+    // catch if field is volume dependent
+    try
+    {
+        n["fields/level/volume_dependent"] = "true";
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                n["fields"],
+                                                                side_topo,
+                                                                side_coords,
+                                                                side_fields,
+                                                                s2dmap,
+                                                                d2smap,
+                                                                options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Volume dependent fields are not supported.";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_field_datatype_ex)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+    options["field_names"] = "level";
+
+    // catch if field has wrong data type
+    try
+    {
+        n["fields/level/values"].set(conduit::DataType::int8(1));
+        blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                                        n["fields"],
+                                                                        side_topo,
+                                                                        side_coords,
+                                                                        side_fields,
+                                                                        s2dmap,
+                                                                        d2smap,
+                                                                        options);
+        FAIL();
+    }
+    catch(const std::exception& err)
+    {
+        std::string msg = "Unsupported field type in dtype: \"int8\"";
+        std::string actual = err.what();
+        EXPECT_TRUE(actual.find(msg) != std::string::npos);
+    }
+}

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -105,7 +105,89 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_2D)
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_generate_unstructured, generate_sides_2D_options_no_field_names_and_field_prefix)
+TEST(conduit_blueprint_generate_unstructured, generate_sides_2D_options_no_field_names)
+{
+    index_t nlevels = 2;
+    Node n, side_mesh, info;
+
+    // create polytessalation with two levels
+    examples::polytess(nlevels, n);
+    EXPECT_TRUE(verify(n, info));
+
+    Node s2dmap, d2smap;
+    Node &side_coords = side_mesh["coordsets/coords"];
+    Node &side_topo = side_mesh["topologies/topo"];
+    Node &side_fields = side_mesh["fields"];
+    Node options;
+
+    blueprint::mesh::topology::unstructured::generate_sides(n["topologies/topo"],
+                                                            side_topo,
+                                                            side_coords,
+                                                            side_fields,
+                                                            s2dmap,
+                                                            d2smap,
+                                                            options);
+
+    EXPECT_TRUE(verify(side_mesh, info));
+
+    EXPECT_EQ(side_mesh["fields/level/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/level/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/level/volume_dependent"].as_string(), "false");
+
+    index_t num_field_values = 56;
+    index_t num_polygons = 9;
+    EXPECT_EQ(side_mesh["fields/level/values"].dtype().number_of_elements(), num_field_values);
+
+    uint32 *level_values = side_mesh["fields/level/values"].value();
+
+    for (int i = 0; i < num_field_values; i ++)
+    {
+        if (i < 8)
+        {
+            EXPECT_EQ(level_values[i], 1);
+        }
+        else
+        {
+            EXPECT_EQ(level_values[i], 2);
+        }
+    }
+
+    EXPECT_EQ(side_mesh["fields/original_element_ids/topology"].as_string(), "topo");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/association"].as_string(), "element");
+    EXPECT_EQ(side_mesh["fields/original_element_ids/volume_dependent"].as_string(), "false");
+
+    EXPECT_EQ(side_mesh["fields/original_element_ids/values"].dtype().number_of_elements(), num_field_values);
+
+    uint32 *id_values = side_mesh["fields/original_element_ids/values"].value();
+    
+    int i = 0;
+    for (int j = 0; j < num_polygons; j ++)
+    {
+        if (j % 2)
+        {
+            EXPECT_EQ(id_values[i], j);
+            EXPECT_EQ(id_values[i + 1], j);
+            EXPECT_EQ(id_values[i + 2], j);
+            EXPECT_EQ(id_values[i + 3], j);
+            i += 4;
+        }
+        else
+        {
+            EXPECT_EQ(id_values[i], j);
+            EXPECT_EQ(id_values[i + 1], j);
+            EXPECT_EQ(id_values[i + 2], j);
+            EXPECT_EQ(id_values[i + 3], j);
+            EXPECT_EQ(id_values[i + 4], j);
+            EXPECT_EQ(id_values[i + 5], j);
+            EXPECT_EQ(id_values[i + 6], j);
+            EXPECT_EQ(id_values[i + 7], j);
+            i += 8;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_generate_unstructured, generate_sides_2D_options_field_prefix)
 {
     index_t nlevels = 2;
     Node n, side_mesh, info;

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -21,23 +21,6 @@
 using namespace conduit;
 using namespace conduit::blueprint::mesh;
 
-// void 
-// generate_sides_and_map_fields(const Node &poly_mesh,
-//                                                             Node &side_mesh,
-//                                                             const std::string &topology)
-// {
-//     Node s2dmap, d2smap;
-//     Node &side_coords = side_mesh["coordsets/coords"];
-//     Node &side_topo = side_mesh["topologies/" + topology];
-//     blueprint::mesh::topology::unstructured::generate_sides(poly_mesh["topologies/" + topology], 
-//                                                             side_topo, 
-//                                                             side_coords, 
-//                                                             s2dmap, 
-//                                                             d2smap);
-//     map_fields_to_generated_sides(poly_mesh, d2smap, side_mesh, topology);
-// }
-
-
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_2D)
 {

--- a/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate_map_fields.cpp
@@ -175,7 +175,7 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exce
     d2smap["values"].set(conduit::DataType::float64(1));
     try
     {
-        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
         FAIL();
     }
     catch(const std::exception& err)
@@ -194,7 +194,7 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exce
     side_mesh["topologies/topo/elements/shape"] = "strange_shape";
     try
     {
-        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
         FAIL();
     }
     catch(const std::exception& err)
@@ -213,7 +213,7 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exce
     n["fields/level/association"] = "vertex";
     try
     {
-        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
         FAIL();
     }
     catch(const std::exception& err)
@@ -233,7 +233,7 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides_and_map_fields_exce
     n["fields/level/volume_dependent"] = "true";
     try
     {
-        blueprint::mesh::topology::unstructured::map_fields(n, d2smap, side_mesh, "topo");
+        blueprint::mesh::topology::unstructured::map_fields_to_generated_sides(n, d2smap, side_mesh, "topo");
         FAIL();
     }
     catch(const std::exception& err)


### PR DESCRIPTION
`generate_sides_and_map_fields` calls the existing `generate_sides`, and then maps fields correctly based on the original and newly generated topologies. It does not currently support vertex associated fields and volume dependent fields.