### PR TITLE
Tiler improvements/fixes

### DIFF
--- a/src/docs/sphinx/blueprint_mesh.rst
+++ b/src/docs/sphinx/blueprint_mesh.rst
@@ -1708,21 +1708,23 @@ main mesh, a boundary mesh, and adjacency sets if the output mesh is to be part 
 
 The ``tiled()`` function accepts a Conduit node containing options that influence how the mesh is generated.
 If the options contain a ``tile`` node that contains a 2D blueprint topology, the first supplied topology will
-be used to override the default tile pattern. The ``reorder`` option indicates the type of point and element
-reordering that will be done. Reordering can improve cache-friendliness. The default is to reorder points
-and elements, using "kdtree" method. Passing "none" or an empty string will prevent reordering.
-The name of the mesh can be given by passing a ``meshname`` option string. Likewise, the name of the boundary
-mesh can be supplied using the ``boundarymeshname`` option. The optional ``translate/x`` and ``translate/y``
-options determine the tile spacing. If the translation values are not given, they will be determined from
-the coordset extents. The output mesh topology will store its integer connectivity information as index_t
-by default. The precision of the integer output can turned to int32 by passing a ``datatype`` option containing
-the "int", "int32", "integer" strings.
-
+be used to override the default tile pattern. The ``tile`` node may contain additional options.
 An important set of options define the left, right, bottom, and top sets of points within the supplied tile
 pattern. The values in the ``left`` option identify the list of points that define the left edge of the tile.
 These are indices into the coordset and the values should be in consecutive order along the edge. Opposite point
 sets must match. In other words, the left and right point sets must contain the same number of points and
 they need to proceed along their edges in the same order. The same is true of the bottom and top point sets.
+The optional ``translate/x`` and ``translate/y`` options determine the tile spacing. If the translation
+values are not given, they will be determined from the coordset extents.
+
+The remaining options described are not part of the ``tile`` node. The ``reorder`` option indicates the
+type of point and element reordering that will be done. Reordering can improve cache-friendliness. The
+default is to reorder points and elements, using "kdtree" method. Passing "none" or an empty string will
+prevent reordering. The name of the mesh can be given by passing a ``meshname`` option string. Likewise,
+the name of the boundary mesh can be supplied using the ``boundarymeshname`` option. The output mesh
+topology will store its integer connectivity information as index_t by default. The precision of the
+integer output can turned to int32 by passing a ``datatype`` option containing the "int", "int32",
+"integer" strings.
 
 The ``tiled()`` function also accepts options that simplify the task of generating
 mesh domains for a multi-domain dataset. The coordinate extents of the current mesh domain are given using
@@ -1734,8 +1736,8 @@ This is used to help construct adjacency sets.
 
 .. code:: yaml
 
-    # Define the tile topology
     tile:
+      # Define the tile
       coordsets:
         coords:
           type: explicit
@@ -1749,15 +1751,20 @@ This is used to help construct adjacency sets.
           elements:
             shape: tri
             connectivity: [0,1,4, 0,4,3, 1,2,5, 1,5,4, 3,4,7, 3,7,6, 4,5,8, 4,8,7]
+      # Define the tile edges
+      left: [0,3,6]
+      right: [2,5,8]
+      bottom: [0,1,2]
+      top: [6,7,8]
+      # Optional tile translation
+      translate:
+        x: 2.
+        y: 2.
     # Set some options that aid tiling.
-    reorder: 1
-    left: [0,3,6]
-    right: [2,5,8]
-    bottom: [0,1,2]
-    top: [6,7,8]
-    translate:
-      x: 2.
-      y: 2.
+    reorder: kdtree
+    domain: [0,0,0]
+    domains: [2,2,2]
+    extents: [0., 0.5, 0., 0.5, 0., 0.5]
 
 .. figure:: tiled_single.png
     :width: 400px

--- a/src/executables/generate_data/conduit_generate_data.cpp
+++ b/src/executables/generate_data/conduit_generate_data.cpp
@@ -33,6 +33,7 @@
 class DomainGenerator
 {
 public:
+    virtual ~DomainGenerator() = default;
     virtual void generate(int domain[3], conduit::Node &n, conduit::Node &opts) = 0;
 
     void setDims(const int d[3])

--- a/src/executables/generate_data/conduit_generate_data.cpp
+++ b/src/executables/generate_data/conduit_generate_data.cpp
@@ -283,7 +283,6 @@ main(int argc, char *argv[])
 
     MPI_Finalize();
 #else
-    conduit::relay::io::save(n, output + "-inspect.yaml", "yaml");
     conduit::relay::io::blueprint::save_mesh(n, output, protocol);
 #endif
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_tiled.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_tiled.cpp
@@ -573,7 +573,7 @@ Tiler::initialize(const conduit::Node &t)
     }
     if(getTopology()["type"].as_string() != "unstructured")
     {
-        CONDUIT_ERROR("The tile topology must be 2D.");
+        CONDUIT_ERROR("The tile topology must be unstructured.");
     }
 
     // Compute the tile extents.

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
@@ -385,7 +385,7 @@ MatchQuery::execute()
                    m_comm);
 
     // Look up a rank that owns a domain.
-    auto domain_to_rank = [&ntuple_values](const std::vector<int> &allqueries, int d) -> int
+    auto domain_to_rank = [=](const std::vector<int> &allqueries, int d) -> int
     {
         for(size_t i = 0; i < allqueries.size(); i += ntuple_values)
         {
@@ -683,7 +683,6 @@ adjset::compare_pointwise(conduit::Node &mesh, const std::string &adjsetName, MP
             for(auto dom_ptr : domains)
             {
                 Node &domain = *dom_ptr;
-                auto domainId = bputils::find_domain_id(domain);
 
                 // If the domain has the adjset, make a point mesh of its points
                 // that we can send to the neighbor.


### PR DESCRIPTION
This PR includes a few things:

* Fixes for compiler warnings that came up using other compilers.
* A fix to the tiled() sphinx doc.
* Tiler enhanced so if the tile definition contains fields, they get tiled too.

![pattern3](https://github.com/LLNL/conduit/assets/2072964/bbb9cc12-3fe6-4d22-9da6-9c0ed17e2a34)
