### PR TITLE
generate_offsets without side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Relay
 - Added any source, any tag variants of mpi receive functions: `recv`, `recv_using_schema`, and `irecv`.
 - Added subpath support for `relay::io::{save,load,save_merged,load_merged}` for basic protocols (json, yaml, etc).
+- Added `generate_offsets_inline(Node &)` for cases where we want topology offsets created in existing tree.
 
 ### Changed
 
@@ -46,6 +47,8 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### Blueprint
 - Removed field `type` entries from braid examples, since that info is not required by the Mesh Blueprint.
+- Fixed a const-ignoring crime related to polyhedral element and subelement offset generation.
+- Refactored unstructured case in `blueprint::mesh::topology::logical_dims` calculation to directly calculate number of elements instead of generating offsets.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,23 +32,24 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added `blueprint::mesh::examples::braid` examples with mixed element topologies (`mesh_type={"mixed", "mixed_2d"}`)
 - Added 1D mesh example support to `blueprint::mesh::examples::basic()`.
 - Added adjacency set aware generate functions (`genearte_points()`, etc) to the non-mpi blueprint library.
+- Added `generate_offsets_inline(Node &)` for cases where we want topology offsets created in an existing tree.
 
 
 #### Relay
 - Added any source, any tag variants of mpi receive functions: `recv`, `recv_using_schema`, and `irecv`.
 - Added subpath support for `relay::io::{save,load,save_merged,load_merged}` for basic protocols (json, yaml, etc).
-- Added `generate_offsets_inline(Node &)` for cases where we want topology offsets created in an existing tree.
 
 ### Changed
-
-#### Relay
-- Changed HDF5 CMake sanity checks to issue `WARNING` instead of `FATAL_ERROR`, since Cray system HDF5 installs do not always present the info we use for sanity checks.
-- Changed HDF5 version guards to also check requested HDF5 API.
 
 #### Blueprint
 - Removed field `type` entries from braid examples, since that info is not required by the Mesh Blueprint.
 - Fixed a const-ignoring crime related to polyhedral element and subelement offset generation.
 - Refactored unstructured case in `blueprint::mesh::topology::logical_dims` calculation to directly calculate number of elements instead of generating offsets.
+
+#### Relay
+- Changed HDF5 CMake sanity checks to issue `WARNING` instead of `FATAL_ERROR`, since Cray system HDF5 installs do not always present the info we use for sanity checks.
+- Changed HDF5 version guards to also check requested HDF5 API.
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Relay
 - Added any source, any tag variants of mpi receive functions: `recv`, `recv_using_schema`, and `irecv`.
 - Added subpath support for `relay::io::{save,load,save_merged,load_merged}` for basic protocols (json, yaml, etc).
