### PR TITLE
add a unit test that demos and times a few diff dispatch options

### DIFF
--- a/src/tests/conduit/CMakeLists.txt
+++ b/src/tests/conduit/CMakeLists.txt
@@ -36,6 +36,7 @@ set(BASIC_TESTS t_conduit_smoke
                 t_conduit_node_iterator
                 t_conduit_node_cpp_iterator
                 t_conduit_node_obj_names_with_slashes
+                t_conduit_node_type_dispatch
                 t_conduit_schema
                 t_conduit_error
                 t_conduit_log

--- a/src/tests/conduit/t_conduit_node_type_dispatch.cpp
+++ b/src/tests/conduit/t_conduit_node_type_dispatch.cpp
@@ -138,31 +138,41 @@ TEST(conduit_node, test_dispatch)
     std::cout << "Number of elements: " <<  ARRAY_SIZE << std::endl;
     std::cout << "Iterations: " << NUM_ITERS << std::endl;
 
+    float64 res1,res2,res3;
+
     Timer t1;
     for(index_t i=0;i<NUM_ITERS;i++)
     {
-        on_the_fly_convert(n);
+        res1 = on_the_fly_convert(n);
     }
     t1.elapsed();
 
     Timer t2;
     for(index_t i=0;i<NUM_ITERS;i++)
     {
-        array_convert(n);
+        res2 = array_convert(n);
     }
     t2.elapsed();
 
     Timer t3;
     for(index_t i=0;i<NUM_ITERS;i++)
     {
-        template_dispatch(n);
+        res3 = template_dispatch(n);
     }
     t3.elapsed();
 
+    EXPECT_EQ(res1,float64(ARRAY_SIZE));
+    EXPECT_EQ(res2,float64(ARRAY_SIZE));
+    EXPECT_EQ(res3,float64(ARRAY_SIZE));
+
+    // std::cout << "on_the_fly_convert (last res): " << res1 << std::endl;
+    // std::cout << "array_convert (last res):      " << res2 << std::endl;
+    // std::cout << "template_dispatch (last res):  " << res3 << std::endl;
 
     std::cout << "on_the_fly_convert: " << t1.elapsed() << std::endl;
     std::cout << "array_convert:      " << t2.elapsed() << std::endl;
     std::cout << "template_dispatch:  " << t3.elapsed() << std::endl;
+
 
 }
 

