### PR TITLE
Refactor CMake fortran module install to be case insensitive

### DIFF
--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -142,27 +142,6 @@ target_include_directories(conduit_blueprint
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-
-if(FORTRAN_FOUND)
-    ###############################################################################
-    # Special install targets for conduit fortran modules
-    ###############################################################################
-
-    set(conduit_blueprint_fortran_modules
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_mesh.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_mcarray.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_table.mod
-        )
-
-    # Setup install to copy the fortran modules
-    install(FILES
-            ${conduit_blueprint_fortran_modules}
-            DESTINATION include/conduit)
-
-endif()
-
-
 ###################################
 # add conduit_blueprint_verify exe
 ###################################

--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -192,21 +192,11 @@ endif()
 
 
 ####################################################################
-# Special install targets for conduit fortran modules
+# Install target for conduit fortran modules
 ####################################################################
 if(FORTRAN_FOUND)
-    set(conduit_fortran_modules
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit.mod)
-
-    if(ENABLE_FORTRAN_OBJ_INTERFACE)
-        list(APPEND conduit_fortran_modules
-                    ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_obj.mod)
-    endif()
-
-    # Setup install to copy the fortran modules
-    install(FILES
-            ${conduit_fortran_modules}
-            DESTINATION include/conduit)
+   install(DIRECTORY
+   ${CMAKE_Fortran_MODULE_DIRECTORY}/
+   DESTINATION include/conduit)
 endif()
-
 

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -301,21 +301,6 @@ if(PYTHON_FOUND)
     add_subdirectory(python)
 endif()
 
-
-###############################################################################
-# Special install targets for conduit fortran modules 
-###############################################################################
-if(FORTRAN_FOUND)
-    set(conduit_relay_fortran_modules
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_relay.mod)
-
-    # Setup install to copy the fortran modules 
-    install(FILES 
-            ${conduit_relay_fortran_modules}
-            DESTINATION include/conduit)
-endif()
-
-
 ################################################################
 # If we have mpi, add the conduit relay mpi library
 ################################################################


### PR DESCRIPTION
The current conduit CMake logic expects lower case fortran modules names.  This currently breaks when using the Cray compiler (which produces uppercase name).

This update alters the install logic to install the fortran modules by DIRECTORY rather than a specific FILE list.