### PR TITLE
Fortran node_datatype API

### DIFF
--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -123,7 +123,8 @@ if(FORTRAN_FOUND)
     # Specify fortran sources
     #
     set(conduit_fortran_sources
-        fortran/conduit_fortran.F90)
+        fortran/conduit_fortran.F90
+        fortran/conduit_fortran_endianess_types.f90)
 
     #  add oo interface if the fortran compiler supports it
     if(ENABLE_FORTRAN_OBJ_INTERFACE)

--- a/src/libs/conduit/fortran/conduit_fortran.F90
+++ b/src/libs/conduit/fortran/conduit_fortran.F90
@@ -1178,6 +1178,15 @@ module conduit
          real(C_DOUBLE) :: res
     end function conduit_node_as_double
 
+    !--------------------------------------------------------------------------
+    pure function conduit_node_dtype(cnode) result(res) &
+             bind(C, name="conduit_node_dtype")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cnode
+         type(C_PTR) :: res
+    end function conduit_node_dtype
+
 
     !--------------------------------------------------------------------------
     end interface

--- a/src/libs/conduit/fortran/conduit_fortran.F90
+++ b/src/libs/conduit/fortran/conduit_fortran.F90
@@ -1188,6 +1188,400 @@ module conduit
          type(C_PTR), value, intent(IN) :: cnode
          type(C_PTR) :: res
     end function conduit_node_dtype
