### PR TITLE
Clean up templating in generate sides code

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -4999,7 +4999,7 @@ namespace detail
                      const int dimensions,
                      const int new_num_shapes, // number of new triangles or tetrahedrons
                      const int num_orig_shapes, // number of original polygons or polyhedra
-                     int_accessor tri_to_poly,
+                     int64_accessor tri_to_poly,
                      Node &volumes_info,
                      Node &volumes_field_values)
     {
@@ -5007,9 +5007,9 @@ namespace detail
         volumes_field_values.set(conduit::DataType::float64(new_num_shapes));
         float64_array tri_volumes = volumes_field_values.value();
 
-        int_accessor connec = topo_dest["elements/connectivity"].value();
-        float_accessor coords_x = coordset_dest["values/x"].value();
-        float_accessor coords_y = coordset_dest["values/y"].value();
+        int64_accessor connec = topo_dest["elements/connectivity"].value();
+        float64_accessor coords_x = coordset_dest["values/x"].value();
+        float64_accessor coords_y = coordset_dest["values/y"].value();
 
         if (dimensions == 2)
         {
@@ -5027,7 +5027,7 @@ namespace detail
         }
         else if (dimensions == 3)
         {
-            float_accessor coords_z = coordset_dest["values/z"].value();
+            float64_accessor coords_z = coordset_dest["values/z"].value();
 
             for (int i = 0; i < new_num_shapes; i ++)
             {
@@ -5078,7 +5078,7 @@ namespace detail
     template<typename T> // T is the type of the new field values
     void
     vertex_associated_field(const Node &topo_dest,
-                            float_accessor poly_field_data,
+                            float64_accessor poly_field_data,
                             int orig_num_points,
                             int new_num_points,
                             int dimensions,
@@ -5097,7 +5097,7 @@ namespace detail
         std::map<int, std::set<int>> info;
 
         int iter = dimensions == 2 ? 3 : 4;
-        int_accessor new_connec = topo_dest["elements/connectivity"].value();
+        int64_accessor new_connec = topo_dest["elements/connectivity"].value();
         int length_of_connec = topo_dest["elements/connectivity"].dtype().number_of_elements();
 
         // iterate thru the connectivity array, going in groups of 3 or 4,
@@ -5170,7 +5170,7 @@ namespace detail
     map_field_to_generated_sides(Node &field_out,
                                  const Node &field_src,
                                  int new_num_shapes,
-                                 int_accessor tri_to_poly,
+                                 int64_accessor tri_to_poly,
                                  float64 *volume_ratio,
                                  bool vol_dep,
                                  bool vert_assoc,
@@ -5183,7 +5183,7 @@ namespace detail
         T *values_array = field_out["values"].value();
 
         // a pointer to the original field values
-        float_accessor poly_field_data = field_src["values"].value();
+        float64_accessor poly_field_data = field_src["values"].value();
 
         // if our field is vertex associated
         if (vert_assoc)
@@ -5256,7 +5256,7 @@ namespace detail
             CONDUIT_ERROR(((std::string) "Bad shape in ").append(topo_dest["elements/shape"].as_string()));
         }
 
-        int_accessor tri_to_poly = d2smap["values"].value();
+        int64_accessor tri_to_poly = d2smap["values"].value();
 
         // set up original elements id field
         Node &original_elements = fields_dest[field_prefix + "original_element_ids"];

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -5075,20 +5075,20 @@ namespace detail
         }
     }
 
-    template<typename U> // U is the type of the new field values
+    template<typename T> // T is the type of the new field values
     void
     vertex_associated_field(const Node &topo_dest,
                             float_accessor poly_field_data,
                             int orig_num_points,
                             int new_num_points,
                             int dimensions,
-                            U *values_array)
+                            T *values_array)
     {
         // copy field values from the original field over to the
         // points that are in both the old and new topologies
         for (int i = 0; i < orig_num_points; i ++)
         {
-            values_array[i] = static_cast<U>(poly_field_data[i]);
+            values_array[i] = static_cast<T>(poly_field_data[i]);
         }
 
         // this map will record for each new point (represented by
@@ -5155,17 +5155,17 @@ namespace detail
                 // the size of the set, since there are neighbors which
                 // may go unused, since they are not from the original
                 // coordset
-                values_array[i] = static_cast<U>(sum / num_neighbors);
+                values_array[i] = static_cast<T>(sum / num_neighbors);
             }
             // if the points go unused in the topology, we assign them 0
             else
             {
-                values_array[i] = static_cast<U>(0.0);
+                values_array[i] = static_cast<T>(0.0);
             }
         }
     }
 
