### PR TITLE
Make partitioner better about outputting material_map node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### Blueprint
 - The `conduit::blueprint::mesh::partition()` function no longer issues an error when it receives a "maxshare" adjset.
+- The partitioner is better about outputting a "material_map" node for matsets. The "material_map" node is optional for some varieties of matset but they can also help the `conduit::blueprint::mesh::matset::to_silo()` function generate the right material numbers when a domain does not contain all materials.
 
 ## [0.8.8] - Released 2023-05-18
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -9337,6 +9337,16 @@ combine(const std::vector<Node> &inputs,
         out_matset["volume_fractions"][name].set(volume_fractions);
         out_matset["element_ids"][name].set(element_ids);
     }
+
+    // If the material_map does not exist, add it since it supplies the entire
+    // list of materials, which can be important when a domain does not have
+    // all materials.
+    if(!out_matset.has_child("material_map") && !material_map.empty())
+    {
+        Node &mm = out_matset["material_map"];
+        for(auto it = material_map.begin(); it != material_map.end(); it++)
+            mm[it->second] = it->first;
+    }
 }
 
 }

--- a/src/tests/blueprint/baselines/t_blueprint_mesh_partition/venn_uni_by_element_combined.yaml
+++ b/src/tests/blueprint/baselines/t_blueprint_mesh_partition/venn_uni_by_element_combined.yaml
@@ -24,6 +24,11 @@ matsets:
       circle_a: [9, 13, 10, 14]
       circle_b: [10, 11, 14, 15]
       circle_c: [5, 9, 6, 7, 10, 11]
+    material_map: 
+      background: 0
+      circle_a: 1
+      circle_b: 2
+      circle_c: 3
 fields: 
   original_vertex_ids: 
     topology: "topo"

--- a/src/tests/blueprint/baselines/t_blueprint_mesh_partition/venn_uni_by_material_combined.yaml
+++ b/src/tests/blueprint/baselines/t_blueprint_mesh_partition/venn_uni_by_material_combined.yaml
@@ -24,6 +24,11 @@ matsets:
       circle_a: [9, 13, 10, 14]
       circle_b: [10, 11, 14, 15]
       circle_c: [5, 9, 6, 7, 10, 11]
+    material_map: 
+      background: 0
+      circle_a: 1
+      circle_b: 2
+      circle_c: 3
 fields: 
   original_vertex_ids: 
     topology: "topo"


### PR DESCRIPTION
I changed the partitioner so it outputs a material_map node in a matset definition, even if it is not strictly necessary for the matset variant. For material-dominant matsets, they might only define a subset of materials out of the possible total set of materials for all domains. This causes to_silo() to start numbering materials from 0 and we end up with an incorrect picture. By including the material_map, the to_silo() routine knows the set of all materials and it can number correctly.

This resolves #1155.

![partitioned_matset_fix](https://github.com/LLNL/conduit/assets/2072964/3cb77669-3392-4ec1-9947-d0350f2186ea)

NOTE: I could see VisIt passing the blueprint index material_map to to_silo() just in case domains did not have material_map.
