### PR TITLE
fix a wide variety of compiler warnings

### DIFF
--- a/src/executables/generate_data/conduit_generate_data.cpp
+++ b/src/executables/generate_data/conduit_generate_data.cpp
@@ -266,7 +266,7 @@ main(int argc, char *argv[])
 #endif
                         // Make the new domain.
                         char domainName[32];
-                        sprintf(domainName, "domain_%07d", domainid);
+                        snprintf(domainName, sizeof(domainName), "domain_%07d", domainid);
                         conduit::Node &d = n[domainName];
                         g->generate(domain, d, opts);
 #ifdef CONDUIT_PARALLEL

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -2969,7 +2969,7 @@ Partitioner::get_vertex_ids_for_element_ids(const conduit::Node &n_topo,
 
             // Compute some size,offsets into the stream to help
             std::vector<index_t> sizes, offsets;
-            index_t offset = 0, elemid = 0;
+            index_t offset = 0;
             for(index_t j = 0; j < stream_ids.number_of_elements(); j++)
             {
                 auto n = static_cast<index_t>(element_counts[j]);
@@ -2979,7 +2979,6 @@ Partitioner::get_vertex_ids_for_element_ids(const conduit::Node &n_topo,
                     sizes.push_back(npts);
                     offsets.push_back(offset);
                     offset += npts;
-                    elemid++;
                 }
             }
 
@@ -3499,7 +3498,7 @@ Partitioner::unstructured_topo_from_unstructured(const conduit::Node &n_topo,
 
             // Compute some size,offsets into the stream to help
             std::vector<index_t> stream_ids_expanded, offsets;
-            index_t offset = 0, elemid = 0;
+            index_t offset = 0;
             for(index_t j = 0; j < stream_ids.number_of_elements(); j++)
             {
                 auto n = static_cast<index_t>(element_counts[j]);
@@ -3509,7 +3508,6 @@ Partitioner::unstructured_topo_from_unstructured(const conduit::Node &n_topo,
                     stream_ids_expanded.push_back(stream_ids[j]);
                     offsets.push_back(offset);
                     offset += npts;
-                    elemid++;
                 }
             }
 
@@ -5531,7 +5529,7 @@ point_merge::execute(const std::vector<const Node *> &coordsets,
     std::vector<Node> working_sets;
     std::vector<coord_system> systems;
     std::vector<std::vector<float64>> extents;
-    index_t ncartesian = 0, ncylindrical = 0, nspherical = 0, nlogical = 0;
+    index_t ncartesian = 0, ncylindrical = 0, nspherical = 0;
     index_t dimension = 0;
     for(size_t i = 0u; i < coordsets.size(); i++)
     {
@@ -5567,7 +5565,6 @@ point_merge::execute(const std::vector<const Node *> &coordsets,
         }
         else if(system == "logical")
         {
-            nlogical++;
             systems.push_back(coord_system::logical);
         }
         else // system == cartesian
@@ -7626,6 +7623,7 @@ private:
             }
             std::cout << std::endl;
         #else
+            (void)iteration;
         #endif
             iteration++;
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_topology_metadata.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_topology_metadata.cpp
@@ -3647,7 +3647,6 @@ TopologyMetadata::TopologyMetadata(const conduit::Node &topology,
     const Node &topo_elem_offsets = dim_topos[topo_shape.dim]["elements/offsets"];
     const auto elem_conn_access = topo_elem_conn.as_index_t_accessor();
     const auto elem_offsets_access = topo_elem_offsets.as_index_t_accessor();
-    index_t topo_conn_len = 0;
     for(index_t ei = 0; ei < topo_num_elems; ei++)
     {
         index_t bi = topo_num_coords + ei;
@@ -3656,7 +3655,6 @@ TopologyMetadata::TopologyMetadata(const conduit::Node &topology,
         index_t entity_end_index = (ei < topo_num_elems - 1) ? elem_offsets_access[ei + 1] : 
                                        topo_elem_conn.dtype().number_of_elements();
         index_t entity_size = entity_end_index - entity_start_index;
-        topo_conn_len += entity_size;
 
         // Get the vector we'll populate.
         std::vector<int64> &elem_indices = entity_index_bag[bi];

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2073,7 +2073,7 @@ topology::unstructured::generate_offsets(const Node &topo,
         {
             const Node &n_element_counts = topo["elements/element_index/element_counts"];
 
-            index_t offset = 0, elemid = 0;
+            index_t offset = 0;
             for(index_t j = 0; j < n_stream_ids.dtype().number_of_elements(); j++)
             {
                 // Get the j'th elements from n_stream_ids, n_element_counts
@@ -2088,7 +2088,6 @@ topology::unstructured::generate_offsets(const Node &topo,
                 {
                     offsets.push_back(offset);
                     offset += npts;
-                    elemid++;
                 }
             }
         }
@@ -2096,7 +2095,7 @@ topology::unstructured::generate_offsets(const Node &topo,
         {
             const Node &n_stream = topo["elements/stream"];
             const Node &n_element_offsets = topo["elements/element_index/offsets"];
-            index_t offset = 0, elemid = 0;
+            index_t offset = 0;
             for(index_t j = 0; j < n_stream_ids.dtype().number_of_elements(); j++)
             {
                 // Get the j'th elements from n_stream_ids, n_element_offsets
@@ -2121,7 +2120,6 @@ topology::unstructured::generate_offsets(const Node &topo,
                 while(offset < next_offset) {
                     offsets.push_back(offset);
                     offset += npts;
-                    elemid++;
                 }
             }
         }

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh.cpp
@@ -2349,6 +2349,7 @@ void to_polyhedral(const Node &n,
                             } 
                             else
                             {
+                                (void)kstride;
                                 assert(stride == kstride);
                                 edge_ratio = ratio[2];
                             }
@@ -2464,7 +2465,6 @@ void to_polyhedral(const Node &n,
                             }
                             else
                             {
-                                index_t ctr = 0; 
                                 for (auto vi = subelem.begin(); vi != subelem.end();
                                      ++vi)
                                 {
@@ -2474,7 +2474,6 @@ void to_polyhedral(const Node &n,
                                             add_verts.begin(), add_verts.end());
                                         break;
                                     }
-                                    ++ctr;
                                 }
                             }
                         }

--- a/src/libs/conduit/conduit_annotations.cpp
+++ b/src/libs/conduit/conduit_annotations.cpp
@@ -104,6 +104,8 @@ initialize(const Node &opts)
     }
     cali_cfg_manager->start();
 
+#else
+    (void)opts;
 #endif
 }
 

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -8623,7 +8623,6 @@ Node::update_compatible(const Node &n_src)
     {
         // if we are already a list type, then call update_compatible on
         // the children in the list
-        index_t src_idx = 0;
         index_t src_num_children = n_src.number_of_children();
         if( dtype().id() == DataType::LIST_ID)
         {
@@ -8633,7 +8632,6 @@ Node::update_compatible(const Node &n_src)
                  idx++)
             {
                 child(idx).update_compatible(n_src.child(idx));
-                src_idx++;
             }
         }
     }

--- a/src/libs/relay/conduit_relay_io_blueprint.cpp
+++ b/src/libs/relay/conduit_relay_io_blueprint.cpp
@@ -1531,6 +1531,7 @@ void write_mesh(const Node &mesh,
             //              << " details\n"
             //              << books.to_yaml();
             // }
+            (void)twirls;
 
             // check if we have another round
             // stop when all batons are -1

--- a/src/libs/relay/conduit_relay_io_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_io_hdf5.cpp
@@ -2753,9 +2753,6 @@ fill_dataset_opts(const std::string & ref_path, const Node & inopts,
         return;
     }
 
-    hid_t h5_status    = 0;
-
-    index_t nelems     = H5Sget_simple_extent_npoints(dataspace_id);
     index_t rank       = H5Sget_simple_extent_ndims(dataspace_id);
     filled_opts["slabparams/rank"] = rank;
 
@@ -2777,7 +2774,6 @@ fill_dataset_opts(const std::string & ref_path, const Node & inopts,
     nsizes.set(DataType::index_t(rank));
     index_t_array nsizes_array = nsizes.value();
     hsize_t* psizes = new hsize_t[rank];
-    index_t rval = H5Sget_simple_extent_dims(dataspace_id, psizes, nullptr);
     for (int d = 0; d < rank; ++d)
     {
         nsizes_array[d] = psizes[d];

--- a/src/libs/relay/conduit_relay_io_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_io_hdf5.cpp
@@ -2774,6 +2774,7 @@ fill_dataset_opts(const std::string & ref_path, const Node & inopts,
     nsizes.set(DataType::index_t(rank));
     index_t_array nsizes_array = nsizes.value();
     hsize_t* psizes = new hsize_t[rank];
+    H5Sget_simple_extent_dims(dataspace_id, psizes, nullptr);
     for (int d = 0; d < rank; ++d)
     {
         nsizes_array[d] = psizes[d];

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -2727,7 +2727,7 @@ void silo_write_field(DBfile *dbfile,
                             comp_name_ptrs);
 
     const std::string safe_meshname = (overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
-    int var_type;
+    int var_type = DB_INVALID_OBJECT;
     int silo_error = 0;
     if (mesh_type == "unstructured")
     {
@@ -3324,7 +3324,7 @@ void silo_write_topo(const Node &mesh_domain,
                                           &silo_coordsys_type),
                              "error adding coordsys option");
 
-    int mesh_type;
+    int mesh_type = DB_INVALID_OBJECT;
 
     if (topo_type == "unstructured" ||
         topo_type == "structured" ||

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -1753,7 +1753,7 @@ communicate_using_schema::execute()
     if(logging)
     {
         char fn[128];
-        sprintf(fn, ".%04d.log", rank);
+        snprintf(fn, sizeof(fn), ".%04d.log", rank);
         std::string filename(loggingRoot + fn);
         log.open(filename.c_str(), std::ofstream::out);
         log << "* Log started on rank " << rank << " at " << t0 << std::endl;

--- a/src/tests/conduit/t_conduit_node.cpp
+++ b/src/tests/conduit/t_conduit_node.cpp
@@ -1339,7 +1339,6 @@ TEST(conduit_node, swap_schema_parent)
     root["path"].swap(subtree);
 
     path_name = root["path"].name();
-    path_schema_parent_existence;
     if (root["path"].schema().parent() != NULL)
     {
         path_schema_parent_existence = "path schema parent exists";
@@ -1376,7 +1375,6 @@ TEST(conduit_node, move_schema_parent)
     root["path"].move(subtree);
 
     path_name = root["path"].name();
-    path_schema_parent_existence;
     if (root["path"].schema().parent() != NULL)
     {
         path_schema_parent_existence = "path schema parent exists";


### PR DESCRIPTION
1. variables set but not used
2. sprintf is deprecated on Mac, use snprintf
3. variables used uninitialized if error occurs