### PR TITLE
specifies target_include_directories

### DIFF
--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -126,6 +126,12 @@ add_compiled_library(NAME conduit_blueprint
                      FOLDER libs)
 
 
+target_include_directories(conduit_blueprint
+                           PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+
 if(FORTRAN_FOUND)
     ###############################################################################
     # Special install targets for conduit fortran modules

--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -140,6 +140,12 @@ add_compiled_library(NAME   conduit
                      FOLDER libs)
 
 
+target_include_directories(conduit
+                           PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
+
 #################################
 # Fortran related target options
 #################################

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -219,6 +219,11 @@ add_compiled_library(NAME conduit_relay
                      HEADERS_DEST_DIR include/conduit
                      FOLDER libs)
 
+target_include_directories(conduit_relay
+                           PUBLIC
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
 # add civetweb if web server support is enabled
 if(ENABLE_RELAY_WEBSERVER)
     target_sources(conduit_relay PRIVATE $<TARGET_OBJECTS:conduit_civetweb>)


### PR DESCRIPTION
Proposed resolution to: https://github.com/LLNL/conduit/issues/964

I added calls to `target_include_directories`.  I'm a brand new user of Conduit so I'm not sure if these changes are 100% comprehensive to enable `add_subdirectory` usage, but so far this is working for me.  I would appreciate any feedback and would be eager to perform any additional tasks required to support such usage.

In terms of the approach, I called `target_include_directories` directly rather than calling BLT, based on analogous code in RAJA https://github.com/LLNL/RAJA/blob/87a5cac67214e5e96c941bd652b1c0981e9f2123/CMakeLists.txt#L297