### PR TITLE
BitwidthMapping: only set `bitwidth_prefer_long_long` without C++11

### DIFF
--- a/src/libs/conduit/cmake/BitwidthMapping.cmake
+++ b/src/libs/conduit/cmake/BitwidthMapping.cmake
@@ -787,7 +787,6 @@ endmacro()
 # over `long`.
 #-----------------------------------------------------------------------------
 
-set(bitwidth_prefer_long_long FALSE)
 if(CONDUIT_USE_CXX11)
     # note: this call assumes this file included from libs/conduit/CMakeLists.txt
     try_compile( bitwidth_prefer_long_long   # result var
@@ -796,6 +795,8 @@ if(CONDUIT_USE_CXX11)
                  OUTPUT_VARIABLE bitwidth_prefer_long_long_out
                  CXX_STANDARD 11
                  CXX_STANDARD_REQUIRED TRUE)
+else()
+    set(bitwidth_prefer_long_long FALSE)
 endif()
 
 


### PR DESCRIPTION
CMake policy CMP0126[1], introduced in CMake 3.21, changes behavior for `set(CACHE)` so that local variable definitions are no longer removed when defining a value for the cache. This is part of a series of policy changes related to how cache and local variables interacted and making them more separate and easier to reason about (namely that changing cache variables doesn't affect local variables). However, in connection with the rule that local variables always win, this policy change means that code which conditionally does a cache setting must defer setting some default local value until it knows the cache will not be used.

Fix `bitwidth_prefer_long_long` to be set locally only if it is not meant to be set via the cache so that the default `FALSE` setting does not unconditionally get used.

[1] https://cmake.org/cmake/help/latest/policy/CMP0126.html

Fixes: #1090