### PR TITLE
Python:  ABI3 compatibility changes

### DIFF
--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -2,6 +2,21 @@
 # Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
 # other details. No copyright assignment is required to contribute to Conduit.
 
+# Create an interface target to hold the common flags for python targets
+add_library(conduit_python_build INTERFACE)
+install(TARGETS conduit_python_build EXPORT "conduit")
+
+if(PYTHON_FOUND)
+  if(PYTHON_CONFIG_VERSION VERSION_GREATER_EQUAL "3.11")
+    option(CONDUIT_PYTHON_USE_LIMITED_API "Build Python extensions using Limited API" OFF)
+    if(CONDUIT_PYTHON_USE_LIMITED_API)
+      set(CONDUIT_PYTHON_LIMITED_API 0x030B0000)
+      target_compile_definitions(conduit_python_build INTERFACE Py_LIMITED_API=${CONDUIT_PYTHON_LIMITED_API})
+      message(STATUS "Using Python's Stable ABI Version: ${CONDUIT_PYTHON_LIMITED_API}")
+    endif()
+  endif()
+endif()
+
 ################################
 # Add the conduit lib
 ################################

--- a/src/libs/blueprint/python/CMakeLists.txt
+++ b/src/libs/blueprint/python/CMakeLists.txt
@@ -14,7 +14,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_python conduit conduit_blueprint conduit_python_build)
 
 #############################################################
 # blueprint.mcarray
@@ -29,7 +29,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mcarray_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_mcarray_python conduit conduit_blueprint conduit_python_build)
 
 # add mcarray examples submodule
 PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_examples_python
@@ -40,7 +40,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_examples_pyth
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mcarray_examples_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_mcarray_examples_python conduit conduit_blueprint conduit_python_build)
 
 #############################################################
 # blueprint.mesh
@@ -55,7 +55,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mesh_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mesh_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_mesh_python conduit conduit_blueprint conduit_python_build)
 
 
 # add mesh examples submodule
@@ -67,7 +67,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mesh_examples_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mesh_examples_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_mesh_examples_python conduit conduit_blueprint conduit_python_build)
 
 #############################################################
 # blueprint.table
@@ -82,7 +82,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_table_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_table_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_table_python conduit conduit_blueprint conduit_python_build)
 
 
 # add table examples submodule
@@ -94,4 +94,4 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_table_examples_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_table_examples_python conduit conduit_blueprint)
+target_link_libraries(conduit_blueprint_table_examples_python conduit conduit_blueprint conduit_python_build)

--- a/src/libs/conduit/python/CMakeLists.txt
+++ b/src/libs/conduit/python/CMakeLists.txt
@@ -44,7 +44,7 @@ PYTHON_ADD_HYBRID_MODULE(NAME          conduit_python
                          FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_python conduit)
+target_link_libraries(conduit_python conduit conduit_python_build)
 
 
 #############################################################
@@ -60,7 +60,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_utils_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_utils_python conduit)
+target_link_libraries(conduit_utils_python conduit conduit_python_build)
 
 # install the capi header so other python modules can use it
 # support alt install dir for python module via PYTHON_MODULE_INSTALL_PREFIX

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -201,6 +201,7 @@ struct module_state {
     PyObject *error;
     #ifdef Py_LIMITED_API
     PyTypeObject* PyConduit_DataType_TYPE;
+    PyTypeObject* PyConduit_Generator_TYPE;
     #endif
 };
 
@@ -3526,6 +3527,25 @@ static PyMethodDef PyConduit_Generator_METHODS[] = {
 //---------------------------------------------------------------------------//
 
 
+#ifdef Py_LIMITED_API
+static PyType_Slot PyConduit_Generator_SLOTS[]  = {
+  {Py_tp_dealloc, (void*) PyConduit_Generator_dealloc},
+  {Py_tp_methods, (void*) PyConduit_Generator_METHODS},
+  {Py_tp_init,    (void*) PyConduit_Generator_init},
+  {Py_tp_new,     (void*) PyConduit_Generator_new},
+  {0,0},
+};
+
+static PyType_Spec PyConduit_Generator_SPEC = 
+{
+   "Generator",                                /* tp_name */
+   sizeof(PyConduit_Generator),                /* tp_basicsize */
+   0,                                          /* tp_itemsize */
+   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
+   PyConduit_Generator_SLOTS,                  /* tp_slots */
+};
+
+#else
 static PyTypeObject PyConduit_Generator_TYPE = {
    PyVarObject_HEAD_INIT(NULL, 0)
    "Generator",
@@ -3578,13 +3598,16 @@ static PyTypeObject PyConduit_Generator_TYPE = {
    0  /* tp_version_tag */
    PyVarObject_TAIL
 };
+#endif
 
 
 //---------------------------------------------------------------------------//
 static int
 PyConduit_Generator_Check(PyObject* obj)
 {
-    return (PyObject_TypeCheck(obj, &PyConduit_Generator_TYPE));
+    PyTypeObject* type = NULL;
+    Set_PyTypeObject_Macro(type, PyConduit_Generator_TYPE);
+    return (PyObject_TypeCheck(obj, type));
 }
 
 
@@ -8243,6 +8266,7 @@ conduit_python_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(GETSTATE(m)->error);
     #ifdef Py_LIMITED_API
     Py_VISIT(GETSTATE(m)->PyConduit_DataType_TYPE);
+    Py_VISIT(GETSTATE(m)->PyConduit_Generator_TYPE);
     #endif
     return 0;
 }
@@ -8254,6 +8278,7 @@ conduit_python_clear(PyObject *m)
     Py_CLEAR(GETSTATE(m)->error);
     #ifdef Py_LIMITED_API
     Py_CLEAR(GETSTATE(m)->PyConduit_DataType_TYPE);
+    Py_CLEAR(GETSTATE(m)->PyConduit_Generator_TYPE);
     #endif
     return 0;
 }

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -204,6 +204,7 @@ struct module_state {
     PyTypeObject* PyConduit_Generator_TYPE;
     PyTypeObject* PyConduit_Schema_TYPE;
     PyTypeObject* PyConduit_NodeIterator_TYPE;
+    PyTypeObject* PyConduit_Node_TYPE;
     #endif
 };
 
