### PR TITLE
Account for shared vertices in parmetis field generator

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -3281,6 +3281,10 @@ Partitioner::init_chunk_adjsets(const DomainToChunkMap& dom_2_chunks,
             chunks_to_init.push_back(local_chunk_id);
         }
 
+        if (!domain.has_child("adjsets"))
+        {
+            continue;
+        }
         // loop over all adjsets in the current domain
         for (const Node& adjset : domain["adjsets"].children())
         {

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
@@ -585,6 +585,19 @@ protected:
                             std::vector<int> &offsets);
 
     /**
+     @brief Generates initial intermediate adjsets for each chunk, based on the
+            adjsets in the original domains.
+
+     @param chunks A map of pre-partition domains to the set of local chunk ids
+                   it is decomposed into, as well as the associated vertex maps
+                   for each chunk.
+     @param[out] adjset_data An array of nodes containing adjset data for each
+                             chunk local to this rank.
+     */
+    void init_chunk_adjsets(const DomainToChunkMap& chunks,
+                            std::vector<conduit::Node*>& adjset_data);
+
+    /**
      @brief Generates a map from adjset vertex ids to their containing chunks.
             This map is generated per-adjset and is stored in CSR format, and
             is called by build_interdomain_adjsets() to construct splits of the

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
@@ -300,9 +300,28 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
             int64 vert_base_idx = global_verts_offset + local_vert_offsets[local_dom_idx];
 
             int64_array vert_ids_vals = verts_field["values"].value();
+            int64 curr_vert_id = 0;
             for(uint64 i=0; i < local_num_verts[local_dom_idx]; i++)
             {
-                vert_ids_vals[i] = i + vert_base_idx;
+                bool is_primary_domain = true;
+                int primary_domid;
+                if (dom_shared_nodes[local_dom_idx].count(i) > 0)
+                {
+                    primary_domid = dom_shared_nodes[local_dom_idx][i];
+                    is_primary_domain = (primary_domid == -1);
+                }
+
+                if (!is_primary_domain)
+                {
+                    // mark the node with the domain we need to fetch vids from
+                    vert_ids_vals[i] = ~primary_domid;
+                }
+                else
+                {
+                    // number a node for which we are the primary domain
+                    vert_ids_vals[i] = curr_vert_id + vert_base_idx;
+                    curr_vert_id++;
+                }
             }
 
             // NOTE: VISIT BP DOESNT SUPPORT UINT64!!!!

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
@@ -232,39 +232,39 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
     }
 
     // we now have our offsets, we can create output fields on each local domain
-     for(size_t local_dom_idx=0; local_dom_idx < domains.size(); local_dom_idx++)
-     {
-         Node &dom = *domains[local_dom_idx];
-         // we do need to make sure we have the requested topo
-         if(dom["topologies"].has_child(topo_name))
-         {
-             Node &verts_field = dom["fields"][field_prefix + "global_vertex_ids"];
-             verts_field["association"] = "vertex";
-             verts_field["topology"] = topo_name;
-             verts_field["values"].set(DataType::int64(local_num_verts[local_dom_idx]));
+    for(size_t local_dom_idx=0; local_dom_idx < domains.size(); local_dom_idx++)
+    {
+        Node &dom = *domains[local_dom_idx];
+        // we do need to make sure we have the requested topo
+        if(dom["topologies"].has_child(topo_name))
+        {
+            Node &verts_field = dom["fields"][field_prefix + "global_vertex_ids"];
+            verts_field["association"] = "vertex";
+            verts_field["topology"] = topo_name;
+            verts_field["values"].set(DataType::int64(local_num_verts[local_dom_idx]));
 
-             int64 vert_base_idx = global_verts_offset + local_vert_offsets[local_dom_idx];
+            int64 vert_base_idx = global_verts_offset + local_vert_offsets[local_dom_idx];
 
-             int64_array vert_ids_vals = verts_field["values"].value();
-             for(uint64 i=0; i < local_num_verts[local_dom_idx]; i++)
-             {
-                 vert_ids_vals[i] = i + vert_base_idx;
-             }
+            int64_array vert_ids_vals = verts_field["values"].value();
+            for(uint64 i=0; i < local_num_verts[local_dom_idx]; i++)
+            {
+                vert_ids_vals[i] = i + vert_base_idx;
+            }
 
-             // NOTE: VISIT BP DOESNT SUPPORT UINT64!!!!
-             Node &eles_field = dom["fields"][field_prefix + "global_element_ids"];
-             eles_field["association"] = "element";
-             eles_field["topology"] = topo_name;
-             eles_field["values"].set(DataType::int64(local_num_eles[local_dom_idx]));
+            // NOTE: VISIT BP DOESNT SUPPORT UINT64!!!!
+            Node &eles_field = dom["fields"][field_prefix + "global_element_ids"];
+            eles_field["association"] = "element";
+            eles_field["topology"] = topo_name;
+            eles_field["values"].set(DataType::int64(local_num_eles[local_dom_idx]));
 
-             int64 ele_base_idx = global_eles_offset + local_ele_offsets[local_dom_idx];
+            int64 ele_base_idx = global_eles_offset + local_ele_offsets[local_dom_idx];
 
-             int64_array ele_ids_vals = eles_field["values"].value();
-             for(uint64 i=0; i < local_num_eles[local_dom_idx]; i++)
-             {
-                ele_ids_vals[i] = i + ele_base_idx;
-             }
-         }
+            int64_array ele_ids_vals = eles_field["values"].value();
+            for(uint64 i=0; i < local_num_eles[local_dom_idx]; i++)
+            {
+               ele_ids_vals[i] = i + ele_base_idx;
+            }
+        }
     }
 }
 

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
@@ -224,10 +224,19 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
             const Node& dom_aset = dom["adjsets"][adjset_name];
             std::string assoc_type = dom_aset["association"].as_string();
             std::string assoc_topo = dom_aset["topology"].as_string();
-            // TODO: check association, should be vert-based
+            if (assoc_type != "vertex")
+            {
+                CONDUIT_ERROR("Specified adjset \"" << adjset_name << "\" is "
+                              << "not a vertex-associated adjset. Element-"
+                              << "associated adjsets are not supported at this time.");
+
+            }
             if (assoc_topo != topo_name)
             {
-                continue;
+                CONDUIT_ERROR("Specified adjset \"" << adjset_name
+                                << "\" associated with unexpected topology \"" << assoc_topo
+                                << "\" (per generate_partition_field options: topology = \""
+                                << topo_name << "\")");
             }
 
             for (const Node& group : dom_aset["groups"].children())

--- a/src/tests/blueprint/t_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/tests/blueprint/t_blueprint_mpi_mesh_parmetis.cpp
@@ -204,8 +204,9 @@ TEST(blueprint_mpi_parmetis, braid)
     EXPECT_TRUE(conduit::blueprint::mesh::verify(mesh, info));
 
     Node options;
-    options["partitions"] = par_size * 2;
+    options["partitions"] = par_size;
     options["topology"] = "mesh";
+    options["adjset"] = "elem_aset";
 
     // paint a field with parmetis result (WIP)
     conduit::blueprint::mpi::mesh::generate_partition_field(mesh,options,MPI_COMM_WORLD);


### PR DESCRIPTION
* Adds a user-specified option for an adjset name, which is used to determine global vertex ids of shared nodes between domains
* Fixes a bug identified in the re-partitioner where adjsets for the new domains would sometimes be missing.