### PR TITLE
Add a clear error message that parmetis requires mpi

### DIFF
--- a/src/cmake/Setup3rdParty.cmake
+++ b/src/cmake/Setup3rdParty.cmake
@@ -162,6 +162,9 @@ endif()
 # Setup Parmetis if available
 ################################
 if(PARMETIS_DIR)
+    if(NOT ENABLE_MPI)
+        message(FATAL_ERROR "PARMETIS_DIR is set while ENABLE_MPI is OFF. Parmetis support requires MPI.")
+    endif()
     include(cmake/thirdparty/SetupParmetis.cmake)
     include_directories(${PARMETIS_INCLUDE_DIR})
     # if we don't find it, throw a fatal error


### PR DESCRIPTION
Ran into this by accident but this state shouldn't be allowed.

The following: 
```
cmake -DPARMETIS_DIR=/some/path/that/doesnt/matter -DENABLE_MPI=OFF ../src/
```

Now produces:
```
CMake Error at cmake/Setup3rdParty.cmake:166 (message):
  PARMETIS_DIR is set while ENABLE_MPI is OFF.  Parmetis support requires
  MPI.
Call Stack (most recent call first):
  CMakeLists.txt:84 (include)


-- Configuring incomplete, errors occurred!
```

Without this you get the following:

```
src/tests/thirdparty/t_parmetis_smoke.cpp:11:10: fatal error: 'mpi.h' file not found
#include <mpi.h>
     ^~~~~~~
1 error generated.
```