### PR TITLE
Prevent scalars from including component names in CSV output.

### DIFF
--- a/src/libs/relay/conduit_relay_io_csv.cpp
+++ b/src/libs/relay/conduit_relay_io_csv.cpp
@@ -79,7 +79,7 @@ write_header(const Node &values, std::ofstream &fout)
         const Node &value = values[col];
         const std::string base_name = value.name();
         const index_t nc = value.number_of_children();
-        if(nc > 0)
+        if(nc > 1)
         {
             // Each column is "base_name/comp_name"
             for(index_t c = 0; c < nc; c++)


### PR DESCRIPTION
I made a 1 line change into the CSV writing code in relay so scalars do not get an unwanted component name appended. This change fixed an issue reported in VisIt and did not break any tests here when I ran the test suite locally.