### PR TITLE
conduit/c: use a type safe alias for `conduit_{datatype,node}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### General
 - Avoid compile issue with using `_Pragma()` with Python 3.8 on Windows
+- `conduit_node` and `conduit_datatype` in the C API are no longer aliases to `void` so that callers cannot pass just any pointer to the APIs.
 
 #### Blueprint
 - Added the `blueprint::mesh::examples::polychain` example. It is an example of a polyhedral mesh. See Mesh Blueprint Examples docs (https://llnl-conduit.readthedocs.io/en/latest/blueprint_mesh.html#polychain) for more details.

--- a/src/libs/conduit/c/conduit_cpp_to_c.cpp
+++ b/src/libs/conduit/c/conduit_cpp_to_c.cpp
@@ -18,19 +18,20 @@
 namespace conduit
 {
 
+struct conduit_node_impl {};
 
 //---------------------------------------------------------------------------//
 Node *
 cpp_node(conduit_node *cnode)
 {
-    return static_cast<Node*>(cnode);
+    return reinterpret_cast<Node*>(cnode);
 }
 
 //---------------------------------------------------------------------------//
 conduit_node *
 c_node(Node *node)
 {
-    return (void*)node;
+    return reinterpret_cast<conduit_node*>(node);
 }
 
 
@@ -38,42 +39,44 @@ c_node(Node *node)
 const Node *
 cpp_node(const conduit_node *cnode)
 {
-    return static_cast<const Node*>(cnode);
+    return reinterpret_cast<const Node*>(cnode);
 }
 
 //---------------------------------------------------------------------------//
 const conduit_node *
 c_node(const Node *node)
 {
-    return (void*)node;
+    return reinterpret_cast<const conduit_node*>(node);
 }
 
 //---------------------------------------------------------------------------//
 Node &
 cpp_node_ref(conduit_node *cnode)
 {
-    return *static_cast<Node*>(cnode);
+    return *reinterpret_cast<Node*>(cnode);
 }
 
 //---------------------------------------------------------------------------//
 const Node &
 cpp_node_ref(const conduit_node *cnode)
 {
-    return *static_cast<const Node*>(cnode);
+    return *reinterpret_cast<const Node*>(cnode);
 }
+
+struct conduit_datatype_impl {};
 
 //---------------------------------------------------------------------------//
 DataType *
 cpp_datatype(conduit_datatype *cdatatype)
 {
-    return static_cast<DataType*>(cdatatype);
+    return reinterpret_cast<DataType*>(cdatatype);
 }
 
 //---------------------------------------------------------------------------//
 conduit_datatype *
 c_datatype(DataType *datatype)
 {
-    return (void*)datatype;
+    return reinterpret_cast<conduit_datatype*>(datatype);
 }
 
 
@@ -81,28 +84,28 @@ c_datatype(DataType *datatype)
 const DataType *
 cpp_datatype(const conduit_datatype *cdatatype)
 {
-    return static_cast<const DataType*>(cdatatype);
+    return reinterpret_cast<const DataType*>(cdatatype);
 }
 
 //---------------------------------------------------------------------------//
 const conduit_datatype *
 c_datatype(const DataType *datatype)
 {
-    return (void*)datatype;
+    return reinterpret_cast<const conduit_datatype*>(datatype);
 }
 
 //---------------------------------------------------------------------------//
 DataType &
 cpp_datatype_ref(conduit_datatype *cdatatype)
 {
-    return *static_cast<DataType*>(cdatatype);
+    return *reinterpret_cast<DataType*>(cdatatype);
 }
 
 //---------------------------------------------------------------------------//
 const DataType &
 cpp_datatype_ref(const conduit_datatype *cdatatype)
 {
-    return *static_cast<const DataType*>(cdatatype);
+    return *reinterpret_cast<const DataType*>(cdatatype);
 }
 
 }

--- a/src/libs/conduit/c/conduit_datatype.h
+++ b/src/libs/conduit/c/conduit_datatype.h
@@ -29,7 +29,8 @@ extern "C" {
 // -- typedef for conduit_datatype --
 //-----------------------------------------------------------------------------
 
-typedef void  conduit_datatype;
+struct conduit_datatype_impl;
+typedef struct conduit_datatype_impl  conduit_datatype;
 
 CONDUIT_API conduit_index_t conduit_datatype_id(const conduit_datatype *cdatatype);
 CONDUIT_API char* conduit_datatype_name(const conduit_datatype *cdatatype);

--- a/src/libs/conduit/c/conduit_node.h
+++ b/src/libs/conduit/c/conduit_node.h
@@ -31,7 +31,8 @@ extern "C" {
 // -- typedef for conduit_node --
 //-----------------------------------------------------------------------------
 
-typedef void  conduit_node;
+struct conduit_node_impl;
+typedef struct conduit_node_impl  conduit_node;
 
 //-----------------------------------------------------------------------------
 // -- conduit_node creation and destruction --


### PR DESCRIPTION
Using `typedef void` meant that the APIs were all taking `void*` which
in turn means that any pointer is valid to pass to these types. Instead,
use a unique opaque type so that callers must either do the unsafe
casting themselves or use the `cpp_to_c` APIs to do the casting the
intended way.

The actual definition of the structs themselves are empty; they are just
used it as a way to smuggle the C++ pointer around under an opaque name.

Fixes: #782