### PR TITLE
Correct mistakes with Blueprint Silo I/O Add root file extension option

### DIFF
--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -4023,6 +4023,10 @@ write_multimats(DBfile *dbfile,
 ///            when cycle is present,  "default"   ==> "cycle"
 ///            else,                   "default"   ==> "none"
 ///
+///      root_file_ext: "default", "root", "silo"
+///            "default"   ==> "root"
+///            if overlink, this parameter is unused.
+///
 ///      mesh_name:  (used if present, default ==> "mesh")
 ///
 ///      ovl_topo_name: (used if present, default ==> "")
@@ -4056,6 +4060,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
 
     std::string opts_file_style    = "default";
     std::string opts_suffix        = "default";
+    std::string opts_root_file_ext = "default";
     std::string opts_out_mesh_name = "mesh"; // used only for the non-overlink case
     std::string opts_ovl_topo_name = ""; // used only for the overlink case
     std::string opts_silo_type     = "default";
@@ -4093,6 +4098,21 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             CONDUIT_ERROR("write_mesh invalid suffix option: \"" 
                           << opts_suffix << "\"\n"
                           " expected: \"default\", \"cycle\", or \"none\"");
+        }
+    }
+
+    // check for + validate root_file_ext option
+    if(opts.has_child("root_file_ext") && opts["root_file_ext"].dtype().is_string())
+    {
+        opts_root_file_ext = opts["root_file_ext"].as_string();
+
+        if(opts_root_file_ext != "default" && 
+           opts_root_file_ext != "root" &&
+           opts_root_file_ext != "silo" )
+        {
+            CONDUIT_ERROR("write_mesh invalid root_file_ext option: \"" 
+                          << opts_root_file_ext << "\"\n"
+                          " expected: \"default\", \"root\", or \"silo\"");
         }
     }
     
@@ -4185,6 +4205,11 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     //     silo_type = DB_TAURUS;
     // }
 
+    if (opts_root_file_ext == "default")
+    {
+        opts_root_file_ext = "root";
+    }
+
     // more will happen for this case later
     if (opts_file_style == "overlink")
     {
@@ -4192,6 +4217,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                      "with this option will be missing several components "
                      "that Overlink requires.")
         opts_suffix = "none"; // force no suffix for overlink case
+        opts_root_file_ext = "silo"; // force .silo file extension for root file
     }
 
     int num_files = opts_num_files;
@@ -4471,7 +4497,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     std::string root_filename;
     if (opts_file_style == "overlink")
     {
-        root_filename = utils::join_file_path(output_dir, "OvlTop.silo");
+        root_filename = utils::join_file_path(output_dir, "OvlTop." + opts_root_file_ext);
     }
     else
     {
@@ -4484,7 +4510,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             root_filename += conduit_fmt::format(".cycle_{:06d}",cycle);
         }
 
-        root_filename += ".root";
+        root_filename += "." + opts_root_file_ext;
     }
 
     // ----------------------------------------------------

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -965,6 +965,10 @@ TEST(conduit_relay_io_silo, unstructured_points)
 ///            when cycle is present,  "default"   ==> "cycle"
 ///            else,                   "default"   ==> "none"
 ///
+///      root_file_ext: "default", "root", "silo"
+///            "default"   ==> "root"
+///            if overlink, this parameter is unused.
+///
 ///      mesh_name:  (used if present, default ==> "mesh")
 ///
 ///      ovl_topo_name: (used if present, default ==> "")
@@ -1117,6 +1121,45 @@ TEST(conduit_relay_io_silo, round_trip_save_option_suffix)
         EXPECT_EQ(load_mesh.number_of_children(), 1);
         EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
 
+        EXPECT_FALSE(load_mesh[0].diff(save_mesh, info));
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_relay_io_silo, round_trip_save_option_root_file_ext)
+{
+    const std::vector<std::string> root_file_exts = {"default", "root", "silo"};
+
+    for (int i = 0; i < root_file_exts.size(); i ++)
+    {
+        Node opts;
+        opts["root_file_ext"] = root_file_exts[i];
+
+        std::string actual_file_ext = root_file_exts[i];
+        if (actual_file_ext == "default")
+        {
+            actual_file_ext = "root";
+        }
+
+        const std::string basename = "round_trip_save_option_root_file_ext_" + 
+                                     root_file_exts[i] + "_basic";
+        const std::string filename = basename + "." + actual_file_ext;
+
+        Node save_mesh, load_mesh, info;
+        blueprint::mesh::examples::basic("rectilinear", 3, 4, 0, save_mesh);
+        remove_path_if_exists(filename);
+        io::silo::save_mesh(save_mesh, basename, opts);
+        io::silo::load_mesh(filename, load_mesh);
+        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+        save_mesh["state/cycle"] = (int64) 0;
+        save_mesh["state/domain_id"] = 0;
+        silo_name_changer("mesh", save_mesh);
+
+        // the loaded mesh will be in the multidomain format
+        // but the saved mesh is in the single domain format
+        EXPECT_EQ(load_mesh.number_of_children(), 1);
+        EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
         EXPECT_FALSE(load_mesh[0].diff(save_mesh, info));
     }
 }


### PR DESCRIPTION
See #1193.

I made some mistakes with git and managed to undo these changes, so here they are again.