-    template<typename U> // U is the type of the new field values
+    template<typename T> // T is the type of the new field values
     void
     map_field_to_generated_sides(Node &field_out,
                                  const Node &field_src,
@@ -5180,7 +5180,7 @@ namespace detail
                                  const Node &topo_dest)
     {
         // a pointer to the destination for field values
-        U *values_array = field_out["values"].value();
+        T *values_array = field_out["values"].value();
 
         // a pointer to the original field values
         float_accessor poly_field_data = field_src["values"].value();
@@ -5188,7 +5188,7 @@ namespace detail
         // if our field is vertex associated
         if (vert_assoc)
         {
-            vertex_associated_field<U>(topo_dest,
+            vertex_associated_field<T>(topo_dest,
                                        poly_field_data,
                                        orig_num_points,
                                        new_num_points,
@@ -5208,11 +5208,11 @@ namespace detail
                 // if our field is volume dependent
                 if (vol_dep)
                 {
-                    values_array[i] = static_cast<U>(poly_field_data[tri_to_poly[i]] * volume_ratio[i]);
+                    values_array[i] = static_cast<T>(poly_field_data[tri_to_poly[i]] * volume_ratio[i]);
                 }
                 else
                 {
-                    values_array[i] = static_cast<U>(poly_field_data[tri_to_poly[i]]);
+                    values_array[i] = static_cast<T>(poly_field_data[tri_to_poly[i]]);
                 }
             }
         }

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -4990,10 +4990,9 @@ namespace detail
         return fabs((a - d).dot((b - d).cross(c - d))) / 6.0f;
     }
 
-    // T is the type of 'tri_to_poly' values
     // U is the type of connectivity values
     // V is the type of coordset values
-    template<typename T, typename U, typename V>
+    template<typename U, typename V>
     void
     // we want access to the new topology so we can calculate the areas
     // of the new triangles/volumes of the new tetrahedra
@@ -5002,7 +5001,7 @@ namespace detail
                             const int dimensions,
                             const int new_num_shapes, // number of new triangles or tetrahedrons
                             const int num_orig_shapes, // number of original polygons or polyhedra
-                            const T *tri_to_poly,
+                            int_accessor tri_to_poly,
                             Node &volumes_info,
                             Node &volumes_field_values)
     {
@@ -5077,9 +5076,8 @@ namespace detail
         }
     }
 
-    // T is the type of 'tri_to_poly' values
     // U is the type of connectivity values
-    template<typename T, typename U>
+    template<typename U>
     // determines the type of the coordinate values and calls
     // volume_dependent_helper to do the work
     void
@@ -5088,75 +5086,75 @@ namespace detail
                      const int dimensions,
                      const int new_num_shapes, // number of new triangles or tetrahedrons
                      const int num_orig_shapes, // number of original polygons or polyhedra
-                     const T *tri_to_poly,
+                     int_accessor tri_to_poly,
                      Node &volumes_info,
                      Node &volumes_field_values)
     {
         if (coordset_dest["values/x"].dtype().is_uint64())
         {
-            volume_dependent_helper<T, U, uint64>(topo_dest,
-                                                  coordset_dest,
-                                                  dimensions,
-                                                  new_num_shapes,
-                                                  num_orig_shapes,
-                                                  tri_to_poly,
-                                                  volumes_info,
-                                                  volumes_field_values);
+            volume_dependent_helper<U, uint64>(topo_dest,
+                                               coordset_dest,
+                                               dimensions,
+                                               new_num_shapes,
+                                               num_orig_shapes,
+                                               tri_to_poly,
+                                               volumes_info,
+                                               volumes_field_values);
         }
         else if (coordset_dest["values/x"].dtype().is_uint32())
         {
-            volume_dependent_helper<T, U, uint32>(topo_dest,
-                                                  coordset_dest,
-                                                  dimensions,
-                                                  new_num_shapes,
-                                                  num_orig_shapes,
-                                                  tri_to_poly,
-                                                  volumes_info,
-                                                  volumes_field_values);
+            volume_dependent_helper<U, uint32>(topo_dest,
+                                               coordset_dest,
+                                               dimensions,
+                                               new_num_shapes,
+                                               num_orig_shapes,
+                                               tri_to_poly,
+                                               volumes_info,
+                                               volumes_field_values);
         }
         else if (coordset_dest["values/x"].dtype().is_int64())
         {
-            volume_dependent_helper<T, U, int64>(topo_dest,
-                                                 coordset_dest,
-                                                 dimensions,
-                                                 new_num_shapes,
-                                                 num_orig_shapes,
-                                                 tri_to_poly,
-                                                 volumes_info,
-                                                 volumes_field_values);
+            volume_dependent_helper<U, int64>(topo_dest,
+                                              coordset_dest,
+                                              dimensions,
+                                              new_num_shapes,
+                                              num_orig_shapes,
+                                              tri_to_poly,
+                                              volumes_info,
+                                              volumes_field_values);
         }
         else if (coordset_dest["values/x"].dtype().is_int32())
         {
-            volume_dependent_helper<T, U, int32>(topo_dest,
-                                                 coordset_dest,
-                                                 dimensions,
-                                                 new_num_shapes,
-                                                 num_orig_shapes,
-                                                 tri_to_poly,
-                                                 volumes_info,
-                                                 volumes_field_values);
+            volume_dependent_helper<U, int32>(topo_dest,
+                                              coordset_dest,
+                                              dimensions,
+                                              new_num_shapes,
+                                              num_orig_shapes,
+                                              tri_to_poly,
+                                              volumes_info,
+                                              volumes_field_values);
         }
         else if (coordset_dest["values/x"].dtype().is_float64())
         {
-            volume_dependent_helper<T, U, float64>(topo_dest,
-                                                   coordset_dest,
-                                                   dimensions,
-                                                   new_num_shapes,
-                                                   num_orig_shapes,
-                                                   tri_to_poly,
-                                                   volumes_info,
-                                                   volumes_field_values);
+            volume_dependent_helper<U, float64>(topo_dest,
+                                                coordset_dest,
+                                                dimensions,
+                                                new_num_shapes,
+                                                num_orig_shapes,
+                                                tri_to_poly,
+                                                volumes_info,
+                                                volumes_field_values);
         }
         else if (coordset_dest["values/x"].dtype().is_float32())
         {
-            volume_dependent_helper<T, U, float32>(topo_dest,
-                                                   coordset_dest,
-                                                   dimensions,
-                                                   new_num_shapes,
-                                                   num_orig_shapes,
-                                                   tri_to_poly,
-                                                   volumes_info,
-                                                   volumes_field_values);
+            volume_dependent_helper<U, float32>(topo_dest,
+                                                coordset_dest,
+                                                dimensions,
+                                                new_num_shapes,
+                                                num_orig_shapes,
+                                                tri_to_poly,
+                                                volumes_info,
+                                                volumes_field_values);
         }
         else
         {
@@ -5258,14 +5256,13 @@ namespace detail
         }
     }
 
