### PR TITLE
Change name of map in matsets generated index to "materials"

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -1810,7 +1810,7 @@ mesh::generate_index_for_single_domain(const Node &mesh,
                 while(mats_itr.has_next())
                 {
                     mats_itr.next();
-                    idx_matset["material_map"][mats_itr.name()] = mats_itr.index();
+                    idx_matset["materials"][mats_itr.name()] = mats_itr.index();
                 }
             }
             else // surprise!


### PR DESCRIPTION
The automatic generation of the blueprint index used "material_map" but VisIt expects "materials".