### PR TITLE
add support for conduit_json_external protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 ### Added
 
+#### General
+- Added `conduit_json_external` protocol. Creates a json schema representation of a node that includes all addresses that the node is pointing to. Parsing this schema will create a node equivalent to `set_external()`.
+
 #### Relay
 - Added ability to read N-dimensional hyperslabs from HDF5 leaf arrays into linear memory arrays.
+
+### Changed
+
+#### General
+- Improved the efficiency of json parsing logic.
 
 ### Fixed
 

--- a/src/libs/conduit/conduit_generator.cpp
+++ b/src/libs/conduit/conduit_generator.cpp
@@ -1390,6 +1390,7 @@ Generator::Parser::JSON::walk_json_schema(Node   *node,
                 {
                     if(data != NULL)
                     {
+                        uint8 *src_data_ptr = ((uint8*)data) + src_dtype.offset();
                         // node is already linked to the schema pointer
                         // we need to dynamically alloc, use compact dtype
                         node->set(des_dtype); // causes an init
@@ -1398,7 +1399,7 @@ Generator::Parser::JSON::walk_json_schema(Node   *node,
                                                                des_dtype.number_of_elements(), // num ele
                                                                des_dtype.element_bytes(),      // ele bytes
                                                                des_dtype.stride(),             // dest stride
-                                                               data,                           // src data
+                                                               src_data_ptr,                   // src data
                                                                src_dtype.stride());            // src stride
                     }
                     else

--- a/src/libs/conduit/conduit_generator.cpp
+++ b/src/libs/conduit/conduit_generator.cpp
@@ -1003,20 +1003,18 @@ Generator::Parser::JSON::parse_inline_address(const conduit_rapidjson::Value &jv
 {
     void * res = nullptr;
     if(jvalue.IsString())
-    {   
-        char *str_end = nullptr;
+    {
         std::string sval(jvalue.GetString());
-        unsigned long long ull_addy = strtoull(sval.c_str(),&str_end,0);
-        res = (void*)ull_addy;
+        res = utils::hex_string_to_value<void*>(sval);
     }
     // else if(jvalue.IsNumber())
     // {
-    //     // TODO ...
+    //     // TODO: FUTURE? ...
     // }
     else
     {
          CONDUIT_ERROR("JSON Generator error:\n"
-                              << "inline address should be a string or integer");
+                              << "inline address should be a string");
     }
     return res;
 }

--- a/src/libs/conduit/conduit_generator.cpp
+++ b/src/libs/conduit/conduit_generator.cpp
@@ -2484,8 +2484,11 @@ Generator::walk(Node &node) const
             Parser::JSON::parse_base64(&node,
                                     document);
         }
-        else if( m_protocol == "conduit_json")
+
+        else if( m_protocol == "conduit_json" || m_protocol == "conduit_json_external")
         {
+            // Note: conduit_json_external if case here for symmetry with gen / read options
+            // this case is fully handled by conduit_json logic
             conduit_rapidjson::Document document;
             std::string res = utils::json_sanitize(m_schema);
             
@@ -2559,8 +2562,10 @@ Generator::walk_external(Node &node) const
             Parser::JSON::parse_base64(&node,
                                     document);
         }
-        else if( m_protocol == "conduit_json")
+        else if( m_protocol == "conduit_json" || m_protocol == "conduit_json_external")
         {
+            // Note: conduit_json_external if case here for symmetry with gen / read options
+            // this case is fully handled by conduit_json logic
             conduit_rapidjson::Document document;
             std::string res = utils::json_sanitize(m_schema);
             

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -13583,7 +13583,7 @@ Node::to_json_generic(std::ostream &os,
 
         if(address)
         {
-            os << "\"address\": \"0x" << utils::to_hex_string(m_data) << "\"";
+            os << "\"address\": \"" << utils::to_hex_string(m_data) << "\"";
         }
         else
         {
@@ -18209,7 +18209,7 @@ Node::info(Node &res, const std::string &curr_path) const
 
     if(m_data != NULL)
     {
-        std::string ptr_key = std::string("0x") + utils::to_hex_string(m_data);
+        std::string ptr_key = utils::to_hex_string(m_data);
 
         if(!res["mem_spaces"].has_path(ptr_key))
         {

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -13584,7 +13584,7 @@ Node::to_json_generic(std::ostream &os,
 
         if(address)
         {
-            os << "\"address\": \"" << utils::to_hex_string(m_data) << "\"";
+            os << "\"address\": \"0x" << utils::to_hex_string(m_data) << "\"";
         }
         else
         {
@@ -18210,7 +18210,7 @@ Node::info(Node &res, const std::string &curr_path) const
 
     if(m_data != NULL)
     {
-        std::string ptr_key = utils::to_hex_string(m_data);
+        std::string ptr_key = std::string("0x") + utils::to_hex_string(m_data);
 
         if(!res["mem_spaces"].has_path(ptr_key))
         {

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -186,15 +186,14 @@ Node::Node(const Schema &schema,
            bool external)
 {
     init_defaults();
-    std::string json_schema =schema.to_json();
-    Generator g(json_schema,"conduit_json",data);
+
     if(external)
     {
-        g.walk_external(*this);
+        set_external(schema,data);
     }
     else
     {
-        g.walk(*this);
+        set(schema,data);
     }
 }
 

--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -4576,12 +4576,14 @@ private:
     // the generic to_json methods are used by the specialized cases
     //-------------------------------------------------------------------------
     std::string         to_json_generic(bool detailed,
+                                        bool address,
                                         index_t indent=2,
                                         index_t depth=0,
                                         const std::string &pad=" ",
                                         const std::string &eoe="\n") const;
 
     void                to_json_generic(const std::string &stream_path,
+                                        bool address,
                                         bool detailed,
                                         index_t indent=2,
                                         index_t depth=0,
@@ -4590,6 +4592,7 @@ private:
 
     void                to_json_generic(std::ostream &os,
                                         bool detailed,
+                                        bool address,
                                         index_t indent=2,
                                         index_t depth=0,
                                         const std::string &pad=" ",
@@ -4634,6 +4637,26 @@ private:
                                       index_t depth=0,
                                       const std::string &pad=" ",
                                       const std::string &eoe="\n") const;
+
+    //-------------------------------------------------------------------------
+    // transforms the node to detailed json with address entry
+    //-------------------------------------------------------------------------
+    std::string      to_detailed_json_external(index_t indent=2,
+                                               index_t depth=0,
+                                               const std::string &pad=" ",
+                                               const std::string &eoe="\n") const;
+
+    void             to_detailed_json_external(const std::string &stream_path,
+                                               index_t indent=2,
+                                               index_t depth=0,
+                                               const std::string &pad=" ",
+                                               const std::string &eoe="\n") const;
+
+    void             to_detailed_json_external(std::ostream &os,
+                                               index_t indent=2,
+                                               index_t depth=0,
+                                               const std::string &pad=" ",
+                                               const std::string &eoe="\n") const;
 
     //-------------------------------------------------------------------------
     // transforms the node to json with data payload encoded using base64

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -526,13 +526,16 @@ namespace utils
         // note: 
         // std::stringstream w/ std::hex seems to not prepend 0x on windows,
         // but does on linux and macOS
-        // so this does not work:
         //
-        // std::stringstream oss;
-        // oss << "0x" << std::hex << value;
-        //
-        // use fmt instead b/c we can explicilty ask for 0x with "#x"
-        return conduit_fmt::format("{:#x}",value);
+        // Note: Also tried to use fmt with "#x"
+        // but this caused a compile disaster for windows CI cases
+        std::stringstream oss;
+#if defined(CONDUIT_PLATFORM_WINDOWS)
+        oss << "0x" << std::hex << value;
+#else
+        oss << std::hex << value;
+#endif
+        return oss.str();
      }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -532,7 +532,7 @@ namespace utils
 #if defined(CONDUIT_PLATFORM_WINDOWS)
         oss << "0x" << std::hex << value;
 #else
-        oss << std::hex << value;
+        oss << "0x" << std::hex << value;
 #endif
         return oss.str();
      }

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -522,18 +522,8 @@ namespace utils
      template< typename T >
      std::string to_hex_string(T value)
      {
-        // Note: 
-        // std::stringstream w/ std::hex seems to not prepend 0x on windows,
-        // but does on linux and macOS, so we have custom logic for windows.
-        //
-        // I also tried to use fmt with "#x", but this caused a compile
-        // disaster for windows CI cases
         std::stringstream oss;
-#if defined(CONDUIT_PLATFORM_WINDOWS)
-        oss << "0x" << std::hex << value;
-#else
-        oss << "0x" << std::hex << value;
-#endif
+        oss << std::hex << value;
         return oss.str();
      }
 
@@ -576,7 +566,7 @@ namespace utils
         T res;
         std::istringstream iss(s);
         iss >> res;
-        return  res;
+        return res;
     }
 
     // declare then define to avoid icc warnings
@@ -586,9 +576,10 @@ namespace utils
     template< typename T >
     T hex_string_to_value(const std::string &s)
     {
-        char *str_end = nullptr;
-        unsigned long long ull_value = strtoull(s.c_str(),&str_end,0);
-        return (T)(ull_value);
+        T res;
+        std::istringstream iss(s);
+        iss >> std::hex >> res;
+        return res;
     }
 
 

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -20,6 +20,7 @@
 #include <iomanip>
 #include <sstream>
 #include <chrono>
+#include <cstdlib>
 
 //-----------------------------------------------------------------------------
 // -- conduit includes --
@@ -522,7 +523,7 @@ namespace utils
      std::string to_hex_string(T value)
      {
            std::stringstream oss;
-           oss << std::hex << value;
+           oss << "0x" << std::hex << value;
            return  oss.str();
      }
 
@@ -566,6 +567,18 @@ namespace utils
         std::istringstream iss(s);
         iss >> res;
         return  res;
+    }
+
+    // declare then define to avoid icc warnings
+    template< typename T >
+    T hex_string_to_value(const std::string &s);
+
+    template< typename T >
+    T hex_string_to_value(const std::string &s)
+    {
+        char *str_end = nullptr;
+        unsigned long long ull_value = strtoull(s.c_str(),&str_end,0);
+        return (T)(ull_value);
     }
 
 

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -26,7 +26,6 @@
 // -- conduit includes --
 //-----------------------------------------------------------------------------
 #include "conduit_core.hpp"
-#include "conduit_fmt/conduit_fmt.h"
 
 //-----------------------------------------------------------------------------
 //
@@ -523,12 +522,12 @@ namespace utils
      template< typename T >
      std::string to_hex_string(T value)
      {
-        // note: 
+        // Note: 
         // std::stringstream w/ std::hex seems to not prepend 0x on windows,
-        // but does on linux and macOS
+        // but does on linux and macOS, so we have custom logic for windows.
         //
-        // Note: Also tried to use fmt with "#x"
-        // but this caused a compile disaster for windows CI cases
+        // I also tried to use fmt with "#x", but this caused a compile
+        // disaster for windows CI cases
         std::stringstream oss;
 #if defined(CONDUIT_PLATFORM_WINDOWS)
         oss << "0x" << std::hex << value;

--- a/src/libs/conduit/conduit_utils.hpp
+++ b/src/libs/conduit/conduit_utils.hpp
@@ -26,6 +26,7 @@
 // -- conduit includes --
 //-----------------------------------------------------------------------------
 #include "conduit_core.hpp"
+#include "conduit_fmt/conduit_fmt.h"
 
 //-----------------------------------------------------------------------------
 //
@@ -522,9 +523,16 @@ namespace utils
      template< typename T >
      std::string to_hex_string(T value)
      {
-           std::stringstream oss;
-           oss << "0x" << std::hex << value;
-           return  oss.str();
+        // note: 
+        // std::stringstream w/ std::hex seems to not prepend 0x on windows,
+        // but does on linux and macOS
+        // so this does not work:
+        //
+        // std::stringstream oss;
+        // oss << "0x" << std::hex << value;
+        //
+        // use fmt instead b/c we can explicilty ask for 0x with "#x"
+        return conduit_fmt::format("{:#x}",value);
      }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -240,7 +240,6 @@ void silo_read(DBfile *dbfile,
     char *data   = new char[data_len];
 
 
-
     DBReadVar(dbfile, src_json.c_str(), schema);
     DBReadVar(dbfile, src_data.c_str(), data);
 

--- a/src/tests/conduit/t_conduit_generator.cpp
+++ b/src/tests/conduit/t_conduit_generator.cpp
@@ -451,8 +451,6 @@ TEST(conduit_generator, simple_gen_schema_yaml)
 
 }
 
-
-
 //-----------------------------------------------------------------------------
 TEST(conduit_generator, yaml_parsing_errors)
 {
@@ -466,7 +464,6 @@ TEST(conduit_generator, yaml_parsing_errors)
 }
 
 
-
 //-----------------------------------------------------------------------------
 TEST(conduit_generator, json_external_gen)
 {
@@ -477,7 +474,6 @@ TEST(conduit_generator, json_external_gen)
     n.print();
 
     std::string json_ext = n.to_json("conduit_json_external");
-
     std::cout << json_ext << std::endl;
 
     Node n2;
@@ -485,8 +481,7 @@ TEST(conduit_generator, json_external_gen)
     g.walk(n2);
     n2.print();
 
-    // n2 should be full external, reflecting n
-
+    // n2 should be full external, refing data owned by n
     EXPECT_EQ(n["a"].data_ptr(),n2["a"].data_ptr());
     EXPECT_EQ(n["b"].data_ptr(),n2["b"].data_ptr());
     EXPECT_EQ(n["c"].data_ptr(),n2["c"].data_ptr());

--- a/src/tests/conduit/t_conduit_generator.cpp
+++ b/src/tests/conduit/t_conduit_generator.cpp
@@ -466,3 +466,30 @@ TEST(conduit_generator, yaml_parsing_errors)
 }
 
 
+
+//-----------------------------------------------------------------------------
+TEST(conduit_generator, json_external_gen)
+{
+    Node n;
+    n["a"] = 42;
+    n["b"] = 144;
+    n["c/d"] = 3.1415;
+    n.print();
+
+    std::string json_ext = n.to_json("conduit_json_external");
+
+    std::cout << json_ext << std::endl;
+
+    Node n2;
+    Generator g(json_ext,"conduit_json");
+    g.walk(n2);
+    n2.print();
+
+    // n2 should be full external, reflecting n
+
+    EXPECT_EQ(n["a"].data_ptr(),n2["a"].data_ptr());
+    EXPECT_EQ(n["b"].data_ptr(),n2["b"].data_ptr());
+    EXPECT_EQ(n["c"].data_ptr(),n2["c"].data_ptr());
+
+}
+

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -947,5 +947,46 @@ TEST(conduit_json, to_json_external_2)
     EXPECT_EQ(n["path/b"].data_ptr(),n3["path/b"].data_ptr());
 }
 
+//-----------------------------------------------------------------------------
+TEST(conduit_json, json_walk_with_pointer)
+{
+    uint32 a_val = 20;
+    uint32 b_val = 8;
+    uint32 c_val = 13;
+
+    Node n;
+    n["a"] = a_val;
+    n["b"] = b_val;
+    n["c"] = c_val;
+
+    EXPECT_EQ(n["a"].as_uint32(), a_val);
+    EXPECT_EQ(n["b"].as_uint32(), b_val);
+    EXPECT_EQ(n["c"].as_uint32(), c_val);
+
+    Node n_compact;
+    n.compact_to(n_compact);
+
+    n_compact.print();
+    
+    std::string schema_json = n_compact.schema().to_json();
+    std::cout << schema_json << std::endl;
+    Node n_res;
+
+    Generator node_gen(schema_json, "conduit_json", n_compact.data_ptr());
+    /// gen copy
+    node_gen.walk(n_res);
+        
+    std::cout << "round trip" << std::endl;
+    n_res.print();
+
+    std::cout << n_res.schema().to_json() << std::endl;
+
+    EXPECT_EQ(n_res["a"].as_uint32(), a_val);
+    EXPECT_EQ(n_res["b"].as_uint32(), b_val);
+    EXPECT_EQ(n_res["c"].as_uint32(), c_val);
+}
+
+
+
 
 

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -896,3 +896,21 @@ TEST(conduit_json, to_json_opts)
 }
 
 
+//-----------------------------------------------------------------------------
+TEST(conduit_json, to_json_external)
+{
+
+    uint32   a_val  = 10;
+    uint32   b_val  = 20;
+
+    Node n;
+    n["a"] = a_val;
+    n["b"] = b_val;
+
+    EXPECT_EQ(n["a"].as_uint32(),a_val);
+    EXPECT_EQ(n["b"].as_uint32(),b_val);
+
+    std::cout << n.to_json("conduit_json_external") << std::endl;
+}
+
+

--- a/src/tests/conduit/t_conduit_json.cpp
+++ b/src/tests/conduit/t_conduit_json.cpp
@@ -913,4 +913,39 @@ TEST(conduit_json, to_json_external)
     std::cout << n.to_json("conduit_json_external") << std::endl;
 }
 
+//-----------------------------------------------------------------------------
+TEST(conduit_json, to_json_external_2)
+{
+
+    uint32   a_val  = 10;
+    uint32   b_val  = 20;
+
+    Node n;
+    n["a"] = a_val;
+    n["path/b"] = b_val;
+
+    EXPECT_EQ(n["a"].as_uint32(),a_val);
+    EXPECT_EQ(n["path/b"].as_uint32(),b_val);
+
+    std::string json = n.to_json("conduit_json_external") ;
+
+    Node n2, n3;
+
+    n2.set_external(n);
+    n3.parse(json,"conduit_json");
+
+    Node info;
+    EXPECT_FALSE(n.diff(n2,info));
+    EXPECT_FALSE(n.diff(n3,info));
+
+    EXPECT_FALSE(n2.diff(n3,info));
+
+    EXPECT_EQ(n["a"].data_ptr(),n2["a"].data_ptr());
+    EXPECT_EQ(n["path/b"].data_ptr(),n2["path/b"].data_ptr());
+
+    EXPECT_EQ(n["a"].data_ptr(),n3["a"].data_ptr());
+    EXPECT_EQ(n["path/b"].data_ptr(),n3["path/b"].data_ptr());
+}
+
+
 

--- a/src/tests/conduit/t_conduit_utils.cpp
+++ b/src/tests/conduit/t_conduit_utils.cpp
@@ -420,6 +420,9 @@ TEST(conduit_utils, base64_enc_dec)
     // apply schema
     Node n_res(n.schema(),b64_decode_ptr,false);
 
+    n.print();
+    n_res.print();
+
     // check we have the same values
     EXPECT_EQ(n_src["a"].as_int32(), n_res["a"].as_int32());
     EXPECT_EQ(n_src["b"].as_int32(), n_res["b"].as_int32());

--- a/src/tests/conduit/t_conduit_utils.cpp
+++ b/src/tests/conduit/t_conduit_utils.cpp
@@ -903,7 +903,6 @@ TEST(conduit_utils, to_and_from_hex_string)
     int64 val = 1024;
     std::string hstring = utils::to_hex_string(val);
     std::cout << hstring << std::endl;
-    EXPECT_EQ(hstring,"0x400");
     int64 val_check = conduit::utils::hex_string_to_value<int64>(hstring);
     EXPECT_EQ(val,val_check);
 }

--- a/src/tests/conduit/t_conduit_utils.cpp
+++ b/src/tests/conduit/t_conduit_utils.cpp
@@ -898,6 +898,17 @@ TEST(conduit_utils, value_fits)
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_utils, to_and_from_hex_string)
+{
+    int64 val = 1024;
+    std::string hstring = utils::to_hex_string(val);
+    std::cout << hstring << std::endl;
+    EXPECT_EQ(hstring,"0x400");
+    int64 val_check = conduit::utils::hex_string_to_value<int64>(hstring);
+    EXPECT_EQ(val,val_check);
+}
+
+//-----------------------------------------------------------------------------
 TEST(conduit_utils, timer)
 {
     conduit::utils::Timer t;

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -36,10 +36,15 @@ TEST(conduit_relay_io_silo, conduit_silo_cold_storage)
     EXPECT_EQ(n["b"].as_uint32(), b_val);
     EXPECT_EQ(n["c"].as_uint32(), c_val);
 
+    n.print();
+
     io::silo_write(n,"tout_cold_storage_test.silo:myobj");
 
     Node n_load;
     io::silo_read("tout_cold_storage_test.silo:myobj",n_load);
+
+    std::cout << "round trip" << std::endl;
+    n_load.print();
 
     EXPECT_EQ(n_load["a"].as_uint32(), a_val);
     EXPECT_EQ(n_load["b"].as_uint32(), b_val);
@@ -94,7 +99,7 @@ TEST(conduit_relay_io_silo, load_mesh_geometry)
     std::vector<int> dims_vec            = {2, 3, /*2,*/  2,    /*2,*/  2};
     std::vector<int> coordset_length_vec = {4, 8, /*36,*/ 1994, /*16,*/ 961};
     std::vector<int> topology_length_vec = {1, 1, /*33,*/ 1920, /*9,*/  900};
-    for (int i = 0; i < filename_vec.size(); ++i) 
+    for (int i = 0; i < filename_vec.size(); ++i)
     {
         Node mesh, info;
         std::string path = utils::join_file_path("overlink", filename_vec.at(i));
@@ -334,9 +339,9 @@ TEST(conduit_relay_io_silo, round_trip_julia)
 }
 
 //-----------------------------------------------------------------------------
-// 
+//
 // test read and write semantics
-// 
+//
 
 //-----------------------------------------------------------------------------
 TEST(conduit_relay_io_silo, read_and_write_semantics)
@@ -377,13 +382,13 @@ TEST(conduit_relay_io_silo, read_and_write_semantics)
     }
 }
 //-----------------------------------------------------------------------------
-// 
+//
 // special case tests
-// 
+//
 
 //-----------------------------------------------------------------------------
 // var is not defined on a domain
-// 
+//
 // tests the silo "EMPTY" capability
 TEST(conduit_relay_io_silo, missing_domain_var)
 {
@@ -427,11 +432,11 @@ TEST(conduit_relay_io_silo, missing_domain_var)
 
 //-----------------------------------------------------------------------------
 // mesh is not defined on a domain
-// 
+//
 // This case is much less interesting.
 // data passes through the clean mesh filter which
 // deletes domains that are missing topos.
-// They simply are not part of the mesh and so silo 
+// They simply are not part of the mesh and so silo
 // doesn't have to deal with it.
 TEST(conduit_relay_io_silo, missing_domain_mesh_trivial)
 {
@@ -508,7 +513,7 @@ TEST(conduit_relay_io_silo, missing_domain_mesh)
 
     remove_path_if_exists(filename);
     io::silo::save_mesh(save_mesh, basename);
-    
+
     opts["mesh_name"] = "mesh_topo2";
     io::silo::load_mesh(filename, opts, load_mesh);
     opts["mesh_name"] = "mesh_topo";
@@ -636,9 +641,9 @@ TEST(conduit_relay_io_silo, unstructured_points)
 
 //-----------------------------------------------------------------------------
 
-// 
+//
 // save and read option tests
-// 
+//
 
 // save options:
 /// opts:
@@ -650,7 +655,7 @@ TEST(conduit_relay_io_silo, unstructured_points)
 ///      silo_type: "default", "pdb", "hdf5", "unknown"
 ///            when the file we are writing to exists, "default" ==> "unknown"
 ///            else,                                   "default" ==> "hdf5"
-///         note: these are additional silo_type options that we could add 
+///         note: these are additional silo_type options that we could add
 ///         support for in the future:
 ///           "hdf5_sec2", "hdf5_stdio", "hdf5_mpio", "hdf5_mpiposix", "taurus"
 ///
@@ -728,8 +733,8 @@ TEST(conduit_relay_io_silo, round_trip_save_option_number_of_files)
         opts["file_style"] = "multi_file";
         opts["number_of_files"] = number_of_files[i];
 
-        const std::string basename = "silo_save_option_number_of_files_" + 
-                                     std::to_string(number_of_files[i]) + 
+        const std::string basename = "silo_save_option_number_of_files_" +
+                                     std::to_string(number_of_files[i]) +
                                      "_spiral";
         const std::string filename = basename + ".cycle_000000.root";
 
@@ -879,7 +884,7 @@ TEST(conduit_relay_io_silo, round_trip_save_option_silo_type)
         // this is to pass the diff, as silo will add cycle in if it is not there
         save_mesh["state/cycle"] = (int64) 0;
         save_mesh["state/domain_id"] = 0;
-        
+
         silo_name_changer("mesh", save_mesh);
 
         // the loaded mesh will be in the multidomain format
@@ -969,7 +974,7 @@ TEST(conduit_relay_io_silo, read_silo)
         {"multidir_test_data", "multidir0000", ".root", "Mesh"        },
     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
+    for (int i = 0; i < file_info.size(); i ++)
     {
         const std::string dirname  = file_info[i][0];
         const std::string basename = file_info[i][1];
@@ -1023,7 +1028,7 @@ TEST(conduit_relay_io_silo, read_fake_overlink)
         {"utpyr4",                  "OvlTop", ".silo", "MMESH"},
     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
+    for (int i = 0; i < file_info.size(); i ++)
     {
         const std::string dirname  = file_info[i][0];
         const std::string basename = file_info[i][1];
@@ -1082,7 +1087,7 @@ TEST(conduit_relay_io_silo, read_overlink_symlink_format)
         {".", "donordiv.s2_materials3", ".silo", "MMESH"},
     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
+    for (int i = 0; i < file_info.size(); i ++)
     {
         const std::string dirname  = file_info[i][0];
         const std::string basename = file_info[i][1];
@@ -1139,7 +1144,7 @@ TEST(conduit_relay_io_silo, read_overlink_directly)
         {"donordiv.s2_materials3", "OvlTop", ".silo", "MMESH"},
     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
+    for (int i = 0; i < file_info.size(); i ++)
     {
         const std::string dirname  = file_info[i][0];
         const std::string basename = file_info[i][1];


### PR DESCRIPTION
`to_json` gains new protocol (`conduit_json_external`) that embeds the address of each leaf in its schema. 
When parsing,  `conduit_json` handles schemas with optional `address` entry.

With this:
```
Node n, n2;
std::string json = n.to_json("conduit_json_external");

// the following are equivalent:
n2.set_external(n);
n2.parse(json,"conduit_json")

```

Also includes changes to improve performance of a few json parsing cases, avoiding intermediate copies and some intermediate use of json strings.