-    template<typename T, // T is the type of 'tri_to_poly' values
-             typename U, // U is the type of the new field values (should typically be the same as V)
+    template<typename U, // U is the type of the new field values (should typically be the same as V)
              typename V> // V is the type of the old field values (should typically be the same as U)
     void
     map_field_to_generated_sides(Node &field_out,
                                  const Node &field_src,
                                  int new_num_shapes,
-                                 const T *tri_to_poly,
+                                 int_accessor tri_to_poly,
                                  float64 *volume_ratio,
                                  bool vol_dep,
                                  bool vert_assoc,
@@ -5347,8 +5344,6 @@ namespace detail
         }
     }
 
-    // T is the type of 'tri_to_poly' values
-    template<typename T>
     void
     map_fields_to_generated_sides(const Node &topo_src,
                                   const Node &coordset_src,
@@ -5387,7 +5382,7 @@ namespace detail
             CONDUIT_ERROR(((std::string) "Bad shape in ").append(topo_dest["elements/shape"].as_string()));
         }
 
-        const T *tri_to_poly = d2smap["values"].value();
+        int_accessor tri_to_poly = d2smap["values"].value();
 
         // set up original elements id field
         Node &original_elements = fields_dest[field_prefix + "original_element_ids"];
@@ -5503,47 +5498,47 @@ namespace detail
                     // get the volumes and ratio
                     if (topo_dest["elements/connectivity"].dtype().is_uint64())
                     {
-                        volume_dependent<T, uint64>(topo_dest,
-                                                    coordset_dest,
-                                                    dimensions,
-                                                    new_num_shapes,
-                                                    num_orig_shapes,
-                                                    tri_to_poly,
-                                                    volumes_info,
-                                                    volumes_field["values"]);
+                        volume_dependent<uint64>(topo_dest,
+                                                 coordset_dest,
+                                                 dimensions,
+                                                 new_num_shapes,
+                                                 num_orig_shapes,
+                                                 tri_to_poly,
+                                                 volumes_info,
+                                                 volumes_field["values"]);
                     }
                     else if (topo_dest["elements/connectivity"].dtype().is_uint32())
                     {
-                        volume_dependent<T, uint32>(topo_dest,
-                                                    coordset_dest,
-                                                    dimensions,
-                                                    new_num_shapes,
-                                                    num_orig_shapes,
-                                                    tri_to_poly,
-                                                    volumes_info,
-                                                    volumes_field["values"]);
+                        volume_dependent<uint32>(topo_dest,
+                                                 coordset_dest,
+                                                 dimensions,
+                                                 new_num_shapes,
+                                                 num_orig_shapes,
+                                                 tri_to_poly,
+                                                 volumes_info,
+                                                 volumes_field["values"]);
                     }
                     else if (topo_dest["elements/connectivity"].dtype().is_int64())
                     {
-                        volume_dependent<T, int64>(topo_dest,
-                                                   coordset_dest,
-                                                   dimensions,
-                                                   new_num_shapes,
-                                                   num_orig_shapes,
-                                                   tri_to_poly,
-                                                   volumes_info,
-                                                   volumes_field["values"]);
+                        volume_dependent<int64>(topo_dest,
+                                                coordset_dest,
+                                                dimensions,
+                                                new_num_shapes,
+                                                num_orig_shapes,
+                                                tri_to_poly,
+                                                volumes_info,
+                                                volumes_field["values"]);
                     }
                     else if (topo_dest["elements/connectivity"].dtype().is_int32())
                     {
-                        volume_dependent<T, int32>(topo_dest,
-                                                   coordset_dest,
-                                                   dimensions,
-                                                   new_num_shapes,
-                                                   num_orig_shapes,
-                                                   tri_to_poly,
-                                                   volumes_info,
-                                                   volumes_field["values"]);
+                        volume_dependent<int32>(topo_dest,
+                                                coordset_dest,
+                                                dimensions,
+                                                new_num_shapes,
+                                                num_orig_shapes,
+                                                tri_to_poly,
+                                                volumes_info,
+                                                volumes_field["values"]);
                     }
                     else
                     {
@@ -5559,32 +5554,32 @@ namespace detail
                     if (vol_dep || vert_assoc)
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, uint64>(field_out,
-                                                                         field,
-                                                                         new_num_shapes,
-                                                                         tri_to_poly,
-                                                                         volume_ratio,
-                                                                         vol_dep,
-                                                                         vert_assoc,
-                                                                         orig_num_points,
-                                                                         new_num_points,
-                                                                         dimensions,
-                                                                         topo_dest);
+                        map_field_to_generated_sides<float64, uint64>(field_out,
+                                                                      field,
+                                                                      new_num_shapes,
+                                                                      tri_to_poly,
+                                                                      volume_ratio,
+                                                                      vol_dep,
+                                                                      vert_assoc,
+                                                                      orig_num_points,
+                                                                      new_num_points,
+                                                                      dimensions,
+                                                                      topo_dest);
                     }
                     else
                     {
                         field_out["values"].set(conduit::DataType::uint64(field_out_size));
-                        map_field_to_generated_sides<T, uint64, uint64>(field_out,
-                                                                        field,
-                                                                        new_num_shapes,
-                                                                        tri_to_poly,
-                                                                        volume_ratio,
-                                                                        vol_dep,
-                                                                        vert_assoc,
-                                                                        orig_num_points,
-                                                                        new_num_points,
-                                                                        dimensions,
-                                                                        topo_dest);
+                        map_field_to_generated_sides<uint64, uint64>(field_out,
+                                                                     field,
+                                                                     new_num_shapes,
+                                                                     tri_to_poly,
+                                                                     volume_ratio,
+                                                                     vol_dep,
+                                                                     vert_assoc,
+                                                                     orig_num_points,
+                                                                     new_num_points,
+                                                                     dimensions,
+                                                                     topo_dest);
                     }
                 }
                 else if (field["values"].dtype().is_uint32())
