### PR TITLE
Fix for older Apple Clang - LLVM version 8.1.0 (clang-802.0.42)

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_julia.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_julia.cpp
@@ -613,8 +613,8 @@ int32 refine(int32 domain_index,
       x_vals[o] = float32(iters[y * nx + x_o]);
       y_vals[o] = float32(iters[y_o * nx + x]);
     }
-    float32 ddx = std::abs(x_vals[0] - 2.f * x_vals[1] + x_vals[2]);
-    float32 ddy = std::abs(y_vals[0] - 2.f * y_vals[1] + y_vals[2]);
+    float32 ddx = fabsf(x_vals[0] - 2.f * x_vals[1] + x_vals[2]);
+    float32 ddy = fabsf(y_vals[0] - 2.f * y_vals[1] + y_vals[2]);
     float32 eps = sqrt(ddx*ddx + ddy*ddy);
     // TODO, should der be a floating point # here?
     der[i] = eps;


### PR DESCRIPTION
I ran into a compilation problem using clang on an old Mac. This commit fixes that compilation problem.