### PR TITLE
Update CMake to install Fortran modules with case insensitive command

### DIFF
--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -149,17 +149,17 @@ if(FORTRAN_FOUND)
     ###############################################################################
 
     set(conduit_blueprint_fortran_modules
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_mesh.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_mcarray.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_table.mod
+        "(?i)${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint.mod"
+        "(?i)${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_mesh.mod"
+        "(?i)${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_mcarray.mod"
+        "(?i)${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_blueprint_table.mod"
         )
 
     # Setup install to copy the fortran modules
-    install(FILES
-            ${conduit_blueprint_fortran_modules}
-            DESTINATION include/conduit)
-
+    install(DIRECTORY
+            ${CMAKE_Fortran_MODULE_DIRECTORY}/
+            DESTINATION include/conduit
+            PATTERN "${conduit_blueprint_fortran_modules}")
 endif()
 
 

--- a/src/libs/conduit/CMakeLists.txt
+++ b/src/libs/conduit/CMakeLists.txt
@@ -193,6 +193,7 @@ endif()
 
 ####################################################################
 # Special install targets for conduit fortran modules
+# Use regex to match either lowercase or uppercase module names.
 ####################################################################
 if(FORTRAN_FOUND)
     set(conduit_fortran_modules
@@ -200,13 +201,15 @@ if(FORTRAN_FOUND)
 
     if(ENABLE_FORTRAN_OBJ_INTERFACE)
         list(APPEND conduit_fortran_modules
-                    ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_obj.mod)
+                    "(?i)${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_obj.mod")
     endif()
 
     # Setup install to copy the fortran modules
-    install(FILES
-            ${conduit_fortran_modules}
-            DESTINATION include/conduit)
+    install(DIRECTORY
+            ${CMAKE_Fortran_MODULE_DIRECTORY}/
+            DESTINATION include/conduit
+            PATTERN "${conduit_fortran_modules}")
+
 endif()
 
 

--- a/src/libs/relay/CMakeLists.txt
+++ b/src/libs/relay/CMakeLists.txt
@@ -307,12 +307,13 @@ endif()
 ###############################################################################
 if(FORTRAN_FOUND)
     set(conduit_relay_fortran_modules
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_relay.mod)
+        "(?i)${CMAKE_Fortran_MODULE_DIRECTORY}/conduit_relay.mod")
 
     # Setup install to copy the fortran modules 
-    install(FILES 
-            ${conduit_relay_fortran_modules}
-            DESTINATION include/conduit)
+    install(DIRECTORY
+            ${CMAKE_Fortran_MODULE_DIRECTORY}
+            DESTINATION include/conduit
+            PATTERN "${conduit_relay_fortran_modules}")
 endif()
 
 


### PR DESCRIPTION
Some compilers ( Cray ) produce Fortran modules with uppercase names.  This update will install Fortran module file names with either lower or upper case.