### PR TITLE
all_gather handle case the input node is compact

### DIFF
--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -990,25 +990,27 @@ all_gather(Node &send_node,
     const void *snd_ptr  = send_node.contiguous_data_ptr();
     index_t     snd_size = send_node.total_bytes_compact();
 
-    int mpi_size = mpi::size(mpi_comm);
     
     if( snd_ptr == NULL ||
        !send_node.is_compact() )
     {
         send_node.compact_to(n_snd_compact);
         snd_ptr  = n_snd_compact.data_ptr();
+    }
         // TODO: copy out support w/o always reallocing?
         // TODO: what about common case of scatter w/ leaf types?
         //       instead of list_of, we would have a leaf of
         //       of a given type w/ # of elements == # of ranks. 
-    }
 //    else
 //    {
 //        recv_node.list_of(s_snd_compact,
 //                          mpi_size);
 //    }
-        recv_node.list_of(n_snd_compact.schema(),
-                          mpi_size);
+    
+    int mpi_size = mpi::size(mpi_comm);
+    
+    recv_node.list_of(n_snd_compact.schema(),
+                      mpi_size);
 
     if(!conduit::utils::value_fits<index_t,int>(snd_size))
     {

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -1001,14 +1001,14 @@ all_gather(Node &send_node,
         // TODO: what about common case of scatter w/ leaf types?
         //       instead of list_of, we would have a leaf of
         //       of a given type w/ # of elements == # of ranks. 
+    }
+//    else
+//    {
+//        recv_node.list_of(s_snd_compact,
+//                          mpi_size);
+//    }
         recv_node.list_of(n_snd_compact.schema(),
                           mpi_size);
-    }
-    else
-    {
-        recv_node.list_of(s_snd_compact,
-                          mpi_size);
-    }
 
     if(!conduit::utils::value_fits<index_t,int>(snd_size))
     {

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -985,29 +985,30 @@ all_gather(Node &send_node,
 {
     Node   n_snd_compact;
     Schema s_snd_compact;
-    
     send_node.schema().compact_to(s_snd_compact);
     
     const void *snd_ptr  = send_node.contiguous_data_ptr();
     index_t     snd_size = send_node.total_bytes_compact();
+
+    int mpi_size = mpi::size(mpi_comm);
     
     if( snd_ptr == NULL ||
        !send_node.is_compact() )
     {
         send_node.compact_to(n_snd_compact);
         snd_ptr  = n_snd_compact.data_ptr();
+        // TODO: copy out support w/o always reallocing?
+        // TODO: what about common case of scatter w/ leaf types?
+        //       instead of list_of, we would have a leaf of
+        //       of a given type w/ # of elements == # of ranks. 
+        recv_node.list_of(n_snd_compact.schema(),
+                          mpi_size);
     }
-
-
-    int mpi_size = mpi::size(mpi_comm);
-
-
-    // TODO: copy out support w/o always reallocing?
-    // TODO: what about common case of scatter w/ leaf types?
-    //       instead of list_of, we would have a leaf of
-    //       of a given type w/ # of elements == # of ranks. 
-    recv_node.list_of(n_snd_compact.schema(),
-                      mpi_size);
+    else
+    {
+        recv_node.list_of(s_snd_compact,
+                          mpi_size);
+    }
 
     if(!conduit::utils::value_fits<index_t,int>(snd_size))
     {

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -997,19 +997,14 @@ all_gather(Node &send_node,
         send_node.compact_to(n_snd_compact);
         snd_ptr  = n_snd_compact.data_ptr();
     }
-        // TODO: copy out support w/o always reallocing?
-        // TODO: what about common case of scatter w/ leaf types?
-        //       instead of list_of, we would have a leaf of
-        //       of a given type w/ # of elements == # of ranks. 
-//    else
-//    {
-//        recv_node.list_of(s_snd_compact,
-//                          mpi_size);
-//    }
+    // TODO: copy out support w/o always reallocing?
+    // TODO: what about common case of scatter w/ leaf types?
+    //       instead of list_of, we would have a leaf of
+    //       of a given type w/ # of elements == # of ranks. 
     
     int mpi_size = mpi::size(mpi_comm);
     
-    recv_node.list_of(n_snd_compact.schema(),
+    recv_node.list_of(s_snd_compact.schema(),
                       mpi_size);
 
     if(!conduit::utils::value_fits<index_t,int>(snd_size))

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -1004,7 +1004,7 @@ all_gather(Node &send_node,
     
     int mpi_size = mpi::size(mpi_comm);
     
-    recv_node.list_of(s_snd_compact.schema(),
+    recv_node.list_of(s_snd_compact,
                       mpi_size);
 
     if(!conduit::utils::value_fits<index_t,int>(snd_size))


### PR DESCRIPTION
all_gather was setting the recv_node schema to the compact node that is created if the input node is not compact. If the input node was compact it would break in odd and unexpected ways. 

fixes PR [https://github.com/Alpine-DAV/ascent/pull/839](https://github.com/Alpine-DAV/ascent/pull/839)