### PR TITLE
Fix a narrowing conversion

### DIFF
--- a/src/libs/relay/conduit_relay_io_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_io_hdf5.cpp
@@ -728,7 +728,7 @@ hdf5_dtype_to_conduit_dtype(hid_t hdf5_dtype_id,
                             index_t num_elems,
                             const std::string& ref_path)
 {
-    hsize_t num_elems_array[1] = { num_elems };
+    hsize_t num_elems_array[1] = { static_cast<hsize_t>(num_elems) };
     return hdf5_dtype_to_conduit_dtype(hdf5_dtype_id, num_elems_array, 1, ref_path);
 }
 


### PR DESCRIPTION
It looks like #1129 introduced a narrowing conversion:
```
src/libs/relay/conduit_relay_io_hdf5.cpp:731:36: error: non-constant-expression cannot be narrowed from type 'index_t' (aka 'long') to 'hsize_t' (aka 'unsigned long long') in initializer list [-Wc++11-narrowing]
    hsize_t num_elems_array[1] = { num_elems };
                                   ^~~~~~~~~
```
I avoid this with an explicit `static_cast` -- I assumed that one cannot have a negative number of elements.
