### PR TITLE
a few cmake fixes

### DIFF
--- a/src/cmake/thirdparty/SetupHDF5.cmake
+++ b/src/cmake/thirdparty/SetupHDF5.cmake
@@ -209,6 +209,8 @@ if(hdf5_tpl_lnk_libs_len EQUAL 1)
     else()
         separate_arguments(_temp_link_libs UNIX_COMMAND "${hdf5_tpl_lnk_libs}")
     endif()
+else()
+    set(_temp_link_libs "${hdf5_tpl_lnk_libs}")
 endif()
 
 # add -l to any libraries that are just their names (like "m" instead of "-lm")

--- a/src/cmake/thirdparty/SetupPython.cmake
+++ b/src/cmake/thirdparty/SetupPython.cmake
@@ -5,11 +5,11 @@
 # Find the interpreter first
 if(PYTHON_DIR AND NOT PYTHON_EXECUTABLE)
     if(UNIX)
-        set(PYTHON_EXECUTABLE ${PYTHON_DIR}/bin/python)
-        # if this doesn't exist, we may be using python3, which
-        # in many variants only creates "python3" exe, not "python"
+        # look for python 3 first
+        set(PYTHON_EXECUTABLE ${PYTHON_DIR}/bin/python3)
+        # if this doesn't exist, look for python
         if(NOT EXISTS "${PYTHON_EXECUTABLE}")
-            set(PYTHON_EXECUTABLE ${PYTHON_DIR}/bin/python3)
+            set(PYTHON_EXECUTABLE ${PYTHON_DIR}/bin/python)
         endif()
     elseif(WIN32)
         set(PYTHON_EXECUTABLE ${PYTHON_DIR}/python.exe)
@@ -25,7 +25,7 @@ if(PYTHONINTERP_FOUND)
                         "import sys;from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('VERSION'))"
                         OUTPUT_VARIABLE PYTHON_CONFIG_VERSION
                         ERROR_VARIABLE  ERROR_FINDING_PYTHON_VERSION)
-        MESSAGE(STATUS "PYTHON_CONFIG_VERSION $PYTHON_CONFIG_VERSION}")
+        MESSAGE(STATUS "PYTHON_CONFIG_VERSION ${PYTHON_CONFIG_VERSION}")
 
         execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" 
                                 "import sys;from distutils.sysconfig import get_python_inc;sys.stdout.write(get_python_inc())"


### PR DESCRIPTION
prefer python3 when `PYTHON_DIR` is given, and `PYTHON_EXECUTABLE` is not
typo in cmake message statement
fix issue in cmake hdf5 setup logic