-- Added `generate_offsets_inline(Node &)` for cases where we want topology offsets created in existing tree.
+- Added `generate_offsets_inline(Node &)` for cases where we want topology offsets created in an existing tree.
 
 ### Changed
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3702,7 +3702,7 @@ mesh::topology::unstructured::to_polygonal(const Node &topo,
             temp.set_external(poly_size_data);
             temp.to_data_type(int_dtype.id(), dest["elements/sizes"]);
 
-            generate_offsets(dest, dest["elements/offsets"]);
+            utils::topology::unstructured::generate_offsets_inline(dest);
         }
         else // if(is_topo_3d) // polyhedral
         {
@@ -3773,9 +3773,7 @@ mesh::topology::unstructured::to_polygonal(const Node &topo,
 
             dest["subelements/shape"].set("polygonal");
 
-            // BHAN - For polyhedral, writes offsets for
-            // "elements/offsets" and "subelements/offsets"
-            generate_offsets(dest, dest["elements/offsets"]);
+            utils::topology::unstructured::generate_offsets_inline(dest);
         }
     }
 }

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -5460,6 +5460,18 @@ mesh::topology::unstructured::generate_offsets(const Node &topo,
 
 //-----------------------------------------------------------------------------
 void
+mesh::topology::unstructured::generate_offsets(const Node &topo,
+                                               Node &dest_eleoffsets,
+                                               Node &dest_subeleoffsets)
+{
+    return bputils::topology::unstructured::generate_offsets(topo,
+                                                             dest_eleoffsets,
+                                                             dest_subeleoffsets);
+}
+
+
+//-----------------------------------------------------------------------------
+void
 mesh::topology::unstructured::generate_offsets_inline(Node &topo)
 {
     return bputils::topology::unstructured::generate_offsets_inline(topo);

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -5434,7 +5434,8 @@ mesh::topology::unstructured::generate_corners(const Node &topo,
 
         // TODO(JRC): Implement these counts in-line instead of being lazy and
         // taking care of it at the end of the function w/ a helper.
-        generate_offsets(topo_dest, topo_dest["elements/offsets"]);
+        generate_offsets_inline(topo_dest);
+        
         blueprint::o2mrelation::generate_offsets(s2dmap, info);
         blueprint::o2mrelation::generate_offsets(d2smap, info);
     }
@@ -5446,6 +5447,13 @@ mesh::topology::unstructured::generate_offsets(const Node &topo,
                                                Node &dest)
 {
     return bputils::topology::unstructured::generate_offsets(topo, dest);
+}
+
+//-----------------------------------------------------------------------------
+void
+mesh::topology::unstructured::generate_offsets_inline(Node &topo)
+{
+    return bputils::topology::unstructured::generate_offsets_inline(topo);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -584,7 +584,7 @@ namespace topology
                                                     conduit::Node &d2smap);
 
         //-------------------------------------------------------------------------
-       // Generates element offsets for given topo
+        // Generates element offsets for given topo
         void CONDUIT_BLUEPRINT_API generate_offsets(const conduit::Node &topo,
                                                     conduit::Node &dest);
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -586,6 +586,7 @@ namespace topology
         //-------------------------------------------------------------------------
         void CONDUIT_BLUEPRINT_API generate_offsets(const conduit::Node &topo,
                                                     conduit::Node &dest);
+
     }
 
     //-------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -587,6 +587,10 @@ namespace topology
         void CONDUIT_BLUEPRINT_API generate_offsets(const conduit::Node &topo,
                                                     conduit::Node &dest);
 
+        //-------------------------------------------------------------------------
+        void CONDUIT_BLUEPRINT_API generate_offsets_inline(conduit::Node &topo);
+
+
     }
 
     //-------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -584,10 +584,19 @@ namespace topology
                                                     conduit::Node &d2smap);
 
         //-------------------------------------------------------------------------
+       // Generates element offsets for given topo
         void CONDUIT_BLUEPRINT_API generate_offsets(const conduit::Node &topo,
                                                     conduit::Node &dest);
 
         //-------------------------------------------------------------------------
+        // Generates element and subelement offsets for given topo
+        // (subelement will be empty for non-polyhedral topologies)
+        void CONDUIT_BLUEPRINT_API generate_offsets(const Node &topo,
+                                                    Node &dest_ele_offsets,
+                                                    Node &dest_subele_offsets);
+
+        //-------------------------------------------------------------------------
+        // Adds offsets to given topo
         void CONDUIT_BLUEPRINT_API generate_offsets_inline(conduit::Node &topo);
 
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -4075,8 +4075,7 @@ void polytess(index_t nlevels,
             }
         }
 
-        blueprint::mesh::topology::unstructured::generate_offsets(
-            topology, topology["elements/offsets"]);
+        blueprint::mesh::topology::unstructured::generate_offsets_inline(topology);
 
         // Populate Field //
 
@@ -4510,8 +4509,7 @@ polychain(const index_t length, // how long the chain ought to be
         sub_sizes[i] = ((imodfaces < 9) || ((imodfaces > 10) && (imodfaces < 14))) ? num_points_per_quad_face : num_points_per_tri_face;
     }
 
-    blueprint::mesh::topology::unstructured::generate_offsets(chain_topo,
-                                                              chain_topo["elements/offsets"]);
+    blueprint::mesh::topology::unstructured::generate_offsets_inline(chain_topo);
 
     chain_fields["chain/topology"] = "topo";
     chain_fields["chain/association"] = "element";

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -2907,7 +2907,9 @@ Partitioner::get_vertex_ids_for_element_ids(const conduit::Node &n_topo,
             if(n_topo.has_path("elements/offsets"))
                 n_topo["elements/offsets"].to_unsigned_int_array(n_offsets);
             else
+            {
                 conduit::blueprint::mesh::utils::topology::unstructured::generate_offsets(n_topo, n_offsets);
+            }
             auto offsets = n_offsets.as_unsigned_int_array();
 #else
             if(n_topo.has_path("elements/offsets"))

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -480,8 +480,7 @@ TopologyMetadata::TopologyMetadata(const conduit::Node &topology, const conduit:
             }
         }
 
