### PR TITLE
add more input guards mesh bp braid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Blueprint
 - Added support for both `const` and non-`const` inputs to the `conduit::blueprint::mesh::domains` function.
 - Improved mesh blueprint index generation logic (local and MPI) to support domains with different topos, fields, etc. 
+- Deprecated accepting `npts_z !=0` for 2D shape types in `conduit::blueprint::mesh::examples::{braid,basic,grid}`. They issue a `CONDUIT_INFO` message when this detected and future versions will issue a `CONDUIT_ERROR`.
 
 #### Relay
 - Added CMake option (`ENABLE_RELAY_WEBSERVER`, default = `ON`) to control if Conduit's Relay Web Server support is built. Down stream codes can check for support via header ifdef `CONDUIT_RELAY_WEBSERVER_ENABLED` or at runtime in `conduit::relay::about`.

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -66,7 +66,11 @@ namespace examples
 //---------------------------------------------------------------------------//
 const float64 PI_VALUE = 3.14159265359;
 
-// controls if we throw an exception when npts_z != 0 for 2D only examples
+// NOTE(CYRUSH) 
+// Using npts_z != 0 for 2d only shape types in our examples is deprecated
+// this bool controls if we throw an exception when npts_z != 0 for 2D
+// only examples. In a future release move to throw error and remove
+// this and related CONDUIT_INFO logic
 const bool STRICT_NPTS_Z_FOR_2D = false;
 
 //---------------------------------------------------------------------------//