+    
+    !--------------------------------------------------------------------------
+    ! DataType methods
+    !--------------------------------------------------------------------------
+
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_sizeof_index_t() result(res) &
+             bind(C, name="conduit_datatype_sizeof_index_t")
+         use iso_c_binding
+         implicit none
+         integer(C_INT) :: res
+    end function conduit_datatype_sizeof_index_t
+
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_id(cdatatype) result(res) &
+             bind(C, name="conduit_datatype_id")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_id
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_name(cdatatype) result(res) &
+             bind(C, name="conduit_datatype_name")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         character(kind=C_CHAR) ::res 
+    end function c_conduit_datatype_name
+    
+    !--------------------------------------------------------------------------
+    subroutine c_conduit_datatype_name_destroy(nameStr) &
+             bind(C, name="conduit_datatype_name_destroy")
+         use iso_c_binding
+         implicit none
+         character(kind=C_CHAR), intent(IN) ::nameStr(*)
+    end subroutine c_conduit_datatype_name_destroy
+
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_number_of_elements(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_number_of_elements")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_number_of_elements
+
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_offset(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_offset")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_offset
+    
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_stride(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_stride")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_stride
+    
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_element_bytes(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_element_bytes")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_element_bytes
+    
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_endianness(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_endianness")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_endianness
+    
+    !--------------------------------------------------------------------------
+    pure function conduit_datatype_element_index(cdatatype, idx) result(res) &
+            bind(C, name="conduit_datatype_element_index")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(kind(F_CONDUIT_INDEX_ID)), value, intent(IN) :: idx
+         integer(kind(F_CONDUIT_INDEX_ID)) :: res
+    end function conduit_datatype_element_index
+
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_empty(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_empty")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_empty
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_object(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_object")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_object
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_list(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_list")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_list
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_number(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_number")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_number
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_floating_point(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_floating_point")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_floating_point
+
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_integer(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_integer")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_integer
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_signed_integer(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_signed_integer")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_signed_integer
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_unsigned_integer(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_unsigned_integer")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_unsigned_integer
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_int8(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_int8")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_int8
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_int16(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_int16")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_int16
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_int32(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_int32")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_int32
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_int64(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_int64")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_int64
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_uint8(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_uint8")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_uint8
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_uint16(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_uint16")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_uint16
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_uint32(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_uint32")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_uint32
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_uint64(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_uint64")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_uint64
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_float32(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_float32")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_float32
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_float64(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_float64")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_float64
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_char(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_char")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_char
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_short(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_short")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_short
+
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_int(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_int")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_int
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_long(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_long")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_long
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_unsigned_char(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_unsigned_char")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_unsigned_char
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_unsigned_short(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_unsigned_short")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_unsigned_short
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_unsigned_int(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_unsigned_int")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_unsigned_int
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_unsigned_long(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_unsigned_long")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_unsigned_long
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_float(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_float")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_float
+
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_double(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_double")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_double
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_string(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_string")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_string
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_char8_str(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_char8_str")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_char8_str
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_little_endian(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_little_endian")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_little_endian
+    
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_is_big_endian(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_is_big_endian")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_is_big_endian
+
+    !--------------------------------------------------------------------------
+    pure function c_conduit_datatype_endianness_matches_machine(cdatatype) result(res) &
+            bind(C, name="conduit_datatype_endianness_matches_machine")
+         use iso_c_binding
+         implicit none
+         type(C_PTR), value, intent(IN) :: cdatatype
+         integer(C_INT) :: res
+    end function c_conduit_datatype_endianness_matches_machine
 
 
     !--------------------------------------------------------------------------

--- a/src/libs/conduit/fortran/conduit_fortran.F90
+++ b/src/libs/conduit/fortran/conduit_fortran.F90
@@ -78,6 +78,8 @@ module conduit
     integer, parameter :: CONDUIT_DOUBLE_ID = F_CONDUIT_NATIVE_DOUBLE_ID
     !--------------------------------------------------------------------------
 
+    ! conduit_index_t as defined in c
+    integer, parameter :: CONDUIT_INDEX_ID = F_CONDUIT_INDEX_ID
 
 
     !--------------------------------------------------------------------------

--- a/src/libs/conduit/fortran/conduit_fortran.F90
+++ b/src/libs/conduit/fortran/conduit_fortran.F90
@@ -24,7 +24,7 @@ module conduit
     ! generic types
     !--------------------------------------------------------------------------
     integer, parameter :: CONDUIT_EMPTY_ID  = F_CONDUIT_EMPTY_ID
-    integer, parameter :: CONDUIT_OBJECT_ID = F_CONDUIT_EMPTY_ID
+    integer, parameter :: CONDUIT_OBJECT_ID = F_CONDUIT_OBJECT_ID
     integer, parameter :: CONDUIT_LIST_ID   = F_CONDUIT_LIST_ID
     
     !--------------------------------------------------------------------------

--- a/src/libs/conduit/fortran/conduit_fortran_bitwidth_style_types.inc.in
+++ b/src/libs/conduit/fortran/conduit_fortran_bitwidth_style_types.inc.in
@@ -152,6 +152,17 @@
 #error Bitwidth Style Types: no native type found that maps to float64
 #endif
 
+!------------------------------------------------------------------------------
+! Index Types
+!------------------------------------------------------------------------------
+
+! use a 64-bit index, unless CONDUIT_INDEX_32 is defined.
+#ifdef CONDUIT_INDEX_32
+#define F_CONDUIT_INDEX_ID  F_CONDUIT_INT32_ID
+#else
+#define F_CONDUIT_INDEX_ID  F_CONDUIT_INT64_ID
+#endif 
+
 !-----------------------------------------------------------------------------
 !End Bit-width type map sanity checks
 !-----------------------------------------------------------------------------

--- a/src/libs/conduit/fortran/conduit_fortran_endianess_types.f90
+++ b/src/libs/conduit/fortran/conduit_fortran_endianess_types.f90
@@ -1,0 +1,33 @@
+!* Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+!* Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+!* other details. No copyright assignment is required to contribute to Conduit.
+
+
+!------------------------------------------------------------------------------
+! file: conduit_fortran_endianness_types.f90
+!------------------------------------------------------------------------------
+
+!------------------------------------------------------------------------------
+!------------------------------------------------------------------------------
+
+!-------------------------------------------------------------------------------
+!--- conduit_endianness_type_id is an Enumeration used to describe the
+!--- endianness cases supported by conduit
+!-------------------------------------------------------------------------------
+
+module conduit_endianness_enum
+
+implicit none
+
+enum, bind(c)
+
+    ! Use this with `integer(kind(conduit_endianness_type_id))` to declare variables of this type.
+    enumerator :: conduit_endianness_type_id = 0
+
+    enumerator :: conduit_endianness_default_id  = 0
+    enumerator :: conduit_endianness_big_id = 1
+    enumerator :: conduit_endianness_little_id = 2
+
+end enum
+
+end module conduit_endianness_enum

--- a/src/tests/conduit/fortran/CMakeLists.txt
+++ b/src/tests/conduit/fortran/CMakeLists.txt
@@ -10,6 +10,7 @@ set(FORTRAN_TESTS
     t_f_type_sizes
     t_f_conduit_smoke
     t_f_conduit_node
+    t_f_conduit_node_datatype
     t_f_conduit_node_int
     t_f_conduit_node_float
     t_f_conduit_node_char8_str

--- a/src/tests/conduit/fortran/t_f_conduit_node_datatype.f90
+++ b/src/tests/conduit/fortran/t_f_conduit_node_datatype.f90
@@ -1,0 +1,242 @@
+!* Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+!* Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+!* other details. No copyright assignment is required to contribute to Conduit.
+
+!------------------------------------------------------------------------------
+!
+! t_f_conduit_node_datatype.f
+!
+!------------------------------------------------------------------------------
+
+#include "conduit_fortran_bitwidth_style_types.inc"
+
+!------------------------------------------------------------------------------
+module t_f_conduit_node_datatype
+!------------------------------------------------------------------------------
+
+  use iso_c_binding
+  use fruit
+  use conduit
+  implicit none
+
+!------------------------------------------------------------------------------
+contains
+!------------------------------------------------------------------------------
+
+!------------------------------------------------------------------------------    
+!  Opaque Pointer Function Style test
+!------------------------------------------------------------------------------
+      subroutine t_node_datatype_ids
+          type(C_PTR) cnode_a
+          type(C_PTR) list
+          type(C_PTR) dataType
+          integer, parameter :: int64 = selected_int_kind(15)
+          integer(4) i
+          integer(C_INT) :: cint  = 42
+          real(C_DOUBLE) :: cdouble = 42.0
+        
+          
+          !----------------------------------------------------------------------
+          call set_case_name("t_node_datatype_ids")
+          !----------------------------------------------------------------------
+
+          !--------------
+          ! c++ ~equiv:
+          !--------------
+          ! Node n_a;
+          cnode_a = conduit_node_create()
+          dataType = conduit_node_dtype(cnode_a)
+          
+          call assert_true( c_conduit_datatype_is_empty(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_EMPTY_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 0)
+          call assert_true( conduit_datatype_stride(dataType) == 0)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! n_a["data"] = 42;
+          call conduit_node_set_path_int32(cnode_a,"data",42)
+          call assert_true( c_conduit_datatype_is_object(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_OBJECT_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 0)
+          call assert_true( conduit_datatype_stride(dataType) == 0)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! Node n_a 
+          ! for(int i = 0; i < 5 ; i++ )
+          ! {
+          !    Node &list_entry = n.append();
+          !    list_entry.set(i);
+          ! }
+          do i = 1,5
+            list = conduit_node_append(cnode_a)
+            call conduit_node_set_int32(list,i)
+          enddo
+
+          call assert_true( c_conduit_datatype_is_list(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_LIST_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 0)
+          call assert_true( conduit_datatype_stride(dataType) == 0)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+           
+          ! Node n_a = int32(-42)
+          call conduit_node_set_int32(cnode_a,-42)
+          call assert_true( c_conduit_datatype_is_int32(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_INT32_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 4)
+          call assert_true( conduit_datatype_stride(dataType) == 4)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          
+          ! Node n_a = int64(-42)
+          call conduit_node_set_int64(cnode_a,42_int64)
+          call assert_true( c_conduit_datatype_is_int64(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_INT64_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 8)
+          call assert_true( conduit_datatype_stride(dataType) == 8)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! Node n_a = float(42.0)
+          call conduit_node_set_float32(cnode_a,42.0)
+          call assert_true( c_conduit_datatype_is_float32(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_FLOAT32_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 4)
+          call assert_true( conduit_datatype_stride(dataType) == 4)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 1)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! Node n_a = double(42.0)
+          call conduit_node_set_float64(cnode_a,3.1415d+0)
+          call assert_true( c_conduit_datatype_is_float64(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_FLOAT64_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 8)
+          call assert_true( conduit_datatype_stride(dataType) == 8)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 1)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! Node n_a = "test string"
+          call conduit_node_set_char8_str(cnode_a,"test string")
+          call assert_true( c_conduit_datatype_is_char8_str(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_CHAR8_STR_ID)
+          call assert_true( conduit_datatype_element_bytes(dataType) == 1)
+          call assert_true( conduit_datatype_stride(dataType) == 1)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_string(dataType) == 1)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! Node n_a = cint
+          call conduit_node_set_int(cnode_a,cint)
+          call assert_true( c_conduit_datatype_is_int(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_INT_ID)
+          ! depends on type of int in C
+          ! call assert_true( conduit_datatype_element_bytes(dataType) == 1)
+          !call assert_true( conduit_datatype_stride(dataType) == 1)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_string(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          ! Node n_a = double(42)
+          call conduit_node_set_double(cnode_a,cdouble)
+          call assert_true( c_conduit_datatype_is_double(dataType) == 1)
+          call assert_true( conduit_datatype_id(dataType) == CONDUIT_DOUBLE_ID)
+          
+          call assert_true( conduit_datatype_element_bytes(dataType) == 8)
+          call assert_true( conduit_datatype_stride(dataType) == 8)
+          call assert_true( conduit_datatype_offset(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_number(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_signed_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_unsigned_integer(dataType) == 0)
+          call assert_true( c_conduit_datatype_is_floating_point(dataType) == 1)
+          call assert_true( c_conduit_datatype_is_string(dataType) == 0)
+          call assert_true(c_conduit_datatype_endianness_matches_machine(dataType) == 1)
+          
+          
+          call conduit_node_destroy(cnode_a)
+          ! TODO pick 4/8 on compile time
+          !call assert_equals(conduit_datatype_sizeof_index_t(),4)
+          !call assert_equals(conduit_datatype_sizeof_index_t(),8)
+
+      end subroutine t_node_datatype_ids
+
+!------------------------------------------------------------------------------
+end module t_f_conduit_node_datatype
+!------------------------------------------------------------------------------
+
+!------------------------------------------------------------------------------
+program fortran_test
+!------------------------------------------------------------------------------
+  use fruit
+  use t_f_conduit_node_datatype
+  implicit none
+  logical ok
+  
+  call init_fruit
+
+  !----------------------------------------------------------------------------
+  ! call our test routines
+  !----------------------------------------------------------------------------
+  call t_node_datatype_ids
+
+  call fruit_summary
+  call fruit_finalize
+  call is_all_successful(ok)
+  
+  if (.not. ok) then
+     call exit(1)
+  endif
+
+!------------------------------------------------------------------------------
+end program fortran_test
+!------------------------------------------------------------------------------
+
+


### PR DESCRIPTION
The goal of this PR is to the extent the Fortran API to the level of the C API so that users of Kitware's Catalyst can use either API.

This PR builds on the work of  https://gitlab.kitware.com/ben.boeckel/catalyst/-/commits/fortran-bindings/ trying to follow the  conventions in this repository. 

For now, the test covers only the types that can be constructed though the  existing Fortran API and uses only the opaque pointer function style , I plan to add Object Oriented interface similar to the one in `conduit_fortran_obj.f90` soon.