@@ -7307,6 +7308,29 @@ static PyMethodDef PyConduit_Node_METHODS[] = {
     {NULL, NULL, 0, NULL}
 };
 
+#ifdef Py_LIMITED_API
+static PyType_Slot PyConduit_Node_SLOTS[]  = {
+  {Py_tp_dealloc,        (void*) PyConduit_Node_dealloc},
+  {Py_tp_methods,        (void*) PyConduit_Node_METHODS},
+  {Py_tp_init,           (void*) PyConduit_Node_init},
+  {Py_tp_new,            (void*) PyConduit_Node_new},
+  {Py_tp_str,            (void*) PyConduit_Node_str},
+  {Py_mp_subscript,      (void*) PyConduit_Node_GetItem},
+  {Py_mp_ass_subscript,  (void*) PyConduit_Node_SetItem},
+  {Py_tp_iter,           (void*) PyConduit_Node_iter},
+  {0,0},
+};
+
+static PyType_Spec PyConduit_Node_SPEC = 
+{
+   "Node",                                     /* tp_name */
+   sizeof(PyConduit_Node),                     /* tp_basicsize */
+   0,                                          /* tp_itemsize */
+   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
+   PyConduit_Node_SLOTS,                       /* tp_slots */
+};
+
+#else
 //---------------------------------------------------------------------------//
 static PyMappingMethods node_as_mapping = {
    (lenfunc)0,    // len operator is not supported
@@ -7370,6 +7394,7 @@ static PyTypeObject PyConduit_Node_TYPE = {
    0  /* tp_version_tag */
    PyVarObject_TAIL
 };
+#endif
 
 
 //---------------------------------------------------------------------------//
@@ -7430,7 +7455,9 @@ PyConduit_Schema_Python_Wrap(Schema *schema, int python_owns)
 static int
 PyConduit_Node_Check(PyObject *obj)
 {
-    return (PyObject_TypeCheck(obj, &PyConduit_Node_TYPE));
+    PyTypeObject* type = NULL;
+    Set_PyTypeObject_Macro(type, PyConduit_Node_TYPE);
+    return (PyObject_TypeCheck(obj, type));
 }
 
 //---------------------------------------------------------------------------//
@@ -7444,7 +7471,8 @@ PyConduit_Node_Get_Node_Ptr(PyObject *obj)
 static PyObject *
 PyConduit_Node_Python_Wrap(Node *node, int python_owns)
 {
-    PyTypeObject* type = (PyTypeObject*)&PyConduit_Node_TYPE;
+    PyTypeObject* type = NULL;
+    Set_PyTypeObject_Macro(type, PyConduit_Node_TYPE);
     PyConduit_Node *retval = (PyConduit_Node*)PyType_GenericAlloc(type,0);
     retval->node = node;
     retval->python_owns = python_owns;
@@ -8323,6 +8351,7 @@ conduit_python_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(GETSTATE(m)->PyConduit_Generator_TYPE);
     Py_VISIT(GETSTATE(m)->PyConduit_Schema_TYPE);
     Py_VISIT(GETSTATE(m)->PyConduit_NodeIterator_TYPE);
+    Py_VISIT(GETSTATE(m)->PyConduit_Node_TYPE);
     #endif
     return 0;
 }
@@ -8337,6 +8366,7 @@ conduit_python_clear(PyObject *m)
     Py_CLEAR(GETSTATE(m)->PyConduit_Generator_TYPE);
     Py_CLEAR(GETSTATE(m)->PyConduit_Schema_TYPE);
     Py_CLEAR(GETSTATE(m)->PyConduit_NodeIterator_TYPE);
+    Py_CLEAR(GETSTATE(m)->PyConduit_Node_TYPE);
     #endif
     return 0;
 }

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -6049,11 +6049,7 @@ PyConduit_Node_print_detailed(PyConduit_Node *self)
 {
     std::ostringstream oss;
     self->node->to_string_stream(oss,"conduit_json");
-    // create python string from our c++ stream and call std print
-    PyObject *py_str = Py_BuildValue("s", oss.str().c_str());
-    PyObject_Print(py_str, stdout, Py_PRINT_RAW);
-    // dec ref for python string
-    Py_DECREF(py_str);
+    std::fprintf(stdout,"%s",oss.str().c_str());
     Py_RETURN_NONE;
 }
 

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -203,6 +203,7 @@ struct module_state {
     PyTypeObject* PyConduit_DataType_TYPE;
     PyTypeObject* PyConduit_Generator_TYPE;
     PyTypeObject* PyConduit_Schema_TYPE;
+    PyTypeObject* PyConduit_NodeIterator_TYPE;
     #endif
 };
 