@@ -2210,11 +2214,19 @@ basic(const std::string &mesh_type,
     bool npts_z_ok = mesh_types_dims[mesh_type_index] == 2 || npts_z > 1;
     
     
-    if( STRICT_NPTS_Z_FOR_2D &&
-        npts_z != 0 &&
+    if( npts_z != 0 &&
         braid_2d_only_shape_type(mesh_type) )
     {
-        npts_z_ok = false;
+        if(STRICT_NPTS_Z_FOR_2D)
+        {
+            npts_z_ok = false;
+        }
+        else
+        {
+            CONDUIT_INFO("DEPRECATED:"
+                     " Detected npts_z != 0 for example with 2D shape type."
+                     " This will throw a conduit::Error in a future release.");
+        }
     }
 
     // don't let de-morgan get you ...
@@ -2277,11 +2289,19 @@ grid(const std::string &mesh_type,
     // validate braid input here for nicer exception loc
     bool npts_ok = (npts_x > 1 && npts_y > 1);
 
-    if( STRICT_NPTS_Z_FOR_2D &&
-        npts_z != 0 &&
+    if( npts_z != 0 &&
         braid_2d_only_shape_type(mesh_type) )
     {
-        npts_ok = false;
+        if(STRICT_NPTS_Z_FOR_2D)
+        {
+            npts_ok = false;
+        }
+        else
+        {
+            CONDUIT_INFO("DEPRECATED:"
+                    " Detected npts_z != 0 for example with 2D shape type."
+                    " This will throw a conduit::Error in a future release.");
+        }
     }
 
     if( braid_3d_only_shape_type(mesh_type) )
@@ -2391,11 +2411,19 @@ braid(const std::string &mesh_type,
         // check 2d cases which require npts z = 0
         
 
-        if ( STRICT_NPTS_Z_FOR_2D &&
-             npts_z != 0 &&
+        if ( npts_z != 0 &&
              braid_2d_only_shape_type(mesh_type) )
         {
-            npts_z_ok = false;
+            if(STRICT_NPTS_Z_FOR_2D)
+            {
+                npts_z_ok = false;
+            }
+            else;
+            {
+                CONDUIT_INFO("DEPRECATED:"
+                    " Detected npts_z != 0 for example with 2D shape type."
+                    " This will throw a conduit::Error in a future release.");
+            }
         }
 
         // check 3d cases which require z

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -123,7 +123,7 @@ TEST(conduit_blueprint_mesh_examples, mesh_2d)
     // can be overridden via command line
     index_t npts_x = OUTPUT_NUM_AXIS_POINTS;
     index_t npts_y = OUTPUT_NUM_AXIS_POINTS;
-    index_t npts_z = 1; // 2D examples ...
+    index_t npts_z = 0; // 2D examples ...
 
     blueprint::mesh::examples::braid("uniform",
                                       npts_x,

--- a/src/tests/blueprint/t_blueprint_mesh_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate.cpp
@@ -66,6 +66,22 @@ const static index_t COMPLEX_GRID[] = {4, 4, 4};
 typedef std::vector<index_t> index_list;
 
 /// Testing Helpers ///
+index_t braid_bound_npts_z(const std::string &mesh_type, index_t npts_z)
+{
+    if(mesh_type == "tris"  ||
+       mesh_type == "quads" ||
+       mesh_type == "quads_poly" ||
+       mesh_type == "quads_and_tris" ||
+       mesh_type == "quads_and_tris_offsets")
+    {
+        return 0;
+    }
+    else
+    {
+        return npts_z;
+    }
+}
+
 
 // NOTE(JRC): This is basically an implementation of the combinatorical concept
 // of "n choose i" with all results being returned as lists over index space.
@@ -164,7 +180,11 @@ struct GridMesh
     GridMesh(index_t type, const index_t *npts, bool poly = false)
     {
         Node info;
-        mesh::examples::braid(ELEM_TYPE_LIST[type], npts[0], npts[1], npts[2], mesh);
+        mesh::examples::braid(ELEM_TYPE_LIST[type],
+                              npts[0],
+                              npts[1],
+                              braid_bound_npts_z(ELEM_TYPE_LIST[type],npts[2]),
+                              mesh);
 
         Node &topo = mesh["topologies"].child(0);
         mesh::topology::unstructured::generate_offsets(topo, topo["elements/offsets"]);

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -26,7 +26,7 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_basic)
 {
     Node mesh;
     {
-        blueprint::mesh::examples::basic("quads", 2, 2, 2, mesh);
+        blueprint::mesh::examples::basic("quads", 2, 2, 0, mesh);
 
         float64 mset_a_vfs[] = {1.0, 0.5, 0.5, 0.0};
         float64 mset_b_vfs[] = {0.0, 0.5, 0.5, 1.0};

--- a/src/tests/blueprint/t_blueprint_mesh_partition.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_partition.cpp
@@ -558,7 +558,7 @@ TEST(conduit_blueprint_mesh_partition, uniform_explicit_2d)
 //       I could not visually verify the mesh. The files look okay.
 TEST(conduit_blueprint_mesh_partition, quads_poly_explicit_2d)
 {
-    conduit::index_t vdims[] = {11,11,1};
+    conduit::index_t vdims[] = {11,11,0};
     test_explicit_selection("quads_poly", vdims, "quads_poly_explicit_2d", spc);
 }
 
@@ -580,7 +580,7 @@ TEST(conduit_blueprint_mesh_partition, hexs_poly_explicit_3d)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_partition, quads_and_tris_explicit_2d)
 {
-    conduit::index_t vdims[] = {11,11,1};
+    conduit::index_t vdims[] = {11,11,0};
     test_explicit_selection("quads_and_tris", vdims, "quads_end_tris_explicit_2d",
         quads_and_tris_spc);
 }
@@ -604,6 +604,10 @@ test_ranges_selection_2d(const std::string &topo, const std::string &base)
     // Make 10x10x1 cell mesh.
     conduit::Node input, output, options, msg;
     conduit::index_t vdims[] = {11,11,1};
+    if(topo == "quads")
+    {
+        vdims[2] = 0;
+    }
     conduit::blueprint::mesh::examples::braid(topo, vdims[0], vdims[1], vdims[2], input);
     // Override with int64 because YAML loses int/uint information.
     conduit::int64 i100 = 100;
@@ -1038,7 +1042,7 @@ TEST(conduit_blueprint_mesh_combine, recombine_braid)
         std::cout << "-------- End case " << case_name << "   --------" << std::endl;
     };
 
-    static const conduit::index_t dims2[] = {11,11,1};
+    static const conduit::index_t dims2[] = {11,11,0};
     static const std::array<std::string, 4> cases2 = {
         "tris",
         "quads",
@@ -1129,8 +1133,11 @@ TEST(conduit_blueprint_mesh_combine, to_poly)
         conduit::Node poly_braid;
         if(vdims[2] > 1)
         {
-            conduit::blueprint::mesh::examples::braid("hexs_poly", 2,
-                2, 2, poly_braid);
+            conduit::blueprint::mesh::examples::braid("hexs_poly",
+                                                      2,
+                                                      2,
+                                                      2,
+                                                      poly_braid);
 
             // Move the points to the side
             std::array<std::array<double, 8>, 3> new_coords = {{
@@ -1168,7 +1175,7 @@ TEST(conduit_blueprint_mesh_combine, to_poly)
         else
         {
             conduit::blueprint::mesh::examples::braid("quads_poly", 2,
-                2, 1, poly_braid);
+                2, 0, poly_braid);
 
             // Move the points to the side
             std::array<std::array<double, 4>, 2> new_coords = {{
@@ -1241,7 +1248,7 @@ TEST(conduit_blueprint_mesh_combine, to_poly)
         std::cout << "-------- End case " << case_name << "   --------" << std::endl;
     };
 
-    static const conduit::index_t dims2[] = {11,11,1};
+    static const conduit::index_t dims2[] = {11,11,0};
     static const std::array<std::string, 3> cases2 = {
         "tris",
         "quads",

--- a/src/tests/blueprint/t_blueprint_mesh_query.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_query.cpp
@@ -52,7 +52,7 @@ TEST(conduit_blueprint_mesh_query, mesh_domains)
     { // Non-Empty Tests //
         { // Uni-Domain Test //
             Node mesh;
-            blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+            blueprint::mesh::examples::braid("quads",10,10,0,mesh);
 
             const std::vector<Node *> domains = blueprint::mesh::domains(mesh);
             ASSERT_EQ(domains.size(), 1);
@@ -61,7 +61,7 @@ TEST(conduit_blueprint_mesh_query, mesh_domains)
 
         { // Multi-Domain Test //
             Node mesh;
-            blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
 
             std::set<Node *> ref_domains;
             for(const std::string &child_name : mesh.child_names())
@@ -86,7 +86,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
         { // Empty Test //
             Node mesh, info;
 
-            blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
 
             for(Node *domain : blueprint::mesh::domains(mesh))
             {
@@ -102,7 +102,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
         { // Positive Test //
             Node mesh, info;
 
-            blueprint::mesh::examples::grid("quads",10,10,1,2,1,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,1,1,mesh);
             for(const Node *domain : blueprint::mesh::domains(mesh))
             {
                 const Node &domain_adjset = (*domain)["adjsets"].child(0);
@@ -110,7 +110,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
                 ASSERT_TRUE(blueprint::mesh::adjset::is_pairwise(domain_adjset));
             }
 
-            blueprint::mesh::examples::grid("quads",10,10,1,4,1,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,4,1,1,mesh);
             for(const Node *domain : blueprint::mesh::domains(mesh))
             {
                 const Node &domain_adjset = (*domain)["adjsets"].child(0);
@@ -122,7 +122,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
         { // Negative Test //
             Node mesh, info;
 
-            blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
             for(const Node *domain : blueprint::mesh::domains(mesh))
             {
                 const Node &domain_adjset = (*domain)["adjsets"].child(0);
@@ -144,7 +144,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
         { // Empty Test //
             Node mesh, info;
 
-            blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
 
             for(Node *domain : blueprint::mesh::domains(mesh))
             {
@@ -160,7 +160,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
         { // Positive Test //
             Node mesh, info;
 
-            blueprint::mesh::examples::grid("quads",10,10,1,2,1,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,1,1,mesh);
             for(const Node *domain : blueprint::mesh::domains(mesh))
             {
                 const Node &domain_adjset = (*domain)["adjsets"].child(0);
@@ -168,7 +168,7 @@ TEST(conduit_blueprint_mesh_query, adjset_formats)
                 ASSERT_TRUE(blueprint::mesh::adjset::is_maxshare(domain_adjset));
             }
 
-            blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+            blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
             for(const Node *domain : blueprint::mesh::domains(mesh))
             {
                 const Node &domain_adjset = (*domain)["adjsets"].child(0);

--- a/src/tests/blueprint/t_blueprint_mesh_transform.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform.cpp
@@ -32,13 +32,33 @@ typedef bool (*VerifyFun)(const Node&, Node&);
 
 /// Testing Helpers ///
 
+index_t braid_bound_npts_z(const std::string &mesh_type, index_t npts_z)
+{
+    if(mesh_type == "tris"  ||
+       mesh_type == "quads" ||
+       mesh_type == "quads_poly" ||
+       mesh_type == "quads_and_tris" ||
+       mesh_type == "quads_and_tris_offsets")
+    {
+        return 0;
+    }
+    else
+    {
+        return npts_z;
+    }
+}
+
 std::string get_braid_type(const std::string &mesh_type)
 {
     std::string braid_type;
     try
     {
         Node mesh;
-        blueprint::mesh::examples::braid(mesh_type,2,2,2,mesh);
+        blueprint::mesh::examples::braid(mesh_type,
+                                         2,
+                                         2,
+                                         braid_bound_npts_z(mesh_type,2),
+                                         mesh);
         braid_type = mesh_type;
     }
     catch(conduit::Error &) // actual exception is unused
@@ -48,6 +68,8 @@ std::string get_braid_type(const std::string &mesh_type)
 
     return braid_type;
 }
+
+
 
 // TODO(JRC): It would be useful to eventually have this type of procedure
 // available as an abstracted iteration strategy within Conduit (e.g. leaf iterate).
@@ -127,7 +149,11 @@ TEST(conduit_blueprint_mesh_transform, coordset_transforms)
         const std::string icoordset_braid = get_braid_type(icoordset_type);
 
         Node imesh;
-        blueprint::mesh::examples::braid(icoordset_braid,2,3,4,imesh);
+        blueprint::mesh::examples::braid(icoordset_braid,
+                                         2,
+                                         3,
+                                         braid_bound_npts_z(icoordset_braid,4),
+                                         imesh);
         const Node &icoordset = imesh["coordsets"].child(0);
 
         for(size_t xj = xi + 1; xj < bputils::COORD_TYPES.size(); xj++)
@@ -140,7 +166,11 @@ TEST(conduit_blueprint_mesh_transform, coordset_transforms)
                 jcoordset_type << "..." << std::endl;
 
             Node jmesh;
-            blueprint::mesh::examples::braid(jcoordset_braid,2,3,4,jmesh);
+            blueprint::mesh::examples::braid(jcoordset_braid,
+                                             2,
+                                             3,
+                                             braid_bound_npts_z(jcoordset_braid,4),
+                                             jmesh);
             Node &jcoordset = jmesh["coordsets"].child(0);
 
             XformCoordsFun to_new_coordset = xform_funs[xi][xj];
@@ -170,7 +200,11 @@ TEST(conduit_blueprint_mesh_transform, coordset_transform_dtypes)
         const std::string icoordset_braid = get_braid_type(icoordset_type);
 
         Node imesh;
-        blueprint::mesh::examples::braid(icoordset_braid,2,3,4,imesh);
+        blueprint::mesh::examples::braid(icoordset_braid,
+                                         2,
+                                         3,
+                                         braid_bound_npts_z(icoordset_braid,4),
+                                         imesh);
         const Node &icoordset = imesh["coordsets"].child(0);
 
         for(size_t xj = xi + 1; xj < bputils::COORD_TYPES.size(); xj++)
@@ -235,7 +269,11 @@ TEST(conduit_blueprint_mesh_transform, topology_transforms)
         const std::string itopology_braid = get_braid_type(itopology_type);
 
         Node imesh;
-        blueprint::mesh::examples::braid(itopology_braid,2,3,4,imesh);
+        blueprint::mesh::examples::braid(itopology_braid,
+                                         2,
+                                         3,
+                                         braid_bound_npts_z(itopology_braid,4),
+                                         imesh);
         const Node &itopology = imesh["topologies"].child(0);
         const Node &icoordset = imesh["coordsets"].child(0);
 
@@ -249,7 +287,11 @@ TEST(conduit_blueprint_mesh_transform, topology_transforms)
                 jtopology_type << "..." << std::endl;
 
             Node jmesh;
-            blueprint::mesh::examples::braid(jtopology_braid,2,3,4,jmesh);
+            blueprint::mesh::examples::braid(jtopology_braid,
+                                             2,
+                                             3,
+                                             braid_bound_npts_z(jtopology_braid,4),
+                                             jmesh);
             Node &jtopology = jmesh["topologies"].child(0);
             Node &jcoordset = jmesh["coordsets"].child(0);
 
@@ -302,7 +344,11 @@ TEST(conduit_blueprint_mesh_transform, topology_transform_dtypes)
         // NOTE(JRC): For the data type checks, we're only interested in the parts
         // of the subtree that are being transformed; we cull all other data.
         Node ibase;
-        blueprint::mesh::examples::braid(itopology_braid,2,3,4,ibase);
+        blueprint::mesh::examples::braid(itopology_braid,
+                                         2,
+                                         3,
+                                         braid_bound_npts_z(itopology_braid,4),
+                                         ibase);
         {
             Node temp;
             temp["coordsets"].set(ibase["coordsets"]);
@@ -375,7 +421,10 @@ TEST(conduit_blueprint_mesh_transform, polygonal_transforms)
 
         Node topo_mesh, info;
         blueprint::mesh::examples::braid(topo_type,
-            MESH_DIMS[0],MESH_DIMS[1],MESH_DIMS[2],topo_mesh);
+                                         MESH_DIMS[0],
+                                         MESH_DIMS[1],
+                                         braid_bound_npts_z(topo_type,MESH_DIMS[2]),
+                                         topo_mesh);
         const Node &topo_node = topo_mesh["topologies"].child(0);
 
         Node topo_poly;
@@ -507,7 +556,7 @@ TEST(conduit_blueprint_mesh_transform, adjset_transforms)
     // {{2, 1, 1}, {2, 2, 1}, {2, 2, 2}}
     const std::string ADJSET_ELEM_TYPES[4]      = {"quads", "quads", "hexs", "hexs"};
     const index_t ADJSET_DOM_DIMS[4][3]         = {{2, 1, 1}, {2, 2, 1}, {2, 2, 1}, {2, 2, 2}};
-    const index_t ADJSET_POINT_DIMS[4][3]       = {{3, 3, 1}, {3, 3, 1}, {3, 3, 3}, {3, 3, 3}};
+    const index_t ADJSET_POINT_DIMS[4][3]       = {{3, 3, 0}, {3, 3, 0}, {3, 3, 3}, {3, 3, 3}};
 
     for(index_t ai = 0; ai < 4; ai++)
     {
@@ -581,7 +630,7 @@ TEST(conduit_blueprint_mesh_transform, adjset_transform_dtypes)
         const std::string &xform_type = xform_types[xi];
 
         Node ibase, info;
-        blueprint::mesh::examples::grid("quads",2,2,1,2,2,1,ibase);
+        blueprint::mesh::examples::grid("quads",2,2,0,2,2,1,ibase);
 
         for(size_t ii = 0; ii < bputils::INT_DTYPES.size(); ii++)
         {

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -42,6 +42,23 @@ const std::vector<std::string> COORDINATE_COORDSYSS[] =
 typedef bool (*VerifyFun)(const Node&, Node&);
 
 /// Helper Functions ///
+/// Testing Helpers ///
+index_t braid_bound_npts_z(const std::string &mesh_type, index_t npts_z)
+{
+    if(mesh_type == "tris"  ||
+       mesh_type == "quads" ||
+       mesh_type == "quads_poly" ||
+       mesh_type == "quads_and_tris" ||
+       mesh_type == "quads_and_tris_offsets")
+    {
+        return 0;
+    }
+    else
+    {
+        return npts_z;
+    }
+}
+
 
 bool is_valid_coordsys(bool (*coordsys_valid_fun)(const Node&, Node&),
                        const std::vector<std::string>& coordsys)
@@ -450,7 +467,7 @@ TEST(conduit_blueprint_mesh_verify, coordset_types)
     for(index_t ci = 0; ci < 3; ci++)
     {
         n.reset();
-        blueprint::mesh::examples::braid(coordset_fids[ci],10,10,1,n);
+        blueprint::mesh::examples::braid(coordset_fids[ci],10,10,0,n);
         Node& coordset_node = n["coordsets/coords"];
         CHECK_MESH(verify_coordset,coordset_node,info,true);
 
@@ -875,7 +892,7 @@ TEST(conduit_blueprint_mesh_verify, topology_types)
     for(index_t ti = 0; ti < topo_type_count; ti++)
     {
         n.reset();
-        blueprint::mesh::examples::braid(topology_fids[ti],10,10,1,n);
+        blueprint::mesh::examples::braid(topology_fids[ti],10,10,0,n);
         Node& topology_node = n["topologies/mesh"];
         CHECK_MESH(verify_topology,topology_node,info,true);
 
@@ -916,7 +933,11 @@ TEST(conduit_blueprint_mesh_verify, topology_shape)
     for(index_t ti = 0; ti < topo_shape_count; ti++)
     {
         n.reset();
-        blueprint::mesh::examples::braid(topology_fids[ti],10,10,2,n);
+        blueprint::mesh::examples::braid(topology_fids[ti],
+                                         10,
+                                         10,
+                                         braid_bound_npts_z(topology_fids[ti], 2),
+                                         n);
         Node& topology_node = n["topologies/mesh"];
         CHECK_MESH(verify_topology,topology_node,info,true);
 
@@ -945,7 +966,7 @@ TEST(conduit_blueprint_mesh_verify, topology_general)
         Node mesh, info;
         CHECK_MESH(verify_topology,mesh,info,false);
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh);
         Node& n = mesh["topologies"]["mesh"];
 
         { // Type Field Tests //
@@ -1383,7 +1404,7 @@ TEST(conduit_blueprint_mesh_verify, field_general)
         Node mesh, info;
         CHECK_MESH(verify_field,mesh,info,false);
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh);
         Node& n = mesh["fields"]["braid"];
 
         { // Topology Field Tests //
@@ -1456,7 +1477,7 @@ TEST(conduit_blueprint_mesh_verify, adjset_general)
         Node mesh, info;
         CHECK_MESH(verify_adjset,mesh,info,false);
 
-        blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+        blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
         Node& n = mesh.child(0)["adjsets"].child(0);
         CHECK_MESH(verify_adjset,n,info,true);
 
@@ -1706,7 +1727,7 @@ TEST(conduit_blueprint_mesh_verify, index_coordset)
         Node mesh, index, info;
         CHECK_MESH(verify_coordset_index,mesh,info,false);
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh);
         blueprint::mesh::generate_index(mesh,"quads",1,index);
         Node& cindex = index["coordsets"]["coords"];
         CHECK_MESH(verify_coordset_index,cindex,info,true);
@@ -1769,7 +1790,7 @@ TEST(conduit_blueprint_mesh_verify, index_topology)
         Node mesh, index, info;
         CHECK_MESH(verify_topo_index,mesh,info,false);
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh);
         blueprint::mesh::generate_index(mesh,"quads",1,index);
         Node& tindex = index["topologies"]["mesh"];
         CHECK_MESH(verify_topo_index,tindex,info,true);
@@ -1832,7 +1853,7 @@ TEST(conduit_blueprint_mesh_verify, index_matset)
         Node mesh, index, info;
         CHECK_MESH(verify_matset_index,mesh,info,false);
 
-        blueprint::mesh::examples::misc("matsets",10,10,1,mesh);
+        blueprint::mesh::examples::misc("matsets",10,10,0,mesh);
         blueprint::mesh::generate_index(mesh,"quads",1,index);
         Node& mindex = index["matsets"]["mesh"];
         CHECK_MESH(verify_matset_index,mindex,info,true);
@@ -1904,7 +1925,7 @@ TEST(conduit_blueprint_mesh_verify, index_specset)
         Node mesh, index, info;
         CHECK_MESH(verify_specset_index,mesh,info,false);
 
-        blueprint::mesh::examples::misc("specsets",10,10,1,mesh);
+        blueprint::mesh::examples::misc("specsets",10,10,0,mesh);
         blueprint::mesh::generate_index(mesh,"quads",1,index);
         Node& mindex = index["specsets"]["mesh"];
         CHECK_MESH(verify_specset_index,mindex,info,true);
@@ -1961,7 +1982,7 @@ TEST(conduit_blueprint_mesh_verify, index_field)
         Node mesh, index, info;
         CHECK_MESH(verify_field_index,mesh,info,false);
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh);
         blueprint::mesh::generate_index(mesh,"quads",1,index);
         Node& findex = index["fields"]["braid"];
         CHECK_MESH(verify_field_index,findex,info,true);
@@ -2044,7 +2065,7 @@ TEST(conduit_blueprint_mesh_verify, index_adjset)
         Node mesh, index, info;
         CHECK_MESH(verify_adjset_index,mesh,info,false);
 
-        blueprint::mesh::examples::grid("quads",10,10,1,2,2,1,mesh);
+        blueprint::mesh::examples::grid("quads",10,10,0,2,2,1,mesh);
         blueprint::mesh::generate_index(mesh["domain0"],"quads",1,index);
         Node& aindex = index["adjsets"].child(0);
         CHECK_MESH(verify_adjset_index,aindex,info,true);
@@ -2112,7 +2133,7 @@ TEST(conduit_blueprint_mesh_verify, index_nestset)
         Node mesh, index, info;
         CHECK_MESH(verify_nestset_index,mesh,info,false);
 
-        blueprint::mesh::examples::misc("nestsets",5,5,1,mesh);
+        blueprint::mesh::examples::misc("nestsets",5,5,0,mesh);
         blueprint::mesh::generate_index(mesh["domain0"],"quads",1,index);
         Node& aindex = index["nestsets"].child(0);
         CHECK_MESH(verify_nestset_index,aindex,info,true);
@@ -2180,7 +2201,7 @@ TEST(conduit_blueprint_mesh_verify, index_general)
         Node mesh, index, info;
         CHECK_MESH(verify_index,mesh,info,false);
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh);
         blueprint::mesh::generate_index(mesh,"quads",1,index);
         CHECK_MESH(verify_index,index,info,true);
 
@@ -2405,11 +2426,11 @@ TEST(conduit_blueprint_mesh_verify, mesh_multi_domain)
     EXPECT_TRUE(has_empty_warning(info));
 
     Node domains[2];
-    blueprint::mesh::examples::braid("quads",10,10,1,domains[0]);
+    blueprint::mesh::examples::braid("quads",10,10,0,domains[0]);
     blueprint::mesh::to_multi_domain(domains[0],mesh);
     EXPECT_TRUE(blueprint::mesh::is_multi_domain(mesh));
 
-    blueprint::mesh::examples::braid("quads",5,5,1,domains[1]);
+    blueprint::mesh::examples::braid("quads",5,5,0,domains[1]);
     mesh.append().set_external(domains[1]);
     EXPECT_TRUE(blueprint::mesh::is_multi_domain(mesh));
 
@@ -2453,7 +2474,7 @@ TEST(conduit_blueprint_mesh_verify, mesh_general)
         CHECK_MESH(verify_mesh,mesh,info,true);
         EXPECT_TRUE(has_empty_warning(info));
 
-        blueprint::mesh::examples::braid("quads",10,10,1,mesh_data);
+        blueprint::mesh::examples::braid("quads",10,10,0,mesh_data);
 
         Node* domain_ptr = NULL;
         if(fi == 0)


### PR DESCRIPTION
audit uses of braid for 2d only shape types with `npts_z != 0`
add plumbing to allow a strict mode (currently off)
