### PR TITLE
Do not require multiple domains adjset::validate in parallel.

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2028,9 +2028,10 @@ adjset::validate(const conduit::Node &doms,
         coordsetName = to_string(topo["coordset"]);
     }
 
+    const bool checkMultiDomain = true;
     return adjset::validate(doms,
                             adjsetName, association, topologyName, coordsetName,
-                            info, PQ, MQ);
+                            info, PQ, MQ, checkMultiDomain);
 }
 
 //---------------------------------------------------------------------------
@@ -2042,12 +2043,14 @@ adjset::validate(const conduit::Node &doms,
                  const std::string &coordsetName,
                  conduit::Node &info,
                  query::PointQuery &PQ,
-                 query::MatchQuery &MQ)
+                 query::MatchQuery &MQ,
+                 bool checkMultiDomain)
 {
     bool retval = false;
 
-    // Make sure that there are multiple domains.
-    if(!conduit::blueprint::mesh::is_multi_domain(doms))
+    // Make sure that there are multiple domains. Note that we do this
+    // test in serial but not parallel.
+    if(checkMultiDomain && !conduit::blueprint::mesh::is_multi_domain(doms))
     {
         info["errors"].append().set("The dataset is not multidomain.");
         return retval;

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -796,6 +796,10 @@ namespace adjset
      @param[out] info A node that contains any errors.
      @param PQ The PointQuery that will handle vertex association queries.
      @param MQ The MatchQuery that will handle element association queries.
+     @param checkMultiDomain Whether we want to check that an input blueprint
+                             contains multiple domains or not. For parallel,
+                             we do not want to check this since each rank may
+                             have a single domain locally.
 
      @note The association, topologyName, and coordsetName are passed in so
            the routine does not have to figure them out. In parallel, the
@@ -812,7 +816,8 @@ namespace adjset
                                         const std::string &coordsetName,
                                         conduit::Node &info,
                                         query::PointQuery &PQ,
-                                        query::MatchQuery &MQ);
+                                        query::MatchQuery &MQ,
+                                        bool checkMultiDomain);
 }
 //-----------------------------------------------------------------------------
 // -- end conduit::blueprint::mesh::utils::adjset --

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
@@ -565,18 +565,9 @@ adjset::validate(const Node &doms,
         return globalval == size;
     };
 
-    // Make sure that there are multiple domains.
     bool retval = false;
-    bool md = conduit::blueprint::mesh::is_multi_domain(doms);
-    // Make sure all ranks agree on the answer.
-    md = agree(md, comm);
-    if(!md)
-    {
-        info["errors"].append().set("The dataset is not multidomain.");
-        return retval;
-    }
 
-    // Decide whether all ranks have data.
+    // Get the domains.
     auto domains = conduit::blueprint::mesh::domains(doms);
 
     // We need to figure out the association, topologyName, and coordsetName.
@@ -634,9 +625,10 @@ adjset::validate(const Node &doms,
     conduit::blueprint::mpi::mesh::utils::query::MatchQuery MQ(doms, comm);
 
     // Do the validation.
+    const bool checkMultiDomain = false;
     retval = conduit::blueprint::mesh::utils::adjset::validate(doms,
                  adjsetName, association, topologyName, coordsetName,
-                 info, PQ, MQ);
+                 info, PQ, MQ, checkMultiDomain);
 
     // Make sure all ranks agree on the answer.
     retval = agree(retval, comm);


### PR DESCRIPTION
This PR corrects a mistake I made in `conduit::blueprint::mpi::mesh::utils::adjset::validate()` where it required the input mesh to contain multiple domains. This isn't right in parallel since we may just have a single domain mesh on each MPI rank. The serial and parallel versions of the function use the same base function with different queries ( serial vs parallel) so I added another argument to that function to indicate whether we should check for multiple domains.