@@ -5592,32 +5587,32 @@ namespace detail
                     if (vol_dep || vert_assoc)
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, uint32>(field_out,
-                                                                         field,
-                                                                         new_num_shapes,
-                                                                         tri_to_poly,
-                                                                         volume_ratio,
-                                                                         vol_dep,
-                                                                         vert_assoc,
-                                                                         orig_num_points,
-                                                                         new_num_points,
-                                                                         dimensions,
-                                                                         topo_dest);
+                        map_field_to_generated_sides<float64, uint32>(field_out,
+                                                                      field,
+                                                                      new_num_shapes,
+                                                                      tri_to_poly,
+                                                                      volume_ratio,
+                                                                      vol_dep,
+                                                                      vert_assoc,
+                                                                      orig_num_points,
+                                                                      new_num_points,
+                                                                      dimensions,
+                                                                      topo_dest);
                     }
                     else
                     {
                         field_out["values"].set(conduit::DataType::uint32(field_out_size));
-                        map_field_to_generated_sides<T, uint32, uint32>(field_out,
-                                                                        field,
-                                                                        new_num_shapes,
-                                                                        tri_to_poly,
-                                                                        volume_ratio,
-                                                                        vol_dep,
-                                                                        vert_assoc,
-                                                                        orig_num_points,
-                                                                        new_num_points,
-                                                                        dimensions,
-                                                                        topo_dest);
+                        map_field_to_generated_sides<uint32, uint32>(field_out,
+                                                                     field,
+                                                                     new_num_shapes,
+                                                                     tri_to_poly,
+                                                                     volume_ratio,
+                                                                     vol_dep,
+                                                                     vert_assoc,
+                                                                     orig_num_points,
+                                                                     new_num_points,
+                                                                     dimensions,
+                                                                     topo_dest);
                     }
                 }
                 else if (field["values"].dtype().is_int64())
@@ -5625,32 +5620,32 @@ namespace detail
                     if (vol_dep || vert_assoc)
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, int64>(field_out,
-                                                                        field,
-                                                                        new_num_shapes,
-                                                                        tri_to_poly,
-                                                                        volume_ratio,
-                                                                        vol_dep,
-                                                                        vert_assoc,
-                                                                        orig_num_points,
-                                                                        new_num_points,
-                                                                        dimensions,
-                                                                        topo_dest);
+                        map_field_to_generated_sides<float64, int64>(field_out,
+                                                                     field,
+                                                                     new_num_shapes,
+                                                                     tri_to_poly,
+                                                                     volume_ratio,
+                                                                     vol_dep,
+                                                                     vert_assoc,
+                                                                     orig_num_points,
+                                                                     new_num_points,
+                                                                     dimensions,
+                                                                     topo_dest);
                     }
                     else
                     {
                         field_out["values"].set(conduit::DataType::int64(field_out_size));
-                        map_field_to_generated_sides<T, int64, int64>(field_out,
-                                                                      field,
-                                                                      new_num_shapes,
-                                                                      tri_to_poly,
-                                                                      volume_ratio,
-                                                                      vol_dep,
-                                                                      vert_assoc,
-                                                                      orig_num_points,
-                                                                      new_num_points,
-                                                                      dimensions,
-                                                                      topo_dest);
+                        map_field_to_generated_sides<int64, int64>(field_out,
+                                                                   field,
+                                                                   new_num_shapes,
+                                                                   tri_to_poly,
+                                                                   volume_ratio,
+                                                                   vol_dep,
+                                                                   vert_assoc,
+                                                                   orig_num_points,
+                                                                   new_num_points,
+                                                                   dimensions,
+                                                                   topo_dest);
                     }
                 }
                 else if (field["values"].dtype().is_int32())
