### PR TITLE
Convert adjset_validate point mesh to blueprint format.

### DIFF
--- a/src/executables/adjset_validate/adjset_validate.cpp
+++ b/src/executables/adjset_validate/adjset_validate.cpp
@@ -42,15 +42,19 @@ GetAdjsets(const conduit::Node &doms)
 
 //---------------------------------------------------------------------------
 /**
- @brief If the error information included coordinates then we write those to
-        a 3D points file for VisIt so we can look at where the invalid points
-        occur.
+ @brief If the error information included coordinates then we add a new
+        coordset+topo that includes where the failures occurred.
 
+ @param adjsetName The name of the current adjset.
  @param info A node that contains error messages about the adjset.
+ @param[out] n A node that will contain the new point mesh.
  */
 void
-writePoints(const conduit::Node &info)
+addPointMesh(const std::string &adjsetName, const conduit::Node &info, conduit::Node &n)
 {
+    std::vector<double> cx, cy, cz;
+    std::vector<int> domain, vertex, neighbor;
+
     for(conduit::index_t domainId = 0; domainId < info.number_of_children(); domainId++)
     {
         const conduit::Node &dom = info[domainId];
@@ -60,9 +64,6 @@ writePoints(const conduit::Node &info)
         {
             const conduit::Node &adjset = dom[adjsetId];
 
-            std::string filename(domainName + "_" + adjset.name() + ".3D");
-            FILE *fp = nullptr;
-
             for(conduit::index_t groupId = 0; groupId < adjset.number_of_children(); groupId++)
             {
                 const conduit::Node &group = adjset[groupId];
@@ -71,29 +72,56 @@ writePoints(const conduit::Node &info)
                     const conduit::Node &err = group[errId];
                     if(err.has_child("coordinate") && err.has_child("neighbor"))
                     {
-                        if(fp == nullptr)
-                        {
-                            fp = fopen(filename.c_str(), "wt");
-                            fprintf(fp, "x y z vertex\n");
-                        }
+                        auto da = err["coordinate"].as_double_accessor();
+                        cx.push_back(da[0]);
+                        cy.push_back(da[1]);
+                        cz.push_back(da[2]);
 
-                        if(fp != nullptr)
-                        {
-                            conduit::double_accessor da = err["coordinate"].as_double_accessor();
-                            int v = err["vertex"].to_int();
-                            //int v = err["neighbor"].to_int();
-                            fprintf(fp, "%lg %lg %lg %d\n", da[0], da[1], da[2], v);
-                        }
+                        domain.push_back(static_cast<int>(domainId));
+                        vertex.push_back(err["vertex"].to_int());
+                        neighbor.push_back(err["neighbor"].to_int());
                     }
                 }
             }
-
-            if(fp != nullptr)
-            {
-                fclose(fp);
-                std::cout << "Wrote " << filename << std::endl;
-            }
         }
+    }
+
+    // If we had some errors, we'll have coordinates. Add a new coordset+topo.
+    if(!cx.empty())
+    {
+        // Add coordset.
+        std::string coordsetName("coords_" + adjsetName);
+        conduit::Node &coordset = n["coordsets/" + coordsetName];
+        coordset["type"] = "explicit";
+        coordset["values/x"].set(cx);
+        coordset["values/y"].set(cy);
+        coordset["values/z"].set(cz);
+
+        // Add topo
+        std::string topoName(adjsetName);
+        conduit::Node &topo = n["topologies/" + topoName];
+        int npts = static_cast<int>(cx.size());
+        topo["coordset"] = coordsetName;
+        topo["type"] = "points";
+
+        // Add fields.
+        conduit::Node &fields = n["fields"];
+        conduit::Node &f1 = fields[adjsetName + "_domain"];
+        f1["topology"] = topoName;
+        f1["association"] = "vertex";
+        f1["values"].set(domain);
+
+        conduit::Node &f2 = fields[adjsetName + "_neighbor"];
+        f2["topology"] = topoName;
+        f2["association"] = "vertex";
+        f2["values"].set(neighbor);
+
+        conduit::Node &f3 = fields[adjsetName + "_vertex"];
+        f3["topology"] = topoName;
+        f3["association"] = "vertex";
+        f3["values"].set(vertex);
+
+        n["state/domain_id"] = 0;        
     }
 }
 
