### PR TITLE
Add a CONDUIT_USE_PARMETIS macro to conduit_config.h

### DIFF
--- a/src/cmake/thirdparty/SetupParmetis.cmake
+++ b/src/cmake/thirdparty/SetupParmetis.cmake
@@ -71,3 +71,4 @@ blt_register_library(NAME parmetis
                      INCLUDES ${PARMETIS_INCLUDE_DIRS}
                      LIBRARIES ${PARMETIS_LIBRARIES} )
 
+set(CONDUIT_USE_PARMETIS TRUE)

--- a/src/libs/conduit/conduit_config.h.in
+++ b/src/libs/conduit/conduit_config.h.in
@@ -51,6 +51,8 @@
 
 #cmakedefine CONDUIT_USE_OPENMP
 
+#cmakedefine CONDUIT_USE_PARMETIS
+
 #endif
 
 


### PR DESCRIPTION
I need parmetis to do partitioning but Conduit CI builds on that project do not include parmetis. I can't include conduit_blueprint_mpi_mesh_parmetis.hpp in such a build because Conduit would not have installed it and I would get a compilation error.

This change introduces a macro to conduit_config.h that I can check to determine whether Conduit has parmetis support.