### PR TITLE
conduit_config.mk link fix and docs fix

### DIFF
--- a/src/config/conduit_config.mk.in
+++ b/src/config/conduit_config.mk.in
@@ -125,15 +125,15 @@ CONDUIT_CALIPER_LIB_FLAGS  = $(if $(CONDUIT_CALIPER_DIR),-L $(CONDUIT_CALIPER_DI
 ##########
 # All conduit libs, without MPI
 CONDUIT_LIB_FLAGS = -L $(CONDUIT_DIR)/lib \
-                    -lconduit_blueprint \
                     -lconduit_relay \
+                    -lconduit_blueprint \
                     -lconduit $(CONDUIT_ADIOS_LIB_FLAGS) $(CONDUIT_SILO_LIB_FLAGS) $(CONDUIT_HDF5_LIB_FLAGS) $(CONDUIT_ZFP_LIB_FLAGS) $(CONDUIT_CALIPER_LIB_FLAGS) $(CONDUIT_ADIAK_LIB_FLAGS) $(CONDUIT_EXTRA_LIB_FLAGS)
 
 # All conduit libs, with MPI
 CONDUIT_MPI_LIB_FLAGS = -L $(CONDUIT_DIR)/lib \
                         -lconduit_relay_mpi_io \
                         -lconduit_relay_mpi \
+                        -lconduit_relay \
                         -lconduit_blueprint_mpi \
                         -lconduit_blueprint \
-                        -lconduit_relay \
                         -lconduit $(CONDUIT_ADIOS_MPI_LIB_FLAGS) $(CONDUIT_SILO_LIB_FLAGS) $(CONDUIT_HDF5_LIB_FLAGS) $(CONDUIT_ZFP_LIB_FLAGS) $(CONDUIT_METIS_LIB_FLAGS) $(CONDUIT_PARMETIS_LIB_FLAGS) $(CONDUIT_CALIPER_LIB_FLAGS) $(CONDUIT_ADIAK_LIB_FLAGS) $(CONDUIT_EXTRA_LIB_FLAGS)

--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -1594,8 +1594,8 @@ Save a mesh to disk using a specific protocol:
 .. code:: cpp
 
     conduit::relay::io::blueprint::write_mesh(const conduit::Node &mesh,
-                                              const std::string &protocol,
-                                              const std::string &path);
+                                              const std::string &path,
+                                              const std::string &protocol);
 
 Save a mesh to disk using a specific protocol and options:
 


### PR DESCRIPTION
This PR fixes two issues found by @ltaylor16 :


- Fixes link order issue in config.mk which undermine static linking 
- Fix typo in write method signature in mesh blueprint docs