-        Node dim_topo_offsets;
-        topology::unstructured::generate_offsets(dim_topos[di], dim_topo_offsets);
+        topology::unstructured::generate_offsets_inline(dim_topos[di]);
     }
 }
 
@@ -1835,31 +1834,17 @@ topology::reindex_coords(const Node& topo,
 
 //-----------------------------------------------------------------------------
 void
-topology::unstructured::generate_offsets(Node &n,
-                                         Node &dest)
+topology::unstructured::generate_offsets_inline(Node &topo)
 {
-    dest.reset();
-
     // FIXME(JRC): There are weird cases wherein a polyhedral topology can have only
     // the 'elements/offsets' defined and not 'subelements/offsets', which isn't currently
     // properly handled by this function.
 
-    if(n["elements"].has_child("offsets") && !n["elements/offsets"].dtype().is_empty())
+    if( !topo["elements"].has_child("offsets") || 
+        topo["elements/offsets"].dtype().is_empty())
     {
-        if(&dest != &n["elements/offsets"])
-        {
-            dest.set_external(n["elements/offsets"]);
-        }
-    }
-    else
-    {
-        const Node &n_const = n;
-        Node &offsets = n["elements/offsets"];
-        blueprint::mesh::utils::topology::unstructured::generate_offsets(n_const, offsets);
-        if(&dest != &offsets)
-        {
-            dest.set_external(offsets);
-        }
+        blueprint::mesh::utils::topology::unstructured::generate_offsets(topo,
+                                                                         topo["elements/offsets"]);
     }
 }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2145,7 +2145,7 @@ topology::unstructured::points(const Node &n,
     // if they don't exist and aren't regenerated for each subcall that needs them.
     Node ntemp;
     ntemp.set_external(n);
-    generate_offsets(ntemp, ntemp["elements/offsets"]);
+    generate_offsets_inline(ntemp);
 
     const ShapeType topo_shape(ntemp);
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2104,11 +2104,11 @@ topology::unstructured::generate_offsets(const Node &topo,
 
         index_t es_count = topo_elem_size.number_of_elements();
         // IDEAL SOLUTION 
-        // dest_ele_offsets.set(DataType::index_t(es_count));
-        // index_t_array shape_array = dest_ele_offsets.value();
+        dest_ele_offsets.set(DataType::index_t(es_count));
+        index_t_array shape_array = dest_ele_offsets.value();
 
         // EVIL HACK
-        std::vector<index_t> shape_array(es_count, 0);
+        // std::vector<index_t> shape_array(es_count, 0);
 
         index_t es = 0;
         for (index_t ei = 0; ei < es_count; ++ei)
@@ -2118,21 +2118,21 @@ topology::unstructured::generate_offsets(const Node &topo,
         }
 
         // EVIL HACK
-        Node &dest_elem_off = const_cast<Node &>(topo)["elements/offsets"];
-        Node elem_node;
-        elem_node.set_external(shape_array);
-        elem_node.to_data_type(int_dtype.id(), dest_elem_off);
-        elem_node.to_data_type(int_dtype.id(), dest_ele_offsets);
+        // Node &dest_elem_off = const_cast<Node &>(topo)["elements/offsets"];
+        // Node elem_node;
+        // elem_node.set_external(shape_array);
+        // elem_node.to_data_type(int_dtype.id(), dest_elem_off);
+        // elem_node.to_data_type(int_dtype.id(), dest_ele_offsets);
 
         int ses_count = topo_subelem_size.number_of_elements();
 
         // IDEAL SOLUTION
-        // dest_subele_offsets.set(DataType::index_t(ses_count));
-        // index_t_array subshape_array = dest_subele_offsets.value();
+        dest_subele_offsets.set(DataType::index_t(ses_count));
+        index_t_array subshape_array = dest_subele_offsets.value();
 
         // EVIL HACK
-        Node &dest_subelem_off = const_cast<Node &>(topo)["subelements/offsets"];
-        std::vector<index_t> subshape_array(ses_count, 0);
+        // Node &dest_subelem_off = const_cast<Node &>(topo)["subelements/offsets"];
+        // std::vector<index_t> subshape_array(ses_count, 0);
 
         index_t ses = 0;
         for (index_t ei = 0; ei < ses_count; ++ei)
@@ -2142,10 +2142,10 @@ topology::unstructured::generate_offsets(const Node &topo,
         }
 
         // EVIL HACK
-        Node subelem_node;
-        subelem_node.set_external(subshape_array);
-        subelem_node.to_data_type(int_dtype.id(), dest_subelem_off);
-        dest_subele_offsets = dest_subelem_off;
+        // Node subelem_node;
+        // subelem_node.set_external(subshape_array);
+        // subelem_node.to_data_type(int_dtype.id(), dest_subelem_off);
+        // dest_subele_offsets = dest_subelem_off;
     }
 }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2103,12 +2103,9 @@ topology::unstructured::generate_offsets(const Node &topo,
         index_t_accessor topo_subelem_size = topo["subelements/sizes"].value();
 
         index_t es_count = topo_elem_size.number_of_elements();
-        // IDEAL SOLUTION 
+
         dest_ele_offsets.set(DataType::index_t(es_count));
         index_t_array shape_array = dest_ele_offsets.value();
-
-        // EVIL HACK
-        // std::vector<index_t> shape_array(es_count, 0);
 
         index_t es = 0;
         for (index_t ei = 0; ei < es_count; ++ei)
@@ -2117,22 +2114,10 @@ topology::unstructured::generate_offsets(const Node &topo,
             es += topo_elem_size[ei];
         }
 
-        // EVIL HACK
-        // Node &dest_elem_off = const_cast<Node &>(topo)["elements/offsets"];
-        // Node elem_node;
-        // elem_node.set_external(shape_array);
-        // elem_node.to_data_type(int_dtype.id(), dest_elem_off);
-        // elem_node.to_data_type(int_dtype.id(), dest_ele_offsets);
-
         int ses_count = topo_subelem_size.number_of_elements();
 
-        // IDEAL SOLUTION
         dest_subele_offsets.set(DataType::index_t(ses_count));
         index_t_array subshape_array = dest_subele_offsets.value();
-
-        // EVIL HACK
-        // Node &dest_subelem_off = const_cast<Node &>(topo)["subelements/offsets"];
-        // std::vector<index_t> subshape_array(ses_count, 0);
 
         index_t ses = 0;
         for (index_t ei = 0; ei < ses_count; ++ei)
@@ -2140,12 +2125,6 @@ topology::unstructured::generate_offsets(const Node &topo,
             subshape_array[ei] = ses;
             ses += topo_subelem_size[ei];
         }
-
-        // EVIL HACK
-        // Node subelem_node;
-        // subelem_node.set_external(subshape_array);
-        // subelem_node.to_data_type(int_dtype.id(), dest_subelem_off);
-        // dest_subele_offsets = dest_subelem_off;
     }
 }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -453,20 +453,21 @@ namespace topology
     //-------------------------------------------------------------------------
     namespace unstructured
     {
-        // TODO(JRC): Expose this 'cache' version of the function publicly?
-        //-------------------------------------------------------------------------
-        // Adds offsets to given topo
-        void CONDUIT_BLUEPRINT_API generate_offsets_inline(Node &topo);
-
         //-------------------------------------------------------------------------
         // Generates element offsets for given topo
         void CONDUIT_BLUEPRINT_API generate_offsets(const Node &topo,
                                                     Node &dest);
+
         //-------------------------------------------------------------------------
         // Generates element and subelement offsets for given topo
         void CONDUIT_BLUEPRINT_API generate_offsets(const Node &topo,
                                                     Node &dest_ele_offsets,
                                                     Node &dest_subele_offsets);
+
+        //-------------------------------------------------------------------------
+        // Adds offsets to given topo
+        void CONDUIT_BLUEPRINT_API generate_offsets_inline(Node &topo);
+
         //-------------------------------------------------------------------------
         std::vector<index_t> CONDUIT_BLUEPRINT_API points(const Node &topo,
                                                           const index_t i);

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -455,10 +455,11 @@ namespace topology
     {
         // TODO(JRC): Expose this 'cache' version of the function publicly?
         //-------------------------------------------------------------------------
-        void CONDUIT_BLUEPRINT_API generate_offsets(Node &topo,
-                                                    Node &dest);
+        // Adds offsets to given topo
+        void CONDUIT_BLUEPRINT_API generate_offsets_inline(Node &topo);
 
         //-------------------------------------------------------------------------
+        // Generates element offsets for given topo
         void CONDUIT_BLUEPRINT_API generate_offsets(const Node &topo,
                                                     Node &dest);
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -462,7 +462,11 @@ namespace topology
         // Generates element offsets for given topo
         void CONDUIT_BLUEPRINT_API generate_offsets(const Node &topo,
                                                     Node &dest);
-
+        //-------------------------------------------------------------------------
+        // Generates element and subelement offsets for given topo
+        void CONDUIT_BLUEPRINT_API generate_offsets(const Node &topo,
+                                                    Node &dest_ele_offsets,
+                                                    Node &dest_subele_offsets);
         //-------------------------------------------------------------------------
         std::vector<index_t> CONDUIT_BLUEPRINT_API points(const Node &topo,
                                                           const index_t i);

--- a/src/tests/blueprint/t_blueprint_mesh_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate.cpp
@@ -1269,6 +1269,10 @@ TEST(conduit_blueprint_generate_unstructured, generate_faces)
 
         Node info;
         EXPECT_TRUE(mesh::topology::unstructured::verify(face_topo, info));
+        
+        face_topo.print();
+        info.print();
+        
 
         // General Data/Schema Checks //
 

--- a/src/tests/blueprint/t_blueprint_mesh_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate.cpp
@@ -1107,7 +1107,7 @@ TEST(conduit_blueprint_generate_unstructured, generate_points)
 
         Node &point_topo = point_mesh["topologies"][POINT_TOPOLOGY_NAME];
         mesh::topology::unstructured::generate_points(grid_topo, point_topo, t2p_map, p2t_map);
-        
+
         Node data, info;
         EXPECT_TRUE(mesh::topology::unstructured::verify(point_topo, info));
 

--- a/src/tests/blueprint/t_blueprint_mesh_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate.cpp
@@ -950,8 +950,9 @@ TEST(conduit_blueprint_generate_unstructured, generate_offsets_nonpoly)
         Node grid_offsets;
         mesh::topology::unstructured::generate_offsets(grid_topo, grid_offsets);
         const DataType offset_dtype = grid_offsets.dtype();
-
-        EXPECT_EQ(offset_dtype.id(), grid_conn.dtype().id());
+        
+        // relax exact type req, conn transforms will become index_t
+        //EXPECT_EQ(offset_dtype.id(), grid_conn.dtype().id());
         EXPECT_EQ(offset_dtype.number_of_elements(), grid_mesh.elems());
 
         Node expected_offsets_int64(DataType::int64(grid_mesh.elems()));
@@ -985,8 +986,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_offsets_poly)
         Node grid_offsets;
         mesh::topology::unstructured::generate_offsets(grid_topo, grid_offsets);
         const DataType offset_dtype = grid_offsets.dtype();
-
-        EXPECT_EQ(offset_dtype.id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        // EXPECT_EQ(offset_dtype.id(), grid_conn.dtype().id());
         EXPECT_EQ(offset_dtype.number_of_elements(), grid_mesh.elems());
 
         Node expected_offsets_int64(DataType::int64(grid_mesh.elems()));
@@ -1047,7 +1048,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_centroids)
         Node &cent_conn = cent_topo["elements/connectivity"];
 
         EXPECT_EQ(cent_topo["coordset"].as_string(), CENTROID_COORDSET_NAME);
-        EXPECT_EQ(cent_conn.dtype().id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        //EXPECT_EQ(cent_conn.dtype().id(), grid_conn.dtype().id());
         EXPECT_EQ(cent_conn.dtype().number_of_elements(), grid_mesh.elems());
 
         // Verify Data Integrity //
@@ -1061,7 +1063,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_centroids)
         for(index_t mi = 0; mi < 2; mi++)
         {
             conduit::Node& map_node = *map_nodes[mi];
-            EXPECT_EQ(map_node.dtype().id(), grid_conn.dtype().id());
+            // relax exact type req, conn transforms will become index_t
+            //EXPECT_EQ(map_node.dtype().id(), grid_conn.dtype().id());
             EXPECT_EQ(map_node.dtype().number_of_elements(), 2 * grid_mesh.elems());
 
             std::vector<index_t> map_values, expected_values;
@@ -1116,7 +1119,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_points)
         const Node &grid_conn = grid_topo["elements/connectivity"];
         Node &point_conn = point_topo["elements/connectivity"];
 
-        EXPECT_EQ(point_conn.dtype().id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        // EXPECT_EQ(point_conn.dtype().id(), grid_conn.dtype().id());
         EXPECT_EQ(point_conn.dtype().number_of_elements(), grid_points);
 
         // Content Consistency Checks //
@@ -1201,7 +1205,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_lines)
         const Node &grid_conn = grid_topo["elements/connectivity"];
         Node &line_conn = line_topo["elements/connectivity"];
 
-        EXPECT_EQ(line_conn.dtype().id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        // EXPECT_EQ(line_conn.dtype().id(), grid_conn.dtype().id());
         EXPECT_EQ(line_conn.dtype().number_of_elements(), 2 * grid_mesh.lines());
 
         // Content Consistency Checks //
@@ -1269,10 +1274,6 @@ TEST(conduit_blueprint_generate_unstructured, generate_faces)
 
         Node info;
         EXPECT_TRUE(mesh::topology::unstructured::verify(face_topo, info));
-        
-        face_topo.print();
-        info.print();
-        
 
         // General Data/Schema Checks //
 
@@ -1283,7 +1284,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_faces)
 
         EXPECT_EQ(face_topo["coordset"].as_string(), grid_coords.name());
         EXPECT_EQ(face_topo["elements/shape"].as_string(), face_type);
-        EXPECT_EQ(face_conn.dtype().id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        // EXPECT_EQ(face_conn.dtype().id(), grid_conn.dtype().id());
         EXPECT_EQ(face_off.dtype().number_of_elements(), grid_mesh.faces());
 
         // Content Consistency Checks //
@@ -1380,7 +1382,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_sides)
 
         EXPECT_EQ(side_topo["coordset"].as_string(), SIDE_COORDSET_NAME);
         EXPECT_EQ(side_topo["elements/shape"].as_string(), side_type_name);
-        EXPECT_EQ(side_conn.dtype().id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        // EXPECT_EQ(side_conn.dtype().id(), grid_conn.dtype().id());
         EXPECT_EQ(side_off.dtype().number_of_elements(), grid_sides);
 
         // Validate Correctness of Element Integrity //
@@ -1576,7 +1579,8 @@ TEST(conduit_blueprint_generate_unstructured, generate_corners)
 
         EXPECT_EQ(corner_topo["coordset"].as_string(), CORNER_COORDSET_NAME);
         EXPECT_EQ(corner_topo["elements/shape"].as_string(), corner_type_name);
-        EXPECT_EQ(corner_conn.dtype().id(), grid_conn.dtype().id());
+        // relax exact type req, conn transforms will become index_t
+        // EXPECT_EQ(corner_conn.dtype().id(), grid_conn.dtype().id());
         EXPECT_EQ(corner_off.dtype().number_of_elements(), grid_corners);
 
         // Validate Correctness of Element Integrity //

--- a/src/tests/blueprint/t_blueprint_mesh_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_generate.cpp
@@ -1104,7 +1104,7 @@ TEST(conduit_blueprint_generate_unstructured, generate_points)
 
         Node &point_topo = point_mesh["topologies"][POINT_TOPOLOGY_NAME];
         mesh::topology::unstructured::generate_points(grid_topo, point_topo, t2p_map, p2t_map);
-
+        
         Node data, info;
         EXPECT_TRUE(mesh::topology::unstructured::verify(point_topo, info));
 


### PR DESCRIPTION
* add generate_offsets_inline to serve the case where we want to create them in the tree
* refactor the polyhedral case for generate_offsets to clearly identify the cases where we are breaking const rules
* simplify generate_offsets logic using accessors
* refactored `mesh::topology::logical_dims to use direct calc instead of relying on generate offsets

* fixed const-cast related crime for element and subelement offset gen