### PR TITLE
Fix partitioner handling of adjsets for multi-topology domains

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -3731,6 +3731,26 @@ Partitioner::wrap(size_t idx, const conduit::Node &n_mesh) const
 }
 
 //---------------------------------------------------------------------------
+static const conduit::Node* get_associated_topo_adjset(const conduit::Node& domain,
+                                                       const std::string& topo)
+{
+    if (!domain.has_child("adjsets"))
+    {
+        return nullptr;
+    }
+    for (const conduit::Node& adjset : domain["adjsets"].children())
+    {
+        const std::string& adjset_topo = adjset["topology"].as_string();
+        const std::string& adjset_assoc = adjset["association"].as_string();
+        if (topo == adjset_topo && adjset_assoc == "vertex")
+        {
+            return &adjset;
+        }
+    }
+    return nullptr;
+}
+
+//---------------------------------------------------------------------------
 void
 Partitioner::build_intradomain_adjsets(const std::vector<int>& chunk_offsets,
                                        const DomainToChunkMap& dom_2_chunks,
@@ -4258,6 +4278,7 @@ Partitioner::execute(conduit::Node &output)
     // make chunks.
     std::vector<Chunk> chunks;
     std::vector<conduit::Node*> adjset_data;
+    std::vector<const conduit::Node*> chunk_assoc_aset;
 
     // Maps each pre-load balance mesh domain to a set of vertex lists for each chunk.
     // This is used in constructing the intermediate chunk adjsets within a domain.
@@ -4280,13 +4301,14 @@ Partitioner::execute(conduit::Node &output)
             // the whole mesh rather than extracting. If we are using "mapping"
             // then we will be wrapping the mesh so we can add vertex and element
             // maps to it without changing the input mesh.
+            const conduit::Node* assoc_aset = nullptr;
             conduit::Node* wrapped_adjset = nullptr;
             if(mapping || meshes[i]->has_child("adjsets"))
             {
                 conduit::Node *c = wrap(i, *meshes[i]);
-
                 chunks.push_back(Chunk(c, true, dr, dd));
-                if (meshes[i]->has_child("adjsets"))
+                assoc_aset = get_associated_topo_adjset(*meshes[i], selections[i]->get_topology());
+                if (assoc_aset)
                 {
                     wrapped_adjset = c->fetch_ptr("adjsets");
                 }
@@ -4295,6 +4317,7 @@ Partitioner::execute(conduit::Node &output)
             {
                 chunks.push_back(Chunk(meshes[i], false, dr, dd));
             }
+            chunk_assoc_aset.push_back(assoc_aset);
             adjset_data.push_back(wrapped_adjset);
             domain_to_chunk_map[meshes[i]][i] = {};
         }
@@ -4303,7 +4326,10 @@ Partitioner::execute(conduit::Node &output)
             std::vector<index_t> vert_ids;
             conduit::Node *c = extract(i, *meshes[i], vert_ids);
             chunks.push_back(Chunk(c, true, dr, dd));
-            if (meshes[i]->has_child("adjsets"))
+            const conduit::Node* assoc_aset
+                = get_associated_topo_adjset(*meshes[i], selections[i]->get_topology());
+            chunk_assoc_aset.push_back(assoc_aset);
+            if (assoc_aset)
             {
                 adjset_data.push_back(c->fetch_ptr("adjsets"));
             }

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -4067,6 +4067,10 @@ Partitioner::build_interdomain_adjsets(const std::vector<int>& chunk_offsets,
                 // Get local chunk id
                 index_t chunk_id = adjset.first.first - chunk_offset;
                 index_t chunk_nbr = adjset.first.second;
+                if (!adjset_data[chunk_id] || !adjset_data[chunk_id]->has_child(adjset_name))
+                {
+                    continue;
+                }
                 Node& adjset_groups = adjset_data[chunk_id]->fetch(adjset_name + "/groups");
                 Node& new_set = adjset_groups.append();
                 new_set["neighbors"].set(chunk_nbr);

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
@@ -619,7 +619,7 @@ protected:
      @param[out] adjset_data An array of nodes containing adjset data for each
                              chunk local to this rank.
      */
-    void init_chunk_adjsets(const DomainToChunkMap& chunks,
+    void init_chunk_adjsets(const std::vector<const conduit::Node*>& chunk_assoc_adjset,
                             std::vector<conduit::Node*>& adjset_data);
 
     /**

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
@@ -613,9 +613,8 @@ protected:
      @brief Generates initial intermediate adjsets for each chunk, based on the
             adjsets in the original domains.
 
-     @param chunks A map of pre-partition domains to the set of local chunk ids
-                   it is decomposed into, as well as the associated vertex maps
-                   for each chunk.
+     @param chunk_assoc_adjset An array of nodes pointing to corresponding
+                               pre-load balance domain adjsets for each chunk.
      @param[out] adjset_data An array of nodes containing adjset data for each
                              chunk local to this rank.
      */


### PR DESCRIPTION
Currently, the partitioner assumes that all adjsets are associated with the topology being partitioned. When partitioning a related topology, we need to skip over any adjsets that aren't associated with the topology.

Related to #936 