### PR TITLE
expose to_json() conduit method to the c api

### DIFF
--- a/src/libs/conduit/c/conduit_node.h
+++ b/src/libs/conduit/c/conduit_node.h
@@ -211,6 +211,10 @@ CONDUIT_API void conduit_node_load(conduit_node *cnode,
                                    const char* protocol);
 
 //-----------------------------------------------------------------------------
+// the caller must free the result
+CONDUIT_API char* conduit_node_to_json(const conduit_node *cnode);
+
+//-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 // Conduit Node "Set" Methods
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/c/conduit_node_c.cpp
+++ b/src/libs/conduit/c/conduit_node_c.cpp
@@ -424,6 +424,19 @@ conduit_node_load(conduit_node *cnode,
 }
 
 //-----------------------------------------------------------------------------
+char*
+conduit_node_to_json(const conduit_node *cnode)
+{
+    std::string str = cpp_node(cnode)->to_json();
+    std::size_t len = str.length() + 1;
+
+    char* output = (char*)malloc(len);
+    strcpy(output, str.c_str());
+
+    return output;
+}
+
+//-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 // -- set variants -- 

--- a/src/tests/conduit/c/t_c_conduit_node.cpp
+++ b/src/tests/conduit/c/t_c_conduit_node.cpp
@@ -376,6 +376,18 @@ TEST(c_conduit_node, c_save_load)
     conduit_node_destroy(n2);
 }
 
+//-----------------------------------------------------------------------------
+TEST(c_conduit_node, c_to_json)
+{
+    conduit_node *n = conduit_node_create();
+    conduit_node_parse(n,"{\"a\": 42.0}","json");
+
+    char* json = conduit_node_to_json(n);
+    EXPECT_EQ(std::string(json), "\n{\n  \"a\": 42.0\n}");
+
+    free(json);
+    conduit_node_destroy(n);
+}
 
 //-----------------------------------------------------------------------------
 TEST(c_conduit_node, c_child_with_embedded_slashes)


### PR DESCRIPTION
Hello,

in order to be able to convert a conduit node to a string, I need to expose the `to_json` conduit method to the c api. First, Is there a particular reason why this method is not already exposed in the c api ?

I propose in my commit a version of how we can expose it, otherwise we can also expose this method like this (in `conduit_node_c.cpp`) :
```c
void conduit_node_to_json(conduit_node *cnode, conduit_node *output_node)
{
    std::string str = cpp_node(cnode)->to_json();
    cpp_node(output_node)->set_string(str);
}
```

what did you prefer?

Thanks,
Lucas