@@ -5658,32 +5653,32 @@ namespace detail
                     if (vol_dep || vert_assoc)
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, int32>(field_out,
-                                                                        field,
-                                                                        new_num_shapes,
-                                                                        tri_to_poly,
-                                                                        volume_ratio,
-                                                                        vol_dep,
-                                                                        vert_assoc,
-                                                                        orig_num_points,
-                                                                        new_num_points,
-                                                                        dimensions,
-                                                                        topo_dest);
+                        map_field_to_generated_sides<float64, int32>(field_out,
+                                                                     field,
+                                                                     new_num_shapes,
+                                                                     tri_to_poly,
+                                                                     volume_ratio,
+                                                                     vol_dep,
+                                                                     vert_assoc,
+                                                                     orig_num_points,
+                                                                     new_num_points,
+                                                                     dimensions,
+                                                                     topo_dest);
                     }
                     else
                     {
                         field_out["values"].set(conduit::DataType::int32(field_out_size));
-                        map_field_to_generated_sides<T, int32, int32>(field_out,
-                                                                      field,
-                                                                      new_num_shapes,
-                                                                      tri_to_poly,
-                                                                      volume_ratio,
-                                                                      vol_dep,
-                                                                      vert_assoc,
-                                                                      orig_num_points,
-                                                                      new_num_points,
-                                                                      dimensions,
-                                                                      topo_dest);
+                        map_field_to_generated_sides<int32, int32>(field_out,
+                                                                   field,
+                                                                   new_num_shapes,
+                                                                   tri_to_poly,
+                                                                   volume_ratio,
+                                                                   vol_dep,
+                                                                   vert_assoc,
+                                                                   orig_num_points,
+                                                                   new_num_points,
+                                                                   dimensions,
+                                                                   topo_dest);
                     }
                 }
                 else if (field["values"].dtype().is_float64())
@@ -5691,32 +5686,32 @@ namespace detail
                     if (vol_dep || vert_assoc)
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, float64>(field_out,
-                                                                          field,
-                                                                          new_num_shapes,
-                                                                          tri_to_poly,
-                                                                          volume_ratio,
-                                                                          vol_dep,
-                                                                          vert_assoc,
-                                                                          orig_num_points,
-                                                                          new_num_points,
-                                                                          dimensions,
-                                                                          topo_dest);
+                        map_field_to_generated_sides<float64, float64>(field_out,
+                                                                       field,
+                                                                       new_num_shapes,
+                                                                       tri_to_poly,
+                                                                       volume_ratio,
+                                                                       vol_dep,
+                                                                       vert_assoc,
+                                                                       orig_num_points,
+                                                                       new_num_points,
+                                                                       dimensions,
+                                                                       topo_dest);
                     }
                     else
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, float64>(field_out,
-                                                                          field,
-                                                                          new_num_shapes,
-                                                                          tri_to_poly,
-                                                                          volume_ratio,
-                                                                          vol_dep,
-                                                                          vert_assoc,
-                                                                          orig_num_points,
-                                                                          new_num_points,
-                                                                          dimensions,
-                                                                          topo_dest);
+                        map_field_to_generated_sides<float64, float64>(field_out,
+                                                                       field,
+                                                                       new_num_shapes,
+                                                                       tri_to_poly,
+                                                                       volume_ratio,
+                                                                       vol_dep,
+                                                                       vert_assoc,
+                                                                       orig_num_points,
+                                                                       new_num_points,
+                                                                       dimensions,
+                                                                       topo_dest);
                     }
                 }
                 else if (field["values"].dtype().is_float32())
@@ -5724,32 +5719,32 @@ namespace detail
                     if (vol_dep || vert_assoc)
                     {
                         field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<T, float64, float32>(field_out,
-                                                                          field,
-                                                                          new_num_shapes,
-                                                                          tri_to_poly,
-                                                                          volume_ratio,
-                                                                          vol_dep,
-                                                                          vert_assoc,
-                                                                          orig_num_points,
-                                                                          new_num_points,
-                                                                          dimensions,
-                                                                          topo_dest);
+                        map_field_to_generated_sides<float64, float32>(field_out,
+                                                                       field,
+                                                                       new_num_shapes,
+                                                                       tri_to_poly,
+                                                                       volume_ratio,
+                                                                       vol_dep,
+                                                                       vert_assoc,
+                                                                       orig_num_points,
+                                                                       new_num_points,
+                                                                       dimensions,
+                                                                       topo_dest);
                     }
                     else
                     {
                         field_out["values"].set(conduit::DataType::float32(field_out_size));
-                        map_field_to_generated_sides<T, float32, float32>(field_out,
-                                                                          field,
-                                                                          new_num_shapes,
-                                                                          tri_to_poly,
-                                                                          volume_ratio,
-                                                                          vol_dep,
-                                                                          vert_assoc,
-                                                                          orig_num_points,
-                                                                          new_num_points,
-                                                                          dimensions,
-                                                                          topo_dest);
+                        map_field_to_generated_sides<float32, float32>(field_out,
+                                                                       field,
+                                                                       new_num_shapes,
+                                                                       tri_to_poly,
+                                                                       volume_ratio,
+                                                                       vol_dep,
+                                                                       vert_assoc,
+                                                                       orig_num_points,
+                                                                       new_num_points,
+                                                                       dimensions,
+                                                                       topo_dest);
                     }
                 }
                 else