@@ -101,11 +129,13 @@ writePoints(const conduit::Node &info)
 void
 printUsage(const char *program)
 {
-    std::cout << "Usage: " << program << " -input filename [-help]" << std::endl;
+    std::cout << "Usage: " << program << " -input filename [-output filebase] [-protocol name] [-help]" << std::endl;
     std::cout << std::endl;
     std::cout << "Argument         Description" << std::endl;
     std::cout << "================ ============================================================" << std::endl;
     std::cout << "-input filename  Set the input filename." << std::endl;
+    std::cout << "-output filebase The base filename to use when outputting point mesh files." << std::endl;
+    std::cout << "-protocol name   The name of the Conduit protocol to use when writing point mesh files." << std::endl;
     std::cout << std::endl;
     std::cout << "-help            Print the usage and exit." << std::endl;
     std::cout << std::endl;
@@ -115,7 +145,22 @@ printUsage(const char *program)
 int
 main(int argc, char *argv[])
 {
-    std::string input;
+    std::string input, output("adjset_validate"), protocol;
+
+    // Set default protocol. Use HDF5 if present.
+    conduit::Node props;
+    conduit::relay::io::about(props);
+    if(props.has_path("protocols/hdf5"))
+    {
+        if(props["protocols/hdf5"].as_string() == "enabled")
+            protocol = "hdf5";
+    }
+    else
+    {
+        protocol = "yaml";
+    }
+
+    // Handle command line args.
     for(int i = 1; i < argc; i++)
     {
         if(strcmp(argv[i], "-help") == 0 || strcmp(argv[i], "-h") == 0)
@@ -126,6 +171,16 @@ main(int argc, char *argv[])
         else if(strcmp(argv[i], "-input") == 0 && (i+1) < argc)
         {
             input = argv[i+1];
+            i++;
+        }
+        else if(strcmp(argv[i], "-output") == 0 && (i+1) < argc)
+        {
+            output = argv[i+1];
+            i++;
+        }
+        else if(strcmp(argv[i], "-protocol") == 0 && (i+1) < argc)
+        {
+            protocol = argv[i+1];
             i++;
         }
     }
@@ -149,6 +204,7 @@ main(int argc, char *argv[])
         // Look through the adjsets to see if the points are all good.
         std::string msg2("Check adjset ");
         bool err = false;
+        conduit::Node pointMeshes;
         for(size_t i = 0; i < adjsets.size(); i++)
         {
             std::string adjsetName(adjsets[i]->name());
@@ -162,9 +218,14 @@ main(int argc, char *argv[])
             {
                 std::cout << msg2 << adjsetName << "... FAIL: The adjsets contain errors." << std::endl;
                 info.print();
-                writePoints(info);
+                addPointMesh(adjsetName, info, pointMeshes);
                 err = true;
             }
+        }
+        // Write any point meshes that were created.
+        if(pointMeshes.number_of_children() > 0)
+        {
+            conduit::relay::io::blueprint::save_mesh(pointMeshes, output, protocol);
         }
         if(err)
             return -2;

--- a/src/tests/blueprint/t_blueprint_mesh_utils.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_utils.cpp
@@ -180,3 +180,61 @@ TEST(conduit_blueprint_mesh_utils, adjset_validate_element_3d)
     EXPECT_EQ(c1["element"].to_int(), 2);
     EXPECT_EQ(c1["neighbor"].to_int(), 0);
 }
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_utils, adjset_validate_vertex_3d)
+{
+    conduit::Node root, info;
+    create_2_domain_3d_mesh(root, 0, 1);
+    // Add adjsets
+    conduit::Node &d0_adjset = root["domain0/adjsets/main_adjset"];
+    d0_adjset["association"] = "vertex";
+    d0_adjset["topology"] = "main";
+    conduit::Node &d0_01 = d0_adjset["groups/domain0_1"];
+    d0_01["neighbors"] = 1;
+    d0_01["values"].set(std::vector<int>{1,2,3,5,6,7,9,10,11,13,14,15});
+
+    conduit::Node &d1_adjset = root["domain1/adjsets/main_adjset"];
+    d1_adjset["association"] = "vertex";
+    d1_adjset["topology"] = "main";
+    conduit::Node &d1_01 = d1_adjset["groups/domain0_1"];
+    d1_01["neighbors"] = 0;
+    d1_01["values"].set(std::vector<int>{0,1,2,4,5,6,8,9,10,12,13,14});
+
+    EXPECT_TRUE(conduit::blueprint::mesh::adjset::verify(d0_adjset, info));
+    info.reset();
+    EXPECT_TRUE(conduit::blueprint::mesh::adjset::verify(d1_adjset, info));
+
+    save_mesh(root, "adjset_validate_vertex_3d");
+    bool res = conduit::blueprint::mesh::utils::adjset::validate(root, "main_adjset", info);
+    EXPECT_TRUE(res);
+
+    // Now, adjust the adjsets so they are wrong on both domains.
+    d0_01["values"].set(std::vector<int>{1,2,3,5,6,7,9,10,11,13,14,15,/*wrong*/0,4,8,12});
+    d1_01["values"].set(std::vector<int>{0,1,2,4,5,6,8,9,10,12,13,14,/*wrong*/3,7,11,15});
+    info.reset();
+    save_mesh(root, "adjset_validate_vertex_3d_bad");
+    res = conduit::blueprint::mesh::utils::adjset::validate(root, "main_adjset", info);
+    //info.print();
+    EXPECT_FALSE(res);
+
+    EXPECT_TRUE(info.has_path("domain0/main_adjset/domain0_1"));
+    const conduit::Node &n0 = info["domain0/main_adjset/domain0_1"];
+    EXPECT_EQ(n0.number_of_children(), 4);
+    const std::vector<int> d0err_vertex{0,4,8,12};
+    for(conduit::index_t i = 0; i < 4; i++)
+    {
+        EXPECT_EQ(n0[i]["neighbor"].to_int(), 1);
+        EXPECT_TRUE(std::find(d0err_vertex.begin(), d0err_vertex.end(), n0[i]["vertex"].to_int()) != d0err_vertex.end());
+    }
+
+    EXPECT_TRUE(info.has_path("domain1/main_adjset/domain0_1"));
+    const conduit::Node &n1 = info["domain1/main_adjset/domain0_1"];
+    EXPECT_EQ(n1.number_of_children(), 4);
+    const std::vector<int> d1err_vertex{3,7,11,15};
+    for(conduit::index_t i = 0; i < 4; i++)
+    {
+        EXPECT_EQ(n1[i]["neighbor"].to_int(), 0);
+        EXPECT_TRUE(std::find(d1err_vertex.begin(), d1err_vertex.end(), n1[i]["vertex"].to_int()) != d1err_vertex.end());
+    }
+}


### PR DESCRIPTION
This PR includes 2 things:

1. It tests adjset::validate on a vertex adjset (mainly so I could make a file for testing)
2. It converts conduit_adjset_validate point mesh output to Blueprint format. This lets us store more fields too.