### PR TITLE
Add topology reindexing support

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_related_boundary.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_related_boundary.cpp
@@ -713,7 +713,7 @@ void related_boundary(index_t base_grid_ele_i,
     mesh["domain1/adjsets/main_adjset/topology"] = "main";
     Node &d1_adj_groups = mesh["domain1/adjsets/main_adjset/groups"];
 
-    d1_adj_groups["group_0_1_2/neighbors"].set({1,2});
+    d1_adj_groups["group_0_1_2/neighbors"].set({0,2});
     // one point is shared between all three
     d1_adj_groups["group_0_1_2/values"] = (base_grid_ele_i+1) * (base_grid_ele_j+1)-1;
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -387,6 +387,18 @@ namespace topology
     index_t CONDUIT_BLUEPRINT_API length(const conduit::Node &topo);
 
     //-------------------------------------------------------------------------
+    /**
+     * @brief Reindexes the vertices in a topology to be associated with a new
+     * coordset, based on a global vertex ID numbering.
+     * The old coordset must be a subset of the new coordset.
+     */
+    void CONDUIT_BLUEPRINT_API reindex_coords(const conduit::Node& topo,
+                                              const conduit::Node& new_coordset,
+                                              const conduit::Node& old_gvids,
+                                              const conduit::Node& new_gvids,
+                                              conduit::Node& out_topo);
+
+    //-------------------------------------------------------------------------
     // -- begin conduit::blueprint::mesh::utils::topology::unstructured --
     //-------------------------------------------------------------------------
     namespace unstructured


### PR DESCRIPTION
Adds a `conduit::blueprint::mesh::utils::topology::reindex_coords()` function to remap a related topology to a main coordset post-partitioning.

This function requires passing global vertex ID fields for both the main and the related topology in order to determine the correct relation of coordset indices post-partitioning, since both post-partition topologies might have different associated coordsets.