### PR TITLE
Fix check for threads target

### DIFF
--- a/src/config/conduit_setup_deps.cmake
+++ b/src/config/conduit_setup_deps.cmake
@@ -10,7 +10,7 @@ include(CMakeFindDependencyMacro)
 if(UNIX AND NOT APPLE)
 # we depend on Threads::Threads in our exported targets
 # so we need to bootstrap that here
-    if(NOT Threads::Threads)
+    if(NOT TARGET Threads::Threads)
         find_package( Threads REQUIRED )
     endif()
 endif()


### PR DESCRIPTION
This changes the if check to the existence of the target `Threads::Threads` not treating it like a constant, variable, or a string.

This unfortunately is not the source of the current problem I think, this was just causing `find_package(Threads)` to always be called.  I guess something could have this variable defined but that would be crazy and I just noticed this while poking around.