@@ -5851,58 +5846,15 @@ mesh::topology::unstructured::generate_sides(const conduit::Node &topo_src,
     generate_sides(topo_src, topo_dest, coordset_dest, s2dmap, d2smap);
 
     // now map fields
-    if (d2smap["values"].dtype().is_uint64())
-    {
-        detail::map_fields_to_generated_sides<uint64>(topo_src,
-                                                      coordset_src,
-                                                      fields_src,
-                                                      d2smap,
-                                                      topo_dest,
-                                                      coordset_dest,
-                                                      fields_dest,
-                                                      field_names,
-                                                      field_prefix);
-    }
-    else if (d2smap["values"].dtype().is_uint32())
-    {
-        detail::map_fields_to_generated_sides<uint32>(topo_src,
-                                                      coordset_src,
-                                                      fields_src,
-                                                      d2smap,
-                                                      topo_dest,
-                                                      coordset_dest,
-                                                      fields_dest,
-                                                      field_names,
-                                                      field_prefix);
-    }
-    else if (d2smap["values"].dtype().is_int64())
-    {
-        detail::map_fields_to_generated_sides<int64>(topo_src,
-                                                     coordset_src,
-                                                     fields_src,
-                                                     d2smap,
-                                                     topo_dest,
-                                                     coordset_dest,
-                                                     fields_dest,
-                                                     field_names,
-                                                     field_prefix);
-    }
-    else if (d2smap["values"].dtype().is_int32())
-    {
-        detail::map_fields_to_generated_sides<int32>(topo_src,
-                                                     coordset_src,
-                                                     fields_src,
-                                                     d2smap,
-                                                     topo_dest,
-                                                     coordset_dest,
-                                                     fields_dest,
-                                                     field_names,
-                                                     field_prefix);
-    }
-    else
-    {
-        CONDUIT_ERROR("Unsupported field type in " << d2smap["values"].dtype().to_yaml());
-    }
+    detail::map_fields_to_generated_sides(topo_src,
+                                          coordset_src,
+                                          fields_src,
+                                          d2smap,
+                                          topo_dest,
+                                          coordset_dest,
+                                          fields_dest,
+                                          field_names,
+                                          field_prefix);
 }
 
 // this variant of the function same as generate sides and map fields

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -5171,7 +5171,7 @@ namespace detail
                                  const Node &field_src,
                                  int new_num_shapes,
                                  int64_accessor tri_to_poly,
-                                 float64 *volume_ratio,
+                                 float64_accessor volume_ratio,
                                  bool vol_dep,
                                  bool vert_assoc,
                                  int orig_num_points,
@@ -5239,7 +5239,7 @@ namespace detail
         int num_orig_shapes = topo_src["elements/sizes"].dtype().number_of_elements(); // the number of original polygons or polyhedra
         Node volumes_info; // a container for the volumes of old shapes and the ratio between new and old volumes for each new shape
         bool volumes_calculated = false; // so we only calculate the volumes once as we go through the while loop
-        float64 *volume_ratio = NULL; // a pointer to the ratio between new and old volumes for each new shape
+        float64_accessor volume_ratio; // a float64 accessor to the ratio between new and old volumes for each new shape
 
         if (topo_dest["elements/shape"].as_string() == "tet")
         {

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -5075,11 +5075,10 @@ namespace detail
         }
     }
 
-    template<typename U, // U is the type of the new field values (should typically be the same as V)
-             typename V> // V is the type of the old field values (should typically be the same as U)
+    template<typename U> // U is the type of the new field values
     void
     vertex_associated_field(const Node &topo_dest,
-                            const V *poly_field_data,
+                            float_accessor poly_field_data,
                             int orig_num_points,
                             int new_num_points,
                             int dimensions,
@@ -5166,8 +5165,7 @@ namespace detail
         }
     }
 
-    template<typename U, // U is the type of the new field values (should typically be the same as V)
-             typename V> // V is the type of the old field values (should typically be the same as U)
+    template<typename U> // U is the type of the new field values
     void
     map_field_to_generated_sides(Node &field_out,
                                  const Node &field_src,
@@ -5185,17 +5183,17 @@ namespace detail
         U *values_array = field_out["values"].value();
 
         // a pointer to the original field values
-        const V *poly_field_data = field_src["values"].value();
+        float_accessor poly_field_data = field_src["values"].value();
 
         // if our field is vertex associated
         if (vert_assoc)
         {
-            vertex_associated_field<U, V>(topo_dest,
-                                          poly_field_data,
-                                          orig_num_points,
-                                          new_num_points,
-                                          dimensions,
-                                          values_array);
+            vertex_associated_field<U>(topo_dest,
+                                       poly_field_data,
+                                       orig_num_points,
+                                       new_num_points,
+                                       dimensions,
+                                       values_array);
         }
         else
         {
@@ -5384,207 +5382,123 @@ namespace detail
                 }
 
                 int field_out_size = vert_assoc ? new_num_points : new_num_shapes;
-                if (field["values"].dtype().is_uint64())
+
+                // If we are volume dependent or vertex associated, we do not care what 
+                // the original type of the fields was. We are going to make brand new 
+                // fields that have type float64.
+                if (vol_dep || vert_assoc)
                 {
-                    if (vol_dep || vert_assoc)
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, uint64>(field_out,
-                                                                      field,
-                                                                      new_num_shapes,
-                                                                      tri_to_poly,
-                                                                      volume_ratio,
-                                                                      vol_dep,
-                                                                      vert_assoc,
-                                                                      orig_num_points,
-                                                                      new_num_points,
-                                                                      dimensions,
-                                                                      topo_dest);
-                    }
-                    else
-                    {
-                        field_out["values"].set(conduit::DataType::uint64(field_out_size));
-                        map_field_to_generated_sides<uint64, uint64>(field_out,
-                                                                     field,
-                                                                     new_num_shapes,
-                                                                     tri_to_poly,
-                                                                     volume_ratio,
-                                                                     vol_dep,
-                                                                     vert_assoc,
-                                                                     orig_num_points,
-                                                                     new_num_points,
-                                                                     dimensions,
-                                                                     topo_dest);
-                    }
+                    field_out["values"].set(conduit::DataType::float64(field_out_size));
+                    map_field_to_generated_sides<float64>(field_out,
+                                                          field,
+                                                          new_num_shapes,
+                                                          tri_to_poly,
+                                                          volume_ratio,
+                                                          vol_dep,
+                                                          vert_assoc,
+                                                          orig_num_points,
+                                                          new_num_points,
+                                                          dimensions,
+                                                          topo_dest);
                 }