--- a/src/tests/conduit/t_conduit_node_type_dispatch.cpp
+++ b/src/tests/conduit/t_conduit_node_type_dispatch.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_node_type_dispatch.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+
+#include <iostream>
+#include "gtest/gtest.h"
+#include "rapidjson/document.h"
+using namespace conduit;
+
+index_t ARRAY_SIZE = 1000000;
+index_t NUM_ITERS  = 1;
+
+
+/// simple timer class
+//-----------------------------------------------------------------------------
+class Timer 
+{
+
+  typedef std::chrono::high_resolution_clock high_resolution_clock;
+  typedef std::chrono::nanoseconds nanoseconds;
+  typedef std::chrono::duration<float> fsec;
+
+public:
+    explicit Timer()
+    {
+      reset();
+    }
+
+    void reset()
+    {
+      m_start = high_resolution_clock::now();
+    }
+
+    float elapsed() const
+    {
+       auto ftime  = std::chrono::duration_cast<fsec>(high_resolution_clock::now() - m_start);
+       return ftime.count();
+    }
+
+private:
+    high_resolution_clock::time_point m_start;
+};
+
+
+//-----------------------------------------------------------------------------
+// -- type specific template imp 
+template<typename T>
+float64
+template_dispatch_detail(Node &n)
+{
+    float64 res = 0;
+    index_t nele = n.dtype().number_of_elements();
+    T *t_ptr = n.value();
+    for(index_t i=0; i < nele;i++)
+    {
+        res += t_ptr[i];
+    }
+
+    return res;
+}
+
+//-----------------------------------------------------------------------------
+// -- use template dispatch
+float64 
+template_dispatch(Node &n)
+{
+    if(n.dtype().is_float64())
+    {
+        return template_dispatch_detail<float64>(n);
+    }
+    else if(n.dtype().is_float32())
+    {
+        return template_dispatch_detail<float32>(n);
+    }
+
+    return 0.0;
+}
+
+//-----------------------------------------------------------------------------
+// -- convert each element to desired type in the loop
+float64 
+on_the_fly_convert(Node &n)
+{
+    float64 res = 0;
+    index_t nele = n.dtype().number_of_elements();
+
+    Node temp;
+    for(index_t i=0; i < nele;i++)
+    {
+        temp.set_external(n.dtype(),n.element_ptr(i));
+        res += temp.to_float64();
+    }
+
+    return res;
+}
+
+//-----------------------------------------------------------------------------
+// -- convert the array to desired type, then loop
+float64 
+array_convert(Node &n)
+{
+    float64 res = 0;
+    index_t nele = n.dtype().number_of_elements();
+
+    Node temp;
+    n.to_float64_array(temp);
+    float64 *f64_ptr = temp.value();
+
+    for(index_t i=0; i < nele;i++)
+    {
+        res += f64_ptr[i];
+    }
+
+    return res;
+}
+
+
+//-----------------------------------------------------------------------------
+TEST(conduit_node, test_dispatch)
+{
+    Node n;
+    
+    n.set(DataType::float32(ARRAY_SIZE));
+    float32 *f32_ptr = n.value();
+    for(index_t i=0;i<ARRAY_SIZE;i++)
+    {
+        f32_ptr[i] = 1.0;
+    }
+
+    std::cout << "Number of elements: " <<  ARRAY_SIZE << std::endl;
+    std::cout << "Iterations: " << NUM_ITERS << std::endl;
+
+    Timer t1;
+    for(index_t i=0;i<NUM_ITERS;i++)
+    {
+        on_the_fly_convert(n);
+    }
+    t1.elapsed();
+
+    Timer t2;
+    for(index_t i=0;i<NUM_ITERS;i++)
+    {
+        array_convert(n);
+    }
+    t2.elapsed();
+
+    Timer t3;
+    for(index_t i=0;i<NUM_ITERS;i++)
+    {
+        template_dispatch(n);
+    }
+    t3.elapsed();
+
+
+    std::cout << "on_the_fly_convert: " << t1.elapsed() << std::endl;
+    std::cout << "array_convert:      " << t2.elapsed() << std::endl;
+    std::cout << "template_dispatch:  " << t3.elapsed() << std::endl;
+
+}
+
+//-----------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+    int result = 0;
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    // allow override of the data size via the command line
+    if(argc > 1)
+    {
+        ARRAY_SIZE = atoi(argv[1]);
+    }
+
+    if(argc > 2)
+    {
+        NUM_ITERS = atoi(argv[2]);
+    }
+
+
+    result = RUN_ALL_TESTS();
+    return result;
+}
+
+
+
+

--- a/src/tests/conduit/t_conduit_node_type_dispatch.cpp
+++ b/src/tests/conduit/t_conduit_node_type_dispatch.cpp
@@ -11,9 +11,12 @@
 #include "conduit.hpp"
 
 #include <iostream>
+#include <chrono>
+
 #include "gtest/gtest.h"
 #include "rapidjson/document.h"
 using namespace conduit;
+
 
 index_t ARRAY_SIZE = 1000000;
 index_t NUM_ITERS  = 1;


### PR DESCRIPTION
does a simple float64 sum of input array using 3 different methods 

You can override the array size and the number of iterations  timed:

`./tests/conduit/t_conduit_node_type_dispatch {array_size} {num_iters}`

Example run (debug build on macOS with swelling battery)

`./tests/conduit/t_conduit_node_type_dispatch 1000000 10`

```
Number of elements: 1000000
Iterations: 10
on_the_fly_convert: 2.02642
array_convert:      0.218024
template_dispatch:  0.0253357
```