### PR TITLE
Added destination_ranks property to field selection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added `topology::search` function that allows one topology to be searched for in another topology. The topologies must have the same shape type and their respective coordsets can have points in different orders. The shapes are matched using coordinate matching.
 - Added `adjset::validate` function which tests adjacency sets for correctness and flags any errors in a Conduit node. There are serial and parallel versions of the function. The functions apply PointQuery for vertex association adjsets and MatchQuery for element association adjsets. Each domain's adjset will make queries to its neighboring domains as to whether the vertex or element of interest exists in the neighbor's topology.
 - Added `utils::kdtree` class that can be used to accelerate point lookups for coordsets.
+- Field selections for the `conduit::blueprint::mesh::partition()` function support a new `destination_ranks` property that contains a list of integers that map domain numbers to MPI ranks. This property tells the partitioner the ranks where it should place each domain. If the property is not supplied, the partitioner is free to place domains as before.
 
 ### Fixed
 

--- a/src/docs/sphinx/blueprint_mesh_partition.rst
+++ b/src/docs/sphinx/blueprint_mesh_partition.rst
@@ -184,8 +184,8 @@ operate on the specified topology only.
 |                  |                                         |                                          |
 +------------------+-----------------------------------------+------------------------------------------+
 | topology         | The topology to which the selection     | .. code:: yaml                           |
-|                  | will apply.                             |                                          |
-|                  |                                         |    selections:                           |
+|                  | will apply. This is important if the    |                                          |
+|                  | data contain multiple topologies.       |    selections:                           |
 |                  |                                         |      -                                   |
 |                  |                                         |       type: logical                      |
 |                  |                                         |       domain_id: 10                      |
@@ -248,6 +248,28 @@ can be set to "any" if it is desired that the field selection will be applied to
 all domains in the input mesh. The domain_id value can still be set to specific
 integer values to limit the set of domains over which the selection will be applied.
 
++------------------+-----------------------------------------+------------------------------------------+
+| **Option**       | **Description**                         | **Example**                              |
++------------------+-----------------------------------------+------------------------------------------+
+| field            | The name of the element field that will | .. code:: yaml                           |
+|                  | be used for partitioning. The field     |                                          |
+|                  | shall contain non-negative domain       |    selections:                           |
+|                  | numbers.                                |      -                                   |
+|                  |                                         |       type: field                        |
+|                  |                                         |       domain_id: any                     |
+|                  |                                         |                                          |
++------------------+-----------------------------------------+------------------------------------------+
+| destination_ranks| An optional list of integers            | .. code:: yaml                           |
+|                  | representing the MPI rank where the     |                                          |
+|                  | domain will be sent after partitioning. |    selections:                           |
+|                  | This option can help ensure domains for |      -                                   |
+|                  | topologies partitioned via multiple     |       type: field                        |
+|                  | calls to partition() end up together on |       field: partField                   |
+|                  | a target MPI rank. The example shows    |       destination_ranks: [0,1,2,3]       |
+|                  | domain 0 going to MPI rank 0 and so on. |       domain_id: any                     |
+|                  |                                         |                                          |
++------------------+-----------------------------------------+------------------------------------------+
+
 .. code:: yaml
 
   selections:
@@ -255,3 +277,4 @@ integer values to limit the set of domains over which the selection will be appl
      type: field
      domain_id: any
      field: fieldname
+     topology: main


### PR DESCRIPTION
This PR adds a `destination_ranks` property to field selections for the partitioner. This is optional. When present, we can use the property to indicate a preference for how the partitioner maps partitioned domains to MPI ranks. This comes in handy when we make multiple calls to partition()  (once for volume mesh and again for boundaries) and we need the different topologies to end up on the same MPI rank.

```
sel1["type"] = "field";
sel1["domain_id"] = "any";
sel1["field"] = "partitionField";
sel1["topology"] = "main";
// Domain 0 goes to MPI rank 0, 1->1, 2->2, 3->3.
sel1["destination_ranks"].set(std::vector<int>{0,1,2,3});
```