@@ -4998,7 +4999,28 @@ static PyMethodDef PyConduit_NodeIterator_METHODS[] = {
 //---------------------------------------------------------------------------//
 //---------------------------------------------------------------------------//
 
+#ifdef Py_LIMITED_API
+static PyType_Slot PyConduit_NodeIterator_SLOTS[]  = {
+  {Py_tp_dealloc,  (void*) PyConduit_NodeIterator_dealloc},
+  {Py_tp_methods,  (void*) PyConduit_NodeIterator_METHODS},
+  {Py_tp_init,     (void*) PyConduit_NodeIterator_init},
+  {Py_tp_new,      (void*) PyConduit_NodeIterator_new},
+  {Py_tp_str,      (void*) PyConduit_NodeIterator_str},
+  {Py_tp_iter,     (void*) PyConduit_NodeIterator_iter},
+  {Py_tp_iternext, (void*) PyConduit_NodeIterator_iternext},
+  {0,0},
+};
 
+static PyType_Spec PyConduit_NodeIterator_SPEC = 
+{
+   "NodeIterator",                             /* tp_name */
+   sizeof(PyConduit_NodeIterator),             /* tp_basicsize */
+   0,                                          /* tp_itemsize */
+   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
+   PyConduit_NodeIterator_SLOTS,               /* tp_slots */
+};
+
+#else
 static PyTypeObject PyConduit_NodeIterator_TYPE = {
    PyVarObject_HEAD_INIT(NULL, 0)
    "Iterator",
@@ -5051,13 +5073,15 @@ static PyTypeObject PyConduit_NodeIterator_TYPE = {
    0  /* tp_version_tag */
    PyVarObject_TAIL
 };
+#endif
 
 
 //---------------------------------------------------------------------------//
 static PyConduit_NodeIterator *
 PyConduit_NodeIterator_Python_Create()
 {
-    PyTypeObject* type = (PyTypeObject*)&PyConduit_NodeIterator_TYPE;
+    PyTypeObject* type = NULL;
+    Set_PyTypeObject_Macro(type, PyConduit_NodeIterator_TYPE);
     return (PyConduit_NodeIterator*)PyType_GenericAlloc(type,0);
 }
 
@@ -8298,6 +8322,7 @@ conduit_python_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(GETSTATE(m)->PyConduit_DataType_TYPE);
     Py_VISIT(GETSTATE(m)->PyConduit_Generator_TYPE);
     Py_VISIT(GETSTATE(m)->PyConduit_Schema_TYPE);
+    Py_VISIT(GETSTATE(m)->PyConduit_NodeIterator_TYPE);
     #endif
     return 0;
 }
@@ -8311,6 +8336,7 @@ conduit_python_clear(PyObject *m)
     Py_CLEAR(GETSTATE(m)->PyConduit_DataType_TYPE);
     Py_CLEAR(GETSTATE(m)->PyConduit_Generator_TYPE);
     Py_CLEAR(GETSTATE(m)->PyConduit_Schema_TYPE);
+    Py_CLEAR(GETSTATE(m)->PyConduit_NodeIterator_TYPE);
     #endif
     return 0;
 }

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -7407,7 +7407,7 @@ PyConduit_Node_Set_From_Python_Tuple(Node &node,
     
     for(Py_ssize_t idx=0; idx < tuple_size && homogenous_numeric; idx++)
     {
-        PyObject *py_entry = PyTuple_GET_ITEM(value, idx);
+        PyObject *py_entry = PyTuple_GetItem(value, idx);
         if (PyInt_Check(py_entry) || PyLong_Check(py_entry))
         {
             // int64 still ok
@@ -7433,7 +7433,7 @@ PyConduit_Node_Set_From_Python_Tuple(Node &node,
             int64 *vals_ptr = node.value();
             for(Py_ssize_t idx=0; idx < tuple_size; idx++)
             {
-                PyObject *py_entry = PyTuple_GET_ITEM(value, idx);
+                PyObject *py_entry = PyTuple_GetItem(value, idx);
                 if (PyInt_Check(py_entry))
                 {
                     vals_ptr[idx] = (int64)PyInt_AsLong(py_entry);
@@ -7450,7 +7450,7 @@ PyConduit_Node_Set_From_Python_Tuple(Node &node,
             float64 *vals_ptr = node.value();
             for(Py_ssize_t idx=0; idx < tuple_size; idx++)
             {
-                PyObject *py_entry = PyTuple_GET_ITEM(value, idx);
+                PyObject *py_entry = PyTuple_GetItem(value, idx);
 
                 if (PyInt_Check(py_entry))
                 {
@@ -7474,7 +7474,7 @@ PyConduit_Node_Set_From_Python_Tuple(Node &node,
         ok = true;
         for(Py_ssize_t idx=0; idx < tuple_size && ok; idx++)
         {
-            PyObject *py_entry = PyTuple_GET_ITEM(value, idx);
+            PyObject *py_entry = PyTuple_GetItem(value, idx);
             Node &cld = node.append();
             if( PyConduit_Node_Set_From_Python(cld,py_entry) != 0 )
             {

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -7302,7 +7302,7 @@ PyConduit_Node_Set_From_Python_List(Node &node,
     
     for(Py_ssize_t idx=0; idx < list_size && homogenous_numeric; idx++)
     {
-        PyObject *py_entry = PyList_GET_ITEM(value, idx);
+        PyObject *py_entry = PyList_GetItem(value, idx);
         if (PyInt_Check(py_entry) || PyLong_Check(py_entry))
         {
             // int64 still ok
@@ -7326,7 +7326,7 @@ PyConduit_Node_Set_From_Python_List(Node &node,
             int64 *vals_ptr = node.value();
             for(Py_ssize_t idx=0; idx < list_size; idx++)
             {
-                PyObject *py_entry = PyList_GET_ITEM(value, idx);
+                PyObject *py_entry = PyList_GetItem(value, idx);
                 if (PyInt_Check(py_entry))
                 {
                     vals_ptr[idx] = (int64)PyInt_AsLong(py_entry);
@@ -7343,7 +7343,7 @@ PyConduit_Node_Set_From_Python_List(Node &node,
             float64 *vals_ptr = node.value();
             for(Py_ssize_t idx=0; idx < list_size; idx++)
             {
-                PyObject *py_entry = PyList_GET_ITEM(value, idx);
+                PyObject *py_entry = PyList_GetItem(value, idx);
 
                 if (PyInt_Check(py_entry))
                 {
@@ -7367,7 +7367,7 @@ PyConduit_Node_Set_From_Python_List(Node &node,
         ok = true;
         for(Py_ssize_t idx=0; idx < list_size && ok; idx++)
         {
-            PyObject *py_entry = PyList_GET_ITEM(value, idx);
+            PyObject *py_entry = PyList_GetItem(value, idx);
             Node &cld = node.append();
             if( PyConduit_Node_Set_From_Python(cld,py_entry) != 0 )
             {

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -279,7 +279,7 @@ PyConduit_DataType_new(PyTypeObject* type,
         return (NULL);
     }
 
-    PyConduit_DataType *self = (PyConduit_DataType*)type->tp_alloc(type, 0);
+    PyConduit_DataType* self = (PyConduit_DataType*)PyType_GenericAlloc(type,0);
     return ((PyObject*)self);
 }
 
@@ -3224,7 +3224,7 @@ static PyConduit_DataType *
 PyConduit_DataType_Python_Create()
 {
     PyTypeObject* type = (PyTypeObject*)&PyConduit_DataType_TYPE;
-    return (PyConduit_DataType*)type->tp_alloc(type,0);
+    return (PyConduit_DataType*)PyType_GenericAlloc(type,0);
 }
 
 //---------------------------------------------------------------------------//
@@ -3249,7 +3249,7 @@ PyConduit_Generator_new(PyTypeObject *type,
                         PyObject*, // args -- unused
                         PyObject*) // kwds -- unused
 {
-    PyConduit_Generator *self = (PyConduit_Generator*)type->tp_alloc(type, 0);
+    PyConduit_Generator *self = (PyConduit_Generator*)PyType_GenericAlloc(type,0);
 
     if (self)
     {
@@ -3517,7 +3517,7 @@ PyConduit_Schema_new(PyTypeObject* type,
                      PyObject*) // kwds -- unused
 {
 
-    PyConduit_Schema* self = (PyConduit_Schema*)type->tp_alloc(type, 0);
+    PyConduit_Schema *self = (PyConduit_Schema*)PyType_GenericAlloc(type,0);
     
     if (self)
     {
@@ -4559,7 +4559,7 @@ PyConduit_NodeIterator_new(PyTypeObject *type,
         return (NULL);
     }
     
-    PyConduit_DataType *self = (PyConduit_DataType*)type->tp_alloc(type, 0);
+    PyConduit_DataType *self = (PyConduit_DataType*)PyType_GenericAlloc(type,0);
     return ((PyObject*)self);
 }
 
@@ -4909,7 +4909,7 @@ static PyConduit_NodeIterator *
 PyConduit_NodeIterator_Python_Create()
 {
     PyTypeObject* type = (PyTypeObject*)&PyConduit_NodeIterator_TYPE;
-    return (PyConduit_NodeIterator*)type->tp_alloc(type,0);
+    return (PyConduit_NodeIterator*)PyType_GenericAlloc(type,0);
 }
 
 
@@ -5033,7 +5033,7 @@ PyConduit_Node_new(PyTypeObject* type,
         return (NULL);
     }
 
-    PyConduit_Node* self = (PyConduit_Node*)type->tp_alloc(type, 0);
+    PyConduit_Node* self = (PyConduit_Node*)PyType_GenericAlloc(type,0);
 
     if (self)
     {
@@ -7239,7 +7239,7 @@ PyConduit_Schema_Python_Wrap(Schema *schema, int python_owns)
 {
     PyTypeObject *type = (PyTypeObject*)&PyConduit_Schema_TYPE;
 
-    PyConduit_Schema *retval = (PyConduit_Schema*)type->tp_alloc(type, 0);
+    PyConduit_Schema *retval = (PyConduit_Schema*)PyType_GenericAlloc(type,0);
     retval->schema = schema;
     retval->python_owns = python_owns;
     return ((PyObject*)retval);
@@ -7265,7 +7265,7 @@ static PyObject *
 PyConduit_Node_Python_Wrap(Node *node, int python_owns)
 {
     PyTypeObject* type = (PyTypeObject*)&PyConduit_Node_TYPE;
-    PyConduit_Node* retval = (PyConduit_Node*)type->tp_alloc(type, 0);
+    PyConduit_Node *retval = (PyConduit_Node*)PyType_GenericAlloc(type,0);
     retval->node = node;
     retval->python_owns = python_owns;
     return ((PyObject*)retval);

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -7355,7 +7355,7 @@ PyConduit_Node_Set_From_Python_List(Node &node,
                 }
                 else // float
                 {
-                    vals_ptr[idx] = (float64)PyFloat_AS_DOUBLE(py_entry);
+                    vals_ptr[idx] = (float64)PyFloat_AsDouble(py_entry);
                 }
             }
         }
@@ -7462,7 +7462,7 @@ PyConduit_Node_Set_From_Python_Tuple(Node &node,
                 }
                 else // float
                 {
-                    vals_ptr[idx] = (float64)PyFloat_AS_DOUBLE(py_entry);
+                    vals_ptr[idx] = (float64)PyFloat_AsDouble(py_entry);
                 }
             }
         }
@@ -7609,7 +7609,7 @@ PyConduit_Node_Set_From_Python(Node &node,
     }
     else if (PyFloat_Check(value))
     {
-        node = PyFloat_AS_DOUBLE(value);
+      node = PyFloat_AsDouble(value);
     }
     else if (PyArray_Check(value))
     {

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -7287,7 +7287,7 @@ PyConduit_Node_Set_From_Python_List(Node &node,
     // like json and yaml cases, identify if we are 
     // a numeric case, or a more general case
     
-    Py_ssize_t list_size = PyList_GET_SIZE(value);
+    Py_ssize_t list_size = PyList_Size(value);
 
     if(list_size == 0)
     {

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -101,7 +101,7 @@ PyString_AsString(PyObject *py_obj)
                                                           "strict"); // Owned reference
         if(temp_bytes != NULL)
         {
-            res = _conduit_strdup(PyBytes_AS_STRING(temp_bytes));
+            res = _conduit_strdup(PyBytes_AsString(temp_bytes));
             Py_DECREF(temp_bytes);
         }
         else
@@ -111,7 +111,7 @@ PyString_AsString(PyObject *py_obj)
     }
     else if(PyBytes_Check(py_obj))
     {
-        res = _conduit_strdup(PyBytes_AS_STRING(py_obj));
+        res = _conduit_strdup(PyBytes_AsString(py_obj));
     }
     else
     {
@@ -7555,7 +7555,7 @@ PyConduit_Node_Set_From_Numpy_Unicode_Array(Node &node,
         }
 
         // copy data into conduit node
-        cld.set_char8_str(PyBytes_AS_STRING(py_temp_bytes));
+        cld.set_char8_str(PyBytes_AsString(py_temp_bytes));
         // cleanup temp bytes
         Py_DECREF(py_temp_bytes);
     }

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -7392,7 +7392,7 @@ PyConduit_Node_Set_From_Python_Tuple(Node &node,
     // a numeric case, or a more general case
     
     
-    Py_ssize_t tuple_size = PyTuple_GET_SIZE(value);
+    Py_ssize_t tuple_size = PyTuple_Size(value);
     
     if(tuple_size == 0)
     {

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -142,7 +142,7 @@ PyUnicode_From_UTF32_Unicode_Buffer(const char *unicode_buffer,
 {
     return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND,
                                      unicode_buffer,
-                                     string_len);
+                                     string_len/4);
 }
 
 //-----------------------------------------------------------------------------
@@ -7530,9 +7530,8 @@ PyConduit_Node_Set_From_Numpy_Unicode_Array(Node &node,
 
         // get unicode data and construct a python unicode object from it
         void *unicode_buffer_ptr = PyArray_GETPTR1(py_arr,i);
-        int unicode_str_len = ((int)(buffer_len)) / 4;
         PyObject *py_temp_unicode = PyUnicode_From_UTF32_Unicode_Buffer((const char*)unicode_buffer_ptr,
-                                                                        unicode_str_len);
+                                                                        buffer_len);
             
         if(py_temp_unicode == NULL)
         {

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -140,9 +140,16 @@ static PyObject *
 PyUnicode_From_UTF32_Unicode_Buffer(const char *unicode_buffer,
                                     int string_len)
 {
+    #ifdef Py_LIMITED_API
+    return PyUnicode_Decode(unicode_buffer,
+                             string_len,
+                             "utf-32",
+                             "strict");
+    #else
     return PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND,
                                      unicode_buffer,
                                      string_len/4);
+    #endif
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -205,6 +205,7 @@ struct module_state {
     PyTypeObject* PyConduit_Schema_TYPE;
     PyTypeObject* PyConduit_NodeIterator_TYPE;
     PyTypeObject* PyConduit_Node_TYPE;
+    PyTypeObject* PyConduit_Endianness_TYPE;
     #endif
 };
 
@@ -8281,7 +8282,22 @@ static PyMethodDef PyConduit_Endianness_METHODS[] =
 //---------------------------------------------------------------------------//
 //---------------------------------------------------------------------------//
 
+#ifdef Py_LIMITED_API
+static PyType_Slot PyConduit_Endianness_SLOTS[]  = {
+  {Py_tp_methods,        (void*) PyConduit_Endianness_METHODS},
+  {0,0},
+};
 
+static PyType_Spec PyConduit_Endianness_SPEC = 
+{
+   "Endianness",               /* tp_name */
+   0,                          /* tp_basicsize */
+   0,                          /* tp_itemsize */
+   Py_TPFLAGS_DEFAULT,         /* tp_flags */
+   PyConduit_Endianness_SLOTS, /* tp_slots */
+};
+
+#else
 static PyTypeObject PyConduit_Endianness_TYPE = {
    PyVarObject_HEAD_INIT(NULL, 0)
    "Endianness",
@@ -8334,6 +8350,7 @@ static PyTypeObject PyConduit_Endianness_TYPE = {
    0  /* tp_version_tag */
    PyVarObject_TAIL
 };
+#endif
 
 
 
@@ -8352,6 +8369,7 @@ conduit_python_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(GETSTATE(m)->PyConduit_Schema_TYPE);
     Py_VISIT(GETSTATE(m)->PyConduit_NodeIterator_TYPE);
     Py_VISIT(GETSTATE(m)->PyConduit_Node_TYPE);
+    Py_VISIT(GETSTATE(m)->PyConduit_Endianness_TYPE);
     #endif
     return 0;
 }
@@ -8366,7 +8384,7 @@ conduit_python_clear(PyObject *m)
     Py_CLEAR(GETSTATE(m)->PyConduit_Generator_TYPE);
     Py_CLEAR(GETSTATE(m)->PyConduit_Schema_TYPE);
     Py_CLEAR(GETSTATE(m)->PyConduit_NodeIterator_TYPE);
-    Py_CLEAR(GETSTATE(m)->PyConduit_Node_TYPE);
+    Py_CLEAR(GETSTATE(m)->PyConduit_Endianness_TYPE);
     #endif
     return 0;
 }

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -199,6 +199,9 @@ PyUnicode_From_UTF32_Unicode_Buffer(const char *unicode_buffer,
 
 struct module_state {
     PyObject *error;
+    #ifdef Py_LIMITED_API
+    PyTypeObject* PyConduit_DataType_TYPE;
+    #endif
 };
 
 //---------------------------------------------------------------------------//
@@ -3222,7 +3225,25 @@ static PyMethodDef PyConduit_DataType_METHODS[] = {
 //---------------------------------------------------------------------------//
 //---------------------------------------------------------------------------//
 
+#ifdef Py_LIMITED_API
+static PyType_Slot PyConduit_DataType_SLOTS[]  = {
+  {Py_tp_dealloc, (void*) PyConduit_DataType_dealloc},
+  {Py_tp_str,     (void*) PyConduit_DataType_str},
+  {Py_tp_methods, (void*) PyConduit_DataType_METHODS},
+  {Py_tp_init,    (void*) PyConduit_DataType_init},
+  {Py_tp_new,     (void*) PyConduit_DataType_new},
+  {0,0},
+};
 
+static PyType_Spec PyConduit_DataType_SPEC = 
+{
+   "DataType",                                /* tp_name */
+   sizeof(PyConduit_DataType),                /* tp_basicsize */
+   0,                                         /* tp_itemsize */
+   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags */
+   PyConduit_DataType_SLOTS,                  /* tp_slots */
+};
+#else
 static PyTypeObject PyConduit_DataType_TYPE = {
    PyVarObject_HEAD_INIT(NULL, 0)
    "DataType",
@@ -3276,12 +3297,14 @@ static PyTypeObject PyConduit_DataType_TYPE = {
    PyVarObject_TAIL
 };
 
+#endif
 
 //---------------------------------------------------------------------------//
 static PyConduit_DataType *
 PyConduit_DataType_Python_Create()
 {
-    PyTypeObject* type = (PyTypeObject*)&PyConduit_DataType_TYPE;
+    PyTypeObject* type = NULL;
+    Set_PyTypeObject_Macro(type,PyConduit_DataType_TYPE);
     return (PyConduit_DataType*)PyType_GenericAlloc(type,0);
 }
 
@@ -3289,7 +3312,9 @@ PyConduit_DataType_Python_Create()
 static int
 PyConduit_DataType_Check(PyObject *obj)
 {
-    return (PyObject_TypeCheck(obj, &PyConduit_DataType_TYPE));
+    PyTypeObject* type = NULL;
+    Set_PyTypeObject_Macro(type,PyConduit_DataType_TYPE);
+    return (PyObject_TypeCheck(obj, type));
 }
 
 
@@ -8216,6 +8241,9 @@ static int
 conduit_python_traverse(PyObject *m, visitproc visit, void *arg)
 {
     Py_VISIT(GETSTATE(m)->error);
+    #ifdef Py_LIMITED_API
+    Py_VISIT(GETSTATE(m)->PyConduit_DataType_TYPE);
+    #endif
     return 0;
 }
 
@@ -8224,6 +8252,9 @@ static int
 conduit_python_clear(PyObject *m)
 {
     Py_CLEAR(GETSTATE(m)->error);
+    #ifdef Py_LIMITED_API
+    Py_CLEAR(GETSTATE(m)->PyConduit_DataType_TYPE);
+    #endif
     return 0;
 }
 

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -9,6 +9,7 @@
 #include <Python.h>
 #include <structmember.h>
 #include "bytesobject.h"
+#include <string.h> // for strdup
 
 #if PY_MAJOR_VERSION >= 3
 #define IS_PY3K

--- a/src/libs/conduit/python/conduit_python.cpp
+++ b/src/libs/conduit/python/conduit_python.cpp
@@ -475,7 +475,12 @@ PyConduit_DataType_init(PyConduit_DataType* self,
 static void
 PyConduit_DataType_dealloc(PyConduit_DataType *self)
 {
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = ((freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free));
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 //---------------------------------------------------------------------------//
@@ -3268,7 +3273,12 @@ PyConduit_Generator_dealloc(PyConduit_Generator *self)
         delete self->generator;
     }
     
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = ((freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free));
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 
@@ -3583,7 +3593,12 @@ PyConduit_Schema_dealloc(PyConduit_Schema* self)
         delete self->schema;
     }
     
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = ((freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free));
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 //---------------------------------------------------------------------------//
@@ -4596,7 +4611,12 @@ PyConduit_NodeIterator_init(PyConduit_NodeIterator* self,
 static void
 PyConduit_NodeIterator_dealloc(PyConduit_NodeIterator *self)
 {
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = ((freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free));
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 //---------------------------------------------------------------------------//
@@ -5083,7 +5103,12 @@ PyConduit_Node_dealloc(PyConduit_Node* self)
        delete self->node;
     }
 
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = ((freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free));
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/libs/relay/python/CMakeLists.txt
+++ b/src/libs/relay/python/CMakeLists.txt
@@ -14,7 +14,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_python
                            FOLDER        libs/python)
 
 # link with the proper libs
-target_link_libraries(conduit_relay_python conduit conduit_relay)
+target_link_libraries(conduit_relay_python conduit conduit_relay conduit_python_build)
 
 # add relay io submodule
 PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_python
@@ -26,7 +26,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_python
 
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_relay_io_python conduit conduit_relay)
+target_link_libraries(conduit_relay_io_python conduit conduit_relay conduit_python_build)
 
 # add relay io blueprint submodule
 PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_blueprint_python
@@ -37,7 +37,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_blueprint_python
                            FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_relay_io_blueprint_python conduit conduit_relay conduit_blueprint)
+target_link_libraries(conduit_relay_io_blueprint_python conduit conduit_relay conduit_blueprint conduit_python_build)
 
 
 if(ENABLE_RELAY_WEBSERVER)
@@ -50,7 +50,7 @@ if(ENABLE_RELAY_WEBSERVER)
                                FOLDER        libs/python)
 
     # link with the proper libs (beyond python)
-    target_link_libraries(conduit_relay_web_python conduit conduit_relay)
+    target_link_libraries(conduit_relay_web_python conduit conduit_relay conduit_python_build)
 endif()
 
 ################################################################
@@ -68,7 +68,7 @@ if(MPI_FOUND)
                                FOLDER        libs/python)
 
     # link with the proper libs (beyond python)
-    target_link_libraries(conduit_relay_mpi_python conduit conduit_relay_mpi)
+    target_link_libraries(conduit_relay_mpi_python conduit conduit_relay_mpi conduit_python_build)
 
 endif()
 

--- a/src/libs/relay/python/conduit_relay_io_python.cpp
+++ b/src/libs/relay/python/conduit_relay_io_python.cpp
@@ -114,7 +114,7 @@ PyRelay_IOHandle_new(PyTypeObject *type,
                      PyObject*, // args -- unused
                      PyObject*) // kwds -- unused
 {
-    PyRelay_IOHandle *self = (PyRelay_IOHandle*)type->tp_alloc(type, 0);
+    PyRelay_IOHandle *self = (PyRelay_IOHandle*)PyType_GenericAlloc(type, 0);
 
     if (self)
     {

--- a/src/libs/relay/python/conduit_relay_io_python.cpp
+++ b/src/libs/relay/python/conduit_relay_io_python.cpp
@@ -132,8 +132,12 @@ PyRelay_IOHandle_dealloc(PyRelay_IOHandle *self)
     {
         delete self->handle;
     }
-    
+    #ifdef Py_LIMITED_API 
+    freefunc tp_free = (freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free);
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/libs/relay/python/conduit_relay_mpi_python.cpp
+++ b/src/libs/relay/python/conduit_relay_mpi_python.cpp
@@ -90,7 +90,7 @@ PyRelay_MPI_Request_new(PyTypeObject *type,
                         PyObject*, // args -- unused
                         PyObject*) // kwds -- unused
 {
-    PyRelay_MPI_Request *self = (PyRelay_MPI_Request*)type->tp_alloc(type, 0);
+    PyRelay_MPI_Request *self = (PyRelay_MPI_Request*)PyType_GenericAlloc(type, 0);
 
     return ((PyObject*)self);
 }

--- a/src/libs/relay/python/conduit_relay_mpi_python.cpp
+++ b/src/libs/relay/python/conduit_relay_mpi_python.cpp
@@ -1912,6 +1912,11 @@ static struct module_state _state;
 #endif
 //---------------------------------------------------------------------------//
 
+#ifdef Py_LIMITED_API
+// A pointer to the initialized module.
+PyObject* GLOBAL_MODULE = NULL;
+#endif
+
 //---------------------------------------------------------------------------//
 // Extra Module Setup Logic for Python3
 //---------------------------------------------------------------------------//
@@ -2023,6 +2028,10 @@ CONDUIT_RELAY_PYTHON_API void initconduit_relay_mpi_python(void)
     PyModule_AddObject(relay_mpi_module,
                        "Request",
                        (PyObject*)&PyRelay_MPI_Request_TYPE);
+
+#ifdef Py_LIMITED_API
+    GLOBAL_MODULE = relay_mpi_module;
+#endif
 
 #if defined(IS_PY3K)
     return relay_mpi_module;

--- a/src/libs/relay/python/conduit_relay_mpi_python.cpp
+++ b/src/libs/relay/python/conduit_relay_mpi_python.cpp
@@ -99,7 +99,12 @@ PyRelay_MPI_Request_new(PyTypeObject *type,
 static void
 PyRelay_MPI_Request_dealloc(PyRelay_MPI_Request *self)
 {
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = ((freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free));
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 //---------------------------------------------------------------------------//

--- a/src/libs/relay/python/conduit_relay_web_python.cpp
+++ b/src/libs/relay/python/conduit_relay_web_python.cpp
@@ -69,6 +69,34 @@ using namespace conduit::relay::web;
 #define PyVarObject_TAIL
 #endif
 
+//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+// Module Init Code
+//---------------------------------------------------------------------------//
+//---------------------------------------------------------------------------//
+
+struct module_state {
+    PyObject *error;
+    #ifdef Py_LIMITED_API
+    PyTypeObject* PyRelay_Web_WebServer_TYPE;
+    PyTypeObject* PyRelay_Web_WebSocket_TYPE;
+    #endif
+};
+
+//---------------------------------------------------------------------------//
+#if defined(IS_PY3K)
+#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
+#else
+#define GETSTATE(m) (&_state)
+static struct module_state _state;
+#endif
+
+#ifdef Py_LIMITED_API
+// A pointer to the initialized module.
+PyObject* GLOBAL_MODULE = NULL;
+#endif
+//---------------------------------------------------------------------------//
+
 
 //---------------------------------------------------------------------------//
 struct PyRelay_Web_WebServer
@@ -819,24 +847,6 @@ static PyMethodDef relay_web_python_funcs[] =
     {NULL, NULL, METH_VARARGS, NULL}
 };
 
-//---------------------------------------------------------------------------//
-//---------------------------------------------------------------------------//
-// Module Init Code
-//---------------------------------------------------------------------------//
-//---------------------------------------------------------------------------//
-
-struct module_state {
-    PyObject *error;
-};
-
-//---------------------------------------------------------------------------//
-#if defined(IS_PY3K)
-#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
-#else
-#define GETSTATE(m) (&_state)
-static struct module_state _state;
-#endif
-//---------------------------------------------------------------------------//
 
 //---------------------------------------------------------------------------//
 // Extra Module Setup Logic for Python3
@@ -950,6 +960,9 @@ CONDUIT_RELAY_PYTHON_API void initconduit_relay_web_python(void)
                        "WebServer",
                        (PyObject*)&PyRelay_Web_WebServer_TYPE);
 
+#ifdef Py_LIMITED_API
+  GLOBAL_MODULE = relay_web_module;
+#endif
 #if defined(IS_PY3K)
     return relay_web_module;
 #endif

--- a/src/libs/relay/python/conduit_relay_web_python.cpp
+++ b/src/libs/relay/python/conduit_relay_web_python.cpp
@@ -128,7 +128,12 @@ PyRelay_Web_WebServer_dealloc(PyRelay_Web_WebServer *self)
         delete self->webserver;
     }
     
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = (freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free);
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 
@@ -621,7 +626,12 @@ PyRelay_Web_WebSocket_dealloc(PyRelay_Web_WebSocket *self)
 {
     // cpp "socket" pointer is owned by the parent web server, no
     // need to clean them up from python
+    #ifdef Py_LIMITED_API
+    freefunc tp_free = (freefunc)PyType_GetSlot(Py_TYPE((PyObject*)self), Py_tp_free);
+    tp_free((PyObject*)self);
+    #else
     Py_TYPE(self)->tp_free((PyObject*)self);
+    #endif
 }
 
 

--- a/src/libs/relay/python/conduit_relay_web_python.cpp
+++ b/src/libs/relay/python/conduit_relay_web_python.cpp
@@ -109,7 +109,7 @@ PyRelay_Web_WebServer_new(PyTypeObject *type,
                           PyObject*, // args -- unused
                           PyObject*) // kwds -- unused
 {
-    PyRelay_Web_WebServer *self = (PyRelay_Web_WebServer*)type->tp_alloc(type, 0);
+    PyRelay_Web_WebServer *self = (PyRelay_Web_WebServer*)PyType_GenericAlloc(type, 0);
 
     if (self)
     {
@@ -605,7 +605,7 @@ PyRelay_Web_WebSocket_new(PyTypeObject *type,
                           PyObject*, // args -- unused
                           PyObject*) // kwds -- unused
 {
-    PyRelay_Web_WebSocket *self = (PyRelay_Web_WebSocket*)type->tp_alloc(type, 0);
+    PyRelay_Web_WebSocket *self = (PyRelay_Web_WebSocket*)PyType_GenericAlloc(type, 0);
 
     if (self)
     {
@@ -792,7 +792,7 @@ PyRelay_Web_WebSocket_python_wrap(WebSocket *websocket)
 {
     PyTypeObject *type = (PyTypeObject*)&PyRelay_Web_WebSocket_TYPE;
 
-    PyRelay_Web_WebSocket *retval = (PyRelay_Web_WebSocket*)type->tp_alloc(type, 0);
+    PyRelay_Web_WebSocket *retval = (PyRelay_Web_WebSocket*)PyType_GenericAlloc(type, 0);
     retval->websocket = websocket;
     return ((PyObject*)retval);
 }


### PR DESCRIPTION
This pull request enables [ABI3](https://docs.python.org/3/c-api/stable.html) compatibility for Python 3.11+  for the conduit python wrappings.

ABI3 compatibility allows to build a single library/wheel which can be used across multiple Python 3.x versions.

The  option is by default off . It can be enabled if the detected python version is >= 3.11 and the cmake option `CONDUIT_PYTHON_USE_LIMITED_API` is set to `ON`.

Python 3.11 was set as the minimum  version since the [`Py_Buffer`](https://docs.python.org/3/c-api/buffer.html)    object which is used by `PyConduit_Node_set_external` and `PyConduit_Node_set`  became part of the stable ABI only since 3.11. 


The changes are mainly of three types:
 - Replace  Python C-API calls with equivalent from the limited API e.g. `PyFloat_AS_DOUBLE` -> `PyFloat_AsDouble`
 - Make static `PyTypeObject` objects heap allocated. In the limited API `PyTypeObject`  objects are opaque pointers. They are created based on a `PyType_Spec` object using `PyType_FromModuleAndSpec` during the `init` phase of the module. e.g. https://github.com/LLNL/conduit/commit/60dd34e0a0ac09a047f110c4125389790a4fd6b6
 - Access `PyType` members through accessors instead of directly since this is also considered a opaque pointer e.g. 0ab6602edcc5986b05378f70a8d99d1ae46d99e9
 
Python tests pass locally on linux with the option enabled and using python 3.11.
Creating a wheel and testing against [abi3audit](https://github.com/trailofbits/abi3audit)  reports to no abi violations .

cc: @cyrush  @mathstuf 
 