-                else if (field["values"].dtype().is_uint32())
-                {
-                    if (vol_dep || vert_assoc)
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, uint32>(field_out,
-                                                                      field,
-                                                                      new_num_shapes,
-                                                                      tri_to_poly,
-                                                                      volume_ratio,
-                                                                      vol_dep,
-                                                                      vert_assoc,
-                                                                      orig_num_points,
-                                                                      new_num_points,
-                                                                      dimensions,
-                                                                      topo_dest);
-                    }
-                    else
-                    {
-                        field_out["values"].set(conduit::DataType::uint32(field_out_size));
-                        map_field_to_generated_sides<uint32, uint32>(field_out,
-                                                                     field,
-                                                                     new_num_shapes,
-                                                                     tri_to_poly,
-                                                                     volume_ratio,
-                                                                     vol_dep,
-                                                                     vert_assoc,
-                                                                     orig_num_points,
-                                                                     new_num_points,
-                                                                     dimensions,
-                                                                     topo_dest);
-                    }
-                }
-                else if (field["values"].dtype().is_int64())
-                {
-                    if (vol_dep || vert_assoc)
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, int64>(field_out,
-                                                                     field,
-                                                                     new_num_shapes,
-                                                                     tri_to_poly,
-                                                                     volume_ratio,
-                                                                     vol_dep,
-                                                                     vert_assoc,
-                                                                     orig_num_points,
-                                                                     new_num_points,
-                                                                     dimensions,
-                                                                     topo_dest);
-                    }
-                    else
-                    {
-                        field_out["values"].set(conduit::DataType::int64(field_out_size));
-                        map_field_to_generated_sides<int64, int64>(field_out,
-                                                                   field,
-                                                                   new_num_shapes,
-                                                                   tri_to_poly,
-                                                                   volume_ratio,
-                                                                   vol_dep,
-                                                                   vert_assoc,
-                                                                   orig_num_points,
-                                                                   new_num_points,
-                                                                   dimensions,
-                                                                   topo_dest);
-                    }
-                }
-                else if (field["values"].dtype().is_int32())
-                {
-                    if (vol_dep || vert_assoc)
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, int32>(field_out,
-                                                                     field,
-                                                                     new_num_shapes,
-                                                                     tri_to_poly,
-                                                                     volume_ratio,
-                                                                     vol_dep,
-                                                                     vert_assoc,
-                                                                     orig_num_points,
-                                                                     new_num_points,
-                                                                     dimensions,
-                                                                     topo_dest);
-                    }
-                    else
-                    {
-                        field_out["values"].set(conduit::DataType::int32(field_out_size));
-                        map_field_to_generated_sides<int32, int32>(field_out,
-                                                                   field,
-                                                                   new_num_shapes,
-                                                                   tri_to_poly,
-                                                                   volume_ratio,
-                                                                   vol_dep,
-                                                                   vert_assoc,
-                                                                   orig_num_points,
-                                                                   new_num_points,
-                                                                   dimensions,
-                                                                   topo_dest);
-                    }
-                }
-                else if (field["values"].dtype().is_float64())
-                {
-                    if (vol_dep || vert_assoc)
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, float64>(field_out,
-                                                                       field,
-                                                                       new_num_shapes,
-                                                                       tri_to_poly,
-                                                                       volume_ratio,
-                                                                       vol_dep,
-                                                                       vert_assoc,
-                                                                       orig_num_points,
-                                                                       new_num_points,
-                                                                       dimensions,
-                                                                       topo_dest);
-                    }
-                    else
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, float64>(field_out,
-                                                                       field,
-                                                                       new_num_shapes,
-                                                                       tri_to_poly,
-                                                                       volume_ratio,
-                                                                       vol_dep,
-                                                                       vert_assoc,
-                                                                       orig_num_points,
-                                                                       new_num_points,
-                                                                       dimensions,
-                                                                       topo_dest);
-                    }
-                }
-                else if (field["values"].dtype().is_float32())
-                {
-                    if (vol_dep || vert_assoc)
-                    {
-                        field_out["values"].set(conduit::DataType::float64(field_out_size));
-                        map_field_to_generated_sides<float64, float32>(field_out,
-                                                                       field,
-                                                                       new_num_shapes,
-                                                                       tri_to_poly,
-                                                                       volume_ratio,
-                                                                       vol_dep,
-                                                                       vert_assoc,
-                                                                       orig_num_points,
-                                                                       new_num_points,
-                                                                       dimensions,
-                                                                       topo_dest);
-                    }
-                    else
-                    {
-                        field_out["values"].set(conduit::DataType::float32(field_out_size));
-                        map_field_to_generated_sides<float32, float32>(field_out,
-                                                                       field,
-                                                                       new_num_shapes,
-                                                                       tri_to_poly,
-                                                                       volume_ratio,
-                                                                       vol_dep,
-                                                                       vert_assoc,
-                                                                       orig_num_points,
-                                                                       new_num_points,
-                                                                       dimensions,
-                                                                       topo_dest);
-                    }
-                }
+                // If we are neither volume dependent nor vertex associated, we can go
+                // ahead and honor the original field type.
                 else
                 {
-                    CONDUIT_ERROR("Unsupported field type in " << field["values"].dtype().to_yaml());
+                    if (field["values"].dtype().is_uint64())
+                    {
+                        field_out["values"].set(conduit::DataType::uint64(field_out_size));
+                        map_field_to_generated_sides<uint64>(field_out,
+                                                             field,
+                                                             new_num_shapes,
+                                                             tri_to_poly,
+                                                             volume_ratio,
+                                                             vol_dep,
+                                                             vert_assoc,
+                                                             orig_num_points,
+                                                             new_num_points,
+                                                             dimensions,
+                                                             topo_dest);
+                    }
+                    else if (field["values"].dtype().is_uint32())
+                    {
+                        field_out["values"].set(conduit::DataType::uint32(field_out_size));
+                        map_field_to_generated_sides<uint32>(field_out,
+                                                             field,
+                                                             new_num_shapes,
+                                                             tri_to_poly,
+                                                             volume_ratio,
+                                                             vol_dep,
+                                                             vert_assoc,
+                                                             orig_num_points,
+                                                             new_num_points,
+                                                             dimensions,
+                                                             topo_dest);
+                    }
+                    else if (field["values"].dtype().is_int64())
+                    {
+                        field_out["values"].set(conduit::DataType::int64(field_out_size));
+                        map_field_to_generated_sides<int64>(field_out,
+                                                            field,
+                                                            new_num_shapes,
+                                                            tri_to_poly,
+                                                            volume_ratio,
+                                                            vol_dep,
+                                                            vert_assoc,
+                                                            orig_num_points,
+                                                            new_num_points,
+                                                            dimensions,
+                                                            topo_dest);
+                    }
+                    else if (field["values"].dtype().is_int32())
+                    {
+                        field_out["values"].set(conduit::DataType::int32(field_out_size));
+                        map_field_to_generated_sides<int32>(field_out,
+                                                            field,
+                                                            new_num_shapes,
+                                                            tri_to_poly,
+                                                            volume_ratio,
+                                                            vol_dep,
+                                                            vert_assoc,
+                                                            orig_num_points,
+                                                            new_num_points,
+                                                            dimensions,
+                                                            topo_dest);
+                    }
+                    else if (field["values"].dtype().is_float64())
+                    {
+                        field_out["values"].set(conduit::DataType::float64(field_out_size));
+                        map_field_to_generated_sides<float64>(field_out,
+                                                              field,
+                                                              new_num_shapes,
+                                                              tri_to_poly,
+                                                              volume_ratio,
+                                                              vol_dep,
+                                                              vert_assoc,
+                                                              orig_num_points,
+                                                              new_num_points,
+                                                              dimensions,
+                                                              topo_dest);
+                    }
+                    else if (field["values"].dtype().is_float32())
+                    {
+                        field_out["values"].set(conduit::DataType::float32(field_out_size));
+                        map_field_to_generated_sides<float32>(field_out,
+                                                              field,
+                                                              new_num_shapes,
+                                                              tri_to_poly,
+                                                              volume_ratio,
+                                                              vol_dep,
+                                                              vert_assoc,
+                                                              orig_num_points,
+                                                              new_num_points,
+                                                              dimensions,
+                                                              topo_dest);
+                    }
+                    else
+                    {
+                        CONDUIT_ERROR("Unsupported field type in " << field["values"].dtype().to_yaml());
+                    }
                 }
 
                 if (vol_dep)

--- a/src/libs/conduit/conduit_data_accessor.cpp
+++ b/src/libs/conduit/conduit_data_accessor.cpp
@@ -155,6 +155,19 @@ DataAccessor<T>::count(T val) const
 
 //---------------------------------------------------------------------------//
 template <typename T> 
+DataAccessor<T> &
+DataAccessor<T>::operator=(const DataAccessor<T> &accessor)
+{
+    if(this != &accessor)
+    {
+        m_data  = accessor.m_data;
+        m_dtype = accessor.m_dtype;
+    }
+    return *this;
+}
+
+//---------------------------------------------------------------------------//
+template <typename T> 
 T
 DataAccessor<T>::element(index_t idx) const
 {

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -70,6 +70,9 @@ public:
     /// counts number of occurrences of given value
     index_t         count(T value) const;
 
+    /// Assignment operator
+    DataAccessor<T>   &operator=(const DataAccessor<T> &accessor);
+
 //-----------------------------------------------------------------------------
 // Data and Info Access
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1105

Now that we have data accessors and data arrays, a lot of the templating in the generate sides code was able to be removed/simplified.

Also adds the assignment operator to the data accessor.

The tests all pass.