### PR TITLE
Blueprint Silo I/O Add root file extension option

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -63,11 +63,9 @@ namespace examples
 {
 
 //---------------------------------------------------------------------------//
-void venn_full_matset(Node &res)
+void venn_full_matset(Node &res, index_t nx, index_t ny)
 {
     // create the material sets
-    index_t nx = res["coordsets/coords/params/nx"].value();
-    index_t ny = res["coordsets/coords/params/ny"].value();
 
     index_t elements = nx * ny;
 
@@ -211,10 +209,10 @@ void build_material_sparse(Node & src, index_t len,
 
 //---------------------------------------------------------------------------//
 void compute_material_sparse_matset_field(Node &res,
-                                          const std::string & field_name)
+                                          const std::string & field_name,
+                                          index_t nx,
+                                          index_t ny)
 {
-    index_t nx = res["coordsets/coords/params/nx"].value();
-    index_t ny = res["coordsets/coords/params/ny"].value();
     index_t elements = nx * ny;
 
     Node & n = res["fields/" + field_name + "/values"];
@@ -247,11 +245,9 @@ void compute_material_sparse_matset_field(Node &res,
 }
 
 //---------------------------------------------------------------------------//
-void venn_sparse_by_material_matset(Node &res)
+void venn_sparse_by_material_matset(Node &res, index_t nx, index_t ny)
 {    
     // create the materials
-    index_t nx = res["coordsets/coords/params/nx"].value();
-    index_t ny = res["coordsets/coords/params/ny"].value();
     
     // make sure our materials appear in the correct order,
     // by pre-creating the nodes.
@@ -410,15 +406,13 @@ void venn_sparse_by_material_matset(Node &res)
     // importance, sum the product of the volume fraction and the matset
     // value for each element to compute the field itself.
 
-    compute_material_sparse_matset_field(res, "area");
-    compute_material_sparse_matset_field(res, "importance");
+    compute_material_sparse_matset_field(res, "area", nx, ny);
+    compute_material_sparse_matset_field(res, "importance", nx, ny);
 }
 
-void venn_sparse_by_element_matset(Node &res)
+void venn_sparse_by_element_matset(Node &res, index_t nx, index_t ny)
 {
     // create the materials
-    index_t nx = res["coordsets/coords/params/nx"].value();
-    index_t ny = res["coordsets/coords/params/ny"].value();
 
     float64_array cir_a = res["fields/circle_a/values"].value();
     float64_array cir_b = res["fields/circle_b/values"].value();
@@ -546,10 +540,6 @@ void venn(const std::string &matset_type,
     res["coordsets/coords/type"] = "rectilinear";
     res["coordsets/coords/values/x"] = DataType::float64(nx+1);
     res["coordsets/coords/values/y"] = DataType::float64(ny+1);
-
-    // Not part of the blueprint, but I want these values handy
-    res["coordsets/coords/params/nx"] = nx;
-    res["coordsets/coords/params/ny"] = ny;
     
     float64_array x_coords = res["coordsets/coords/values/x"].value();
     float64_array y_coords = res["coordsets/coords/values/y"].value(); 
@@ -793,15 +783,15 @@ void venn(const std::string &matset_type,
 
     if (matset_type == "full")
     {
-        venn_full_matset(res);
+        venn_full_matset(res, nx, ny);
     }
     else if (matset_type == "sparse_by_material")
     {
-        venn_sparse_by_material_matset(res);
+        venn_sparse_by_material_matset(res, nx, ny);
     }
     else if (matset_type == "sparse_by_element")
     {
-        venn_sparse_by_element_matset(res);
+        venn_sparse_by_element_matset(res, nx, ny);
     }
     else
     {

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -63,9 +63,11 @@ namespace examples
 {
 
 //---------------------------------------------------------------------------//
-void venn_full_matset(Node &res, index_t nx, index_t ny)
+void venn_full_matset(Node &res)
 {
     // create the material sets
+    index_t nx = res["coordsets/coords/params/nx"].value();
+    index_t ny = res["coordsets/coords/params/ny"].value();
 
     index_t elements = nx * ny;
 
@@ -209,10 +211,10 @@ void build_material_sparse(Node & src, index_t len,
 
 //---------------------------------------------------------------------------//
 void compute_material_sparse_matset_field(Node &res,
-                                          const std::string & field_name,
-                                          index_t nx,
-                                          index_t ny)
+                                          const std::string & field_name)
 {
+    index_t nx = res["coordsets/coords/params/nx"].value();
+    index_t ny = res["coordsets/coords/params/ny"].value();
     index_t elements = nx * ny;
 
     Node & n = res["fields/" + field_name + "/values"];
@@ -245,9 +247,11 @@ void compute_material_sparse_matset_field(Node &res,
 }
 
 //---------------------------------------------------------------------------//
-void venn_sparse_by_material_matset(Node &res, index_t nx, index_t ny)
+void venn_sparse_by_material_matset(Node &res)
 {    
     // create the materials
+    index_t nx = res["coordsets/coords/params/nx"].value();
+    index_t ny = res["coordsets/coords/params/ny"].value();
     
     // make sure our materials appear in the correct order,
     // by pre-creating the nodes.
@@ -406,13 +410,15 @@ void venn_sparse_by_material_matset(Node &res, index_t nx, index_t ny)
     // importance, sum the product of the volume fraction and the matset
     // value for each element to compute the field itself.
 
-    compute_material_sparse_matset_field(res, "area", nx, ny);
-    compute_material_sparse_matset_field(res, "importance", nx, ny);
+    compute_material_sparse_matset_field(res, "area");
+    compute_material_sparse_matset_field(res, "importance");
 }
 
-void venn_sparse_by_element_matset(Node &res, index_t nx, index_t ny)
+void venn_sparse_by_element_matset(Node &res)
 {
     // create the materials
+    index_t nx = res["coordsets/coords/params/nx"].value();
+    index_t ny = res["coordsets/coords/params/ny"].value();
 
     float64_array cir_a = res["fields/circle_a/values"].value();
     float64_array cir_b = res["fields/circle_b/values"].value();
@@ -540,6 +546,10 @@ void venn(const std::string &matset_type,
     res["coordsets/coords/type"] = "rectilinear";
     res["coordsets/coords/values/x"] = DataType::float64(nx+1);
     res["coordsets/coords/values/y"] = DataType::float64(ny+1);
+
+    // Not part of the blueprint, but I want these values handy
+    res["coordsets/coords/params/nx"] = nx;
+    res["coordsets/coords/params/ny"] = ny;
     
     float64_array x_coords = res["coordsets/coords/values/x"].value();
     float64_array y_coords = res["coordsets/coords/values/y"].value(); 
@@ -783,15 +793,15 @@ void venn(const std::string &matset_type,
 
     if (matset_type == "full")
     {
-        venn_full_matset(res, nx, ny);
+        venn_full_matset(res);
     }
     else if (matset_type == "sparse_by_material")
     {
-        venn_sparse_by_material_matset(res, nx, ny);
+        venn_sparse_by_material_matset(res);
     }
     else if (matset_type == "sparse_by_element")
     {
-        venn_sparse_by_element_matset(res, nx, ny);
+        venn_sparse_by_element_matset(res);
     }
     else
     {

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -5423,6 +5423,10 @@ void CONDUIT_RELAY_API save_mesh(const Node &mesh,
 ///            when cycle is present,  "default"   ==> "cycle"
 ///            else,                   "default"   ==> "none"
 ///
+///      root_file_ext: "default", "root", "silo"
+///            "default"   ==> "root"
+///            if overlink, this parameter is unused.
+///
 ///      mesh_name:  (used if present, default ==> "mesh")
 ///
 ///      ovl_topo_name: (used if present, default ==> "")

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -397,9 +397,6 @@ TEST(conduit_relay_io_silo, round_trip_venn)
             save_mesh["state/cycle"] = (int64) 0;
             save_mesh["state/domain_id"] = 0;
 
-            // TODO remove once https://github.com/LLNL/conduit/issues/1163 is closed
-            save_mesh["coordsets"]["coords"].remove_child("params");
-
             // The field mat_check has values that are one type and matset_values
             // that are another type. The silo writer converts both to double arrays
             // in this case, so we follow suit.
@@ -469,9 +466,6 @@ TEST(conduit_relay_io_silo, round_trip_venn_modded_matnos)
     // make changes to save mesh so the diff will pass
     save_mesh["state/cycle"] = (int64) 0;
     save_mesh["state/domain_id"] = 0;
-
-    // TODO remove once https://github.com/LLNL/conduit/issues/1163 is closed
-    save_mesh["coordsets"]["coords"].remove_child("params");
 
     // The field mat_check has values that are one type and matset_values
     // that are another type. The silo writer converts both to double arrays

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -397,6 +397,9 @@ TEST(conduit_relay_io_silo, round_trip_venn)
             save_mesh["state/cycle"] = (int64) 0;
             save_mesh["state/domain_id"] = 0;
 
+            // TODO remove once https://github.com/LLNL/conduit/issues/1163 is closed
+            save_mesh["coordsets"]["coords"].remove_child("params");
+
             // The field mat_check has values that are one type and matset_values
             // that are another type. The silo writer converts both to double arrays
             // in this case, so we follow suit.
@@ -466,6 +469,9 @@ TEST(conduit_relay_io_silo, round_trip_venn_modded_matnos)
     // make changes to save mesh so the diff will pass
     save_mesh["state/cycle"] = (int64) 0;
     save_mesh["state/domain_id"] = 0;
+
+    // TODO remove once https://github.com/LLNL/conduit/issues/1163 is closed
+    save_mesh["coordsets"]["coords"].remove_child("params");
 
     // The field mat_check has values that are one type and matset_values
     // that are another type. The silo writer converts both to double arrays


### PR DESCRIPTION
Resolves #1191

Also added a test for this. Now you can specify "default", "root", and "silo" as root file extensions. These are ignored if overlink is turned on.