### PR TITLE
add updated diffutils pkg - 3.8 will build with gcc 11

### DIFF
--- a/scripts/uberenv_configs/packages/diffutils/intprops-workaround-nvc-22.1-bug.patch
+++ b/scripts/uberenv_configs/packages/diffutils/intprops-workaround-nvc-22.1-bug.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/intprops.h b/lib/intprops.h
+index 9d10028..1540e3e 100644
+--- a/lib/intprops.h
++++ b/lib/intprops.h
+@@ -232,7 +232,11 @@
+    (A, B, P) work when P is non-null.  */
+ /* __builtin_{add,sub}_overflow exists but is not reliable in GCC 5.x and 6.x,
+    see <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98269>.  */
+-#if 7 <= __GNUC__ && !defined __ICC
++#ifdef __EDG__
++/* EDG-based compilers like nvc 22.1 cannot add 64-bit signed to unsigned
++   <https://bugs.gnu.org/53256>.  */
++# define _GL_HAS_BUILTIN_ADD_OVERFLOW 0
++#elif 7 <= __GNUC__ && !defined __ICC
+ # define _GL_HAS_BUILTIN_ADD_OVERFLOW 1
+ #elif defined __has_builtin
+ # define _GL_HAS_BUILTIN_ADD_OVERFLOW __has_builtin (__builtin_add_overflow)

--- a/scripts/uberenv_configs/packages/diffutils/nvhpc.patch
+++ b/scripts/uberenv_configs/packages/diffutils/nvhpc.patch
@@ -1,0 +1,35 @@
+--- a/lib/xalloc-oversized.h	2020-08-07 08:03:53.257539226 -0700
++++ b/lib/xalloc-oversized.h	2020-08-07 07:57:54.024124785 -0700
+@@ -41,10 +41,10 @@
+    positive and N must be nonnegative.  This is a macro, not a
+    function, so that it works correctly even when SIZE_MAX < N.  */
+ 
+-#if 7 <= __GNUC__
++#if 7 <= __GNUC__ && !defined __NVCOMPILER
+ # define xalloc_oversized(n, s) \
+    __builtin_mul_overflow_p (n, s, (__xalloc_count_type) 1)
+-#elif 5 <= __GNUC__ && !defined __ICC && !__STRICT_ANSI__
++#elif 5 <= __GNUC__ && !defined __ICC && !__STRICT_ANSI__ && !defined __NVCOMPILER
+ # define xalloc_oversized(n, s) \
+    (__builtin_constant_p (n) && __builtin_constant_p (s) \
+     ? __xalloc_oversized (n, s) \
+--- a/lib/intprops.h	2020-08-07 07:58:37.233294093 -0700
++++ b/lib/intprops.h	2020-08-07 08:00:05.887641482 -0700
+@@ -221,14 +221,14 @@
+    : (max) >> (b) < (a))
+ 
+ /* True if __builtin_add_overflow (A, B, P) works when P is non-null.  */
+-#if 5 <= __GNUC__ && !defined __ICC
++#if 5 <= __GNUC__ && !defined __ICC && !defined __NVCOMPILER
+ # define _GL_HAS_BUILTIN_OVERFLOW 1
+ #else
+ # define _GL_HAS_BUILTIN_OVERFLOW 0
+ #endif
+ 
+ /* True if __builtin_add_overflow_p (A, B, C) works.  */
+-#define _GL_HAS_BUILTIN_OVERFLOW_P (7 <= __GNUC__)
++#define _GL_HAS_BUILTIN_OVERFLOW_P (7 <= __GNUC__ && !defined __NVCOMPILER)
+ 
+ /* The _GL*_OVERFLOW macros have the same restrictions as the
+    *_RANGE_OVERFLOW macros, except that they do not assume that operands
+

--- a/scripts/uberenv_configs/packages/diffutils/package.py
+++ b/scripts/uberenv_configs/packages/diffutils/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
+from spack.package import *
+
+
+class Diffutils(AutotoolsPackage, GNUMirrorPackage):
+    """GNU Diffutils is a package of several programs related to finding
+    differences between files."""
+
+    tags = ["core-packages"]
+
+    executables = [r"^diff$"]
+
+    homepage = "https://www.gnu.org/software/diffutils/"
+    gnu_mirror_path = "diffutils/diffutils-3.7.tar.xz"
+
+    version("3.8", sha256="a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec")
+    version("3.7", sha256="b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26")
+    version("3.6", sha256="d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6")
+
+    build_directory = "spack-build"
+
+    patch("nvhpc.patch", when="@3.7 %nvhpc")
+    patch(
+        "intprops-workaround-nvc-22.1-bug.patch",
+        sha256="146b7021bb0a304a3d1c0638956c4e735c2076d292d238f2806efadc972d99e5",
+        when="@3.8 %nvhpc",
+    )
+
+    conflicts("%nvhpc", when="@:3.6,3.8:")
+
+    depends_on("iconv")
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies("%fj"):
+            env.append_flags("CFLAGS", "-Qunused-arguments")
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"diff \(GNU diffutils\) (\S+)", output)
+        return match.group(1) if match else None


### PR DESCRIPTION
resolves #996


diffutils 3.7 does not build with gcc 11, this adds newer spack diffutils setup so we can build diffutils 3.8.
