### PR TITLE
Overlink I/O: Lay the groundwork

### DIFF
--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -4388,12 +4388,16 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
         opts_out_mesh_name = opts["mesh_name"].as_string();
     }
 
-    // check for + validate ovl_topo_name option
-    // only used for overlink case
-    if(opts.has_child("ovl_topo_name") && opts["ovl_topo_name"].dtype().is_string())
+    // we only care about this argument if we are using overlink
+    if (write_overlink)
     {
-        opts_ovl_topo_name = opts["ovl_topo_name"].as_string();
+        // check for + validate ovl_topo_name option
+        if(opts.has_child("ovl_topo_name") && opts["ovl_topo_name"].dtype().is_string())
+        {
+            opts_ovl_topo_name = opts["ovl_topo_name"].as_string();
+        }
     }
+    
 
     // check for number_of_files, 0 or -1 implies #files => # domains
     if(opts.has_child("number_of_files") && opts["number_of_files"].dtype().is_integer())
@@ -4677,7 +4681,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             {
                 if (par_rank == 0)
                 {
-                    CONDUIT_INFO("Silo save: overlink: topo name not provided or not found.");
+                    CONDUIT_INFO("Silo save: Overlink: topo name not provided or not found.");
                 }
 
                 if (dom_topos.number_of_children() > 0)
@@ -4685,14 +4689,14 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                     opts_ovl_topo_name = dom_topos.children().next().name();
                     if (par_rank == 0)
                     {
-                        CONDUIT_INFO("Silo save: overlink: topo name defaulting to " + opts_ovl_topo_name);
+                        CONDUIT_INFO("Silo save: Overlink: topo name defaulting to " + opts_ovl_topo_name);
                     }
                 }
                 else
                 {
                     if (par_rank == 0)
                     {
-                        CONDUIT_WARN("Silo save: overlink: No topologies to save. Doing nothing.");
+                        CONDUIT_WARN("Silo save: Overlink: No topologies to save. Doing nothing.");
                     }
                     return;
                 }
@@ -4703,11 +4707,12 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
         {
             if (par_rank == 0)
             {
-                CONDUIT_WARN("Silo save: overlink: No topologies to save. Doing nothing.");
+                CONDUIT_WARN("Silo save: Overlink: No topologies to save. Doing nothing.");
             }
             return;
         }
 
+        // hardcode this so that we use the correct name going forward
         opts_out_mesh_name = "MMESH";
     }
 
@@ -5612,9 +5617,10 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                         opts_ovl_topo_name, 
                         root, 
                         write_overlink);
+        // TODO need material names here for overlink (not matset names, material names)
         write_multimats(dbfile.getSiloObject(), 
                         opts_out_mesh_name, 
-                        opts_ovl_topo_name, 
+                        opts_ovl_topo_name,
                         root, 
                         write_overlink);
 

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -3125,6 +3125,7 @@ void silo_write_field(DBfile *dbfile,
         var_type = DB_UCDVAR;
 
         // TODO do I actually need to do this? Or am I just letting the overlink spec bully me?
+        // TODO does overlink support non scalars?????
         // use the scalar variant for writing scalars
         // this will make overlink happy
         if (nvars == 1)

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -2736,7 +2736,7 @@ void silo_write_field(DBfile *dbfile,
                       const std::string &var_name,
                       const Node &n_var,
                       const Node &mesh_domain,
-                      const bool overlink,
+                      const bool write_overlink,
                       const int local_num_domains,
                       const int local_domain_index,
                       const uint64 global_domain_id,
@@ -2869,7 +2869,7 @@ void silo_write_field(DBfile *dbfile,
                             comp_vals_ptrs,
                             comp_name_ptrs);
 
-    const std::string safe_meshname = (overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
+    const std::string safe_meshname = (write_overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
     int var_type = DB_INVALID_OBJECT;
     int silo_error = 0;
     if (mesh_type == "unstructured")
@@ -3185,7 +3185,7 @@ void silo_write_quad_rect_mesh(DBfile *dbfile,
                                DBoptlist *state_optlist,
                                const int ndims,
                                char const * const coordnames[],
-                               const bool overlink,
+                               const bool write_overlink,
                                Node &n_mesh_info) 
 {
     Node n_coords_compact;
@@ -3230,7 +3230,7 @@ void silo_write_quad_rect_mesh(DBfile *dbfile,
                                   "Error adding option");
     }
 
-    const std::string safe_meshname = (overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
+    const std::string safe_meshname = (write_overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
 
     int silo_error =
         DBPutQuadmesh(dbfile,                      // silo file ptr
@@ -3255,14 +3255,14 @@ void silo_write_ucd_mesh(DBfile *dbfile,
                          char const * const coordnames[],
                          const void *coords_ptrs,
                          const int coords_dtype,
-                         const bool overlink,
+                         const bool write_overlink,
                          Node &n_mesh_info)
 {
     int num_elems = n_mesh_info[topo_name]["num_elems"].value();
 
     // TODO there is a different approach for polyhedral zone lists
     const std::string zlist_name = topo_name + "_connectivity";
-    const std::string safe_meshname = (overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
+    const std::string safe_meshname = (write_overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
 
     int silo_error = DBPutUcdmesh(dbfile,                      // silo file ptr
                                   safe_meshname.c_str(), // mesh name
@@ -3288,7 +3288,7 @@ void silo_write_structured_mesh(DBfile *dbfile,
                                 char const * const coordnames[],
                                 const void *coords_ptrs,
                                 const int coords_dtype,
-                                const bool overlink,
+                                const bool write_overlink,
                                 Node &n_mesh_info) 
 {
     int ele_dims[3];
@@ -3337,7 +3337,7 @@ void silo_write_structured_mesh(DBfile *dbfile,
                                   "Error adding option");
     }
 
-    const std::string safe_meshname = (overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
+    const std::string safe_meshname = (write_overlink ? "MESH" : detail::sanitize_silo_varname(topo_name));
 
     int silo_error =
         DBPutQuadmesh(dbfile,                // silo file ptr
@@ -3994,7 +3994,7 @@ write_multivars(DBfile *dbfile,
                 const std::string &opts_mesh_name,
                 const std::string &ovl_topo_name,
                 const Node &root,
-                const bool overlink)
+                const bool write_overlink)
 {
     const int num_files = root["number_of_files"].to_index_t();
     const int global_num_domains = root["number_of_domains"].to_index_t();
@@ -4016,7 +4016,7 @@ write_multivars(DBfile *dbfile,
 
             std::string linked_topo_name = n_var["topology"].as_string();
 
-            if (! overlink || linked_topo_name == ovl_topo_name)
+            if (! write_overlink || linked_topo_name == ovl_topo_name)
             {
                 std::string safe_varname = detail::sanitize_silo_varname(var_name);
                 std::string safe_linked_topo_name = detail::sanitize_silo_varname(linked_topo_name);
@@ -4049,7 +4049,7 @@ write_multivars(DBfile *dbfile,
                 CONDUIT_ASSERT(optlist.getSiloObject(), "Error creating options");
 
                 std::string multimesh_name, multivar_name;
-                if (overlink)
+                if (write_overlink)
                 {
                     multimesh_name = opts_mesh_name;
                     multivar_name = safe_varname;

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -1599,7 +1599,17 @@ read_matset_domain(DBfile* matset_domain_file_to_use,
     {
         for (int i = 0; i < matset_ptr->nmat; i ++)
         {
-            const int matno = matset_ptr->matnos[i];
+            int matno;
+            if (matset_ptr->matnos)
+            {
+                // we have mat nos to work with
+                matno = matset_ptr->matnos[i];
+            }
+            else
+            {
+                // we infer that matnos run from 1 to nmat, inclusive
+                matno = i + 1;
+            }
             if (matset_ptr->matnames) // may be null
             {
                 material_map[matset_ptr->matnames[i]] = matno;
@@ -3919,10 +3929,11 @@ void silo_write_matset(DBfile *dbfile,
     convert_to_c_int_array(silo_matset_compact["mix_next"], int_arrays["mix_next"]);
     convert_to_c_int_array(silo_matset_compact["matlist"], int_arrays["matlist"]);
 
+    const std::string safe_matset_name = (write_overlink ? "MATERIAL" : detail::sanitize_silo_varname(matset_name));
+
     int silo_error = 
         DBPutMaterial(dbfile, // Database file pointer
-            // TODO the material name for overlink should be MATERIAL
-                      detail::sanitize_silo_varname(matset_name).c_str(), // matset name
+                      safe_matset_name.c_str(), // matset name
                       safe_meshname.c_str(), // mesh name
                       nmat, // number of materials
                       matnos.data(), // material numbers

--- a/src/tests/relay/silo_test_utils.hpp
+++ b/src/tests/relay/silo_test_utils.hpp
@@ -279,24 +279,12 @@ overlink_name_changer(conduit::Node &save_mesh)
                 n_field["volume_dependent"] = "false";
             }
 
+            // there are only scalar variables for overlink so we do not
+            // need to worry about renaming vector components.
             // we need to rename vector components
             if (n_field["values"].dtype().is_object())
             {
-                if (n_field["values"].number_of_children() > 0)
-                {
-                    int child_index = 0;
-                    auto val_itr = n_field["values"].children();
-                    while (val_itr.has_next())
-                    {
-                        val_itr.next();
-                        std::string comp_name = val_itr.name();
-
-                        // rename vector components
-                        n_field["values"].rename_child(comp_name, std::to_string(child_index));
-
-                        child_index ++;
-                    }
-                }
+                CONDUIT_ERROR("Overlink only allows scalar variables. You are doing this wrong.");
             }
         }
     }

--- a/src/tests/relay/silo_test_utils.hpp
+++ b/src/tests/relay/silo_test_utils.hpp
@@ -59,9 +59,14 @@ silo_name_changer(const std::string &mmesh_name,
 {
     std::map<std::string, std::string> old_to_new_names;
 
-    if (!save_mesh.has_path("state/domain_id"))
+    if (! save_mesh.has_path("state/domain_id"))
     {
         save_mesh["state"]["domain_id"] = 0;
+    }
+    if (! save_mesh.has_path("state/cycle"))
+    {
+        // this is to pass the diff, as silo will add cycle in if it is not there
+        save_mesh["state/cycle"] = (int64) 0;
     }
 
     if (save_mesh.has_child("topologies"))
@@ -158,7 +163,7 @@ silo_name_changer(const std::string &mmesh_name,
                     // will just skip.
                 }
                 std::string new_matset_name = old_to_new_names[old_matset_name];
-                // use new topo name
+                // use new matset name
                 n_field["matset"].reset();
                 n_field["matset"] = new_matset_name;
             }
@@ -205,11 +210,20 @@ silo_name_changer(const std::string &mmesh_name,
 void
 overlink_name_changer(conduit::Node &save_mesh)
 {
-    // we assume 1 coordset, 1 topo, and fields
+    // handle state
+    if (! save_mesh.has_path("state/domain_id"))
+    {
+        save_mesh["state"]["domain_id"] = 0;
+    }
+    if (! save_mesh.has_path("state/cycle"))
+    {
+        save_mesh["state/cycle"] = (int64) 0;
+    }
 
+    // we assume 1 coordset and 1 topo
     Node &coordsets = save_mesh["coordsets"];
     Node &topologies = save_mesh["topologies"];
-    Node &fields = save_mesh["fields"];
+    
 
     // we assume only 1 child for each
     std::string coordset_name = coordsets.children().next().name();
@@ -223,45 +237,69 @@ overlink_name_changer(conduit::Node &save_mesh)
     // rename the topo
     topologies.rename_child(topo_name, "MMESH");
 
-    auto field_itr = fields.children();
-    while (field_itr.has_next())
+    if (save_mesh.has_child("matsets"))
     {
-        Node &n_field = field_itr.next();
-        std::string field_name = field_itr.name();
+        // you can have multiple matsets when saving, provided you only have
+        // one per topo. But if you want the diff to pass for tests, you 
+        // really can only have one. So we assume one.
+        Node &n_matset = save_mesh["matsets"].children().next();
+        std::string matset_name = n_matset.name();
 
         // use new topo name
-        n_field["topology"].reset();
-        n_field["topology"] = "MMESH";
+        n_matset["topology"].reset();
+        n_matset["topology"] = "MMESH";
 
-        // overlink tracks volume dependence so we do not have to remove it
+        // rename the matset
+        save_mesh["matsets"].rename_child(matset_name, "MMATERIAL");
+    }
 
-        // we need to rename vector components
-        if (n_field["values"].dtype().is_object())
+    if (save_mesh.has_child("fields"))
+    {
+        auto field_itr = save_mesh["fields"].children();
+        while (field_itr.has_next())
         {
-            if (n_field["values"].number_of_children() > 0)
+            Node &n_field = field_itr.next();
+
+            // use new topo name
+            n_field["topology"].reset();
+            n_field["topology"] = "MMESH";
+
+            if (n_field.has_child("matset"))
             {
-                int child_index = 0;
-                auto val_itr = n_field["values"].children();
-                while (val_itr.has_next())
+                // use new matset name
+                n_field["matset"].reset();
+                n_field["matset"] = "MMATERIAL";
+            }
+
+            // overlink tracks volume dependence so we do not have to remove it
+            // but we should add it in if it is not present
+            // remove vol dep
+            if (! n_field.has_child("volume_dependent"))
+            {
+                n_field["volume_dependent"] = "false";
+            }
+
+            // we need to rename vector components
+            if (n_field["values"].dtype().is_object())
+            {
+                if (n_field["values"].number_of_children() > 0)
                 {
-                    val_itr.next();
-                    std::string comp_name = val_itr.name();
+                    int child_index = 0;
+                    auto val_itr = n_field["values"].children();
+                    while (val_itr.has_next())
+                    {
+                        val_itr.next();
+                        std::string comp_name = val_itr.name();
 
-                    // rename vector components
-                    n_field["values"].rename_child(comp_name, std::to_string(child_index));
+                        // rename vector components
+                        n_field["values"].rename_child(comp_name, std::to_string(child_index));
 
-                    child_index ++;
+                        child_index ++;
+                    }
                 }
             }
         }
     }
-
-    if (!save_mesh.has_path("state/domain_id"))
-    {
-        save_mesh["state"]["domain_id"] = 0;
-    }
-
-    // TODO materials
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -835,8 +835,10 @@ TEST(conduit_relay_io_silo, missing_domain_mesh)
         save_mesh[child]["state"]["cycle"] = (int64) cycle;
     }
 
+    std::cout << save_mesh.to_yaml() << std::endl;
+
     // we must merge the two meshes in load mesh
-    // this is tricky because one is missing a domain
+    // the indexing is tricky because one is missing a domain
     load_mesh[0]["coordsets"]["mesh_topo"].set_external(load_mesh2[0]["coordsets"]["mesh_topo"]);
     load_mesh[0]["topologies"]["mesh_topo"].set_external(load_mesh2[0]["topologies"]["mesh_topo"]);
     load_mesh[0]["fields"]["mesh_dist"].set_external(load_mesh2[0]["fields"]["mesh_dist"]);

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -835,8 +835,6 @@ TEST(conduit_relay_io_silo, missing_domain_mesh)
         save_mesh[child]["state"]["cycle"] = (int64) cycle;
     }
 
-    std::cout << save_mesh.to_yaml() << std::endl;
-
     // we must merge the two meshes in load mesh
     // the indexing is tricky because one is missing a domain
     load_mesh[0]["coordsets"]["mesh_topo"].set_external(load_mesh2[0]["coordsets"]["mesh_topo"]);
@@ -1575,3 +1573,5 @@ TEST(conduit_relay_io_silo, read_overlink_directly)
 //  - etc.
 
 // TODO what are those bonus tar files doing in the overlink data dir?
+
+// TODO somewhere I need to error on overlink when there are different var or mesh types across domains

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -169,8 +169,6 @@ TEST(conduit_relay_io_silo, round_trip_basic)
         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
         // make changes to save mesh so the diff will pass
-        save_mesh["state/cycle"] = (int64) 0;
-        save_mesh["state/domain_id"] = 0;
         if (mesh_type == "uniform")
         {
             silo_uniform_to_rect_conversion("coords", "mesh", save_mesh);
@@ -326,8 +324,6 @@ TEST(conduit_relay_io_silo, round_trip_julia)
     EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
     // make changes to save mesh so the diff will pass
-    save_mesh["state/cycle"] = (int64) 0;
-    save_mesh["state/domain_id"] = 0;
     silo_name_changer("mesh", save_mesh);
 
     // the loaded mesh will be in the multidomain format
@@ -394,8 +390,6 @@ TEST(conduit_relay_io_silo, round_trip_venn)
             }
 
             // make changes to save mesh so the diff will pass
-            save_mesh["state/cycle"] = (int64) 0;
-            save_mesh["state/domain_id"] = 0;
 
             // The field mat_check has values that are one type and matset_values
             // that are another type. The silo writer converts both to double arrays
@@ -464,8 +458,6 @@ TEST(conduit_relay_io_silo, round_trip_venn_modded_matnos)
     EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
     // make changes to save mesh so the diff will pass
-    save_mesh["state/cycle"] = (int64) 0;
-    save_mesh["state/domain_id"] = 0;
 
     // The field mat_check has values that are one type and matset_values
     // that are another type. The silo writer converts both to double arrays
@@ -1108,12 +1100,6 @@ TEST(conduit_relay_io_silo, round_trip_save_option_suffix)
         io::silo::load_mesh(filename, load_mesh);
         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-        // this is to pass the diff, as silo will add cycle in if it is not there
-        if (include_cycle[i] == "no")
-        {
-            save_mesh["state/cycle"] = (int64) 0;
-        }
-        save_mesh["state/domain_id"] = 0;
         silo_name_changer("mesh", save_mesh);
 
         // the loaded mesh will be in the multidomain format
@@ -1152,8 +1138,6 @@ TEST(conduit_relay_io_silo, round_trip_save_option_root_file_ext)
         io::silo::load_mesh(filename, load_mesh);
         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-        save_mesh["state/cycle"] = (int64) 0;
-        save_mesh["state/domain_id"] = 0;
         silo_name_changer("mesh", save_mesh);
 
         // the loaded mesh will be in the multidomain format
@@ -1180,8 +1164,6 @@ TEST(conduit_relay_io_silo, round_trip_save_option_mesh_name)
     io::silo::load_mesh(filename, load_mesh);
     EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-    save_mesh["state/cycle"] = (int64) 0;
-    save_mesh["state/domain_id"] = 0;
     silo_name_changer("mymesh", save_mesh);
 
     // the loaded mesh will be in the multidomain format
@@ -1225,10 +1207,6 @@ TEST(conduit_relay_io_silo, round_trip_save_option_silo_type)
         io::silo::save_mesh(save_mesh, basename, opts);
         io::silo::load_mesh(filename, load_mesh);
         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
-
-        // this is to pass the diff, as silo will add cycle in if it is not there
-        save_mesh["state/cycle"] = (int64) 0;
-        save_mesh["state/domain_id"] = 0;
         
         silo_name_changer("mesh", save_mesh);
 
@@ -1266,7 +1244,7 @@ TEST(conduit_relay_io_silo, round_trip_save_option_overlink1)
 
         Node save_mesh, load_mesh, info;
         blueprint::mesh::examples::spiral(ndomains, save_mesh);
-        remove_path_if_exists(basename);
+        remove_path_if_exists(filename);
         io::silo::save_mesh(save_mesh, basename, opts);
         io::silo::load_mesh(filename, load_mesh);
         EXPECT_TRUE(blueprint::mesh::verify(load_mesh,info));
@@ -1278,6 +1256,7 @@ TEST(conduit_relay_io_silo, round_trip_save_option_overlink1)
             save_mesh[child]["state"]["cycle"].reset();
             save_mesh[child]["state"]["cycle"] = (int64) cycle;
             // overlink preserves volume dependence in VAR_ATTRIBUTES
+            // TODO can I remove this b/c ovl name changer does htis?
             save_mesh[child]["fields"]["dist"]["volume_dependent"] = "false";
         }
 
@@ -1314,15 +1293,54 @@ TEST(conduit_relay_io_silo, round_trip_save_option_overlink2)
     field2["volume_dependent"] = "true";
     field2["values"].set_external(save_mesh["fields"]["field"]["values"]);
 
-    remove_path_if_exists(basename);
+    remove_path_if_exists(filename);
     io::silo::save_mesh(save_mesh, basename, opts);
     io::silo::load_mesh(filename, load_mesh);
     EXPECT_TRUE(blueprint::mesh::verify(load_mesh,info));
 
-    overlink_name_changer(save_mesh);
     // make changes to save mesh so the diff will pass
-    save_mesh["state/cycle"] = (int64) 0;
-    save_mesh["state/domain_id"] = 0;
+    overlink_name_changer(save_mesh);
+
+    // the loaded mesh will be in the multidomain format
+    // but the saved mesh is in the single domain format
+    EXPECT_EQ(load_mesh.number_of_children(), 1);
+    EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
+
+    EXPECT_FALSE(load_mesh[0].diff(save_mesh, info));
+}
+
+//-----------------------------------------------------------------------------
+// this tests material i/o
+TEST(conduit_relay_io_silo, round_trip_save_option_overlink3)
+{
+    Node save_mesh, load_mesh, info;
+    const int nx = 100, ny = 100;
+    const double radius = 0.25;
+    blueprint::mesh::examples::venn("sparse_by_element", nx, ny, radius, save_mesh);
+
+    const std::string basename = "silo_save_option_overlink_venn";
+    const std::string filename = basename + "/OvlTop.silo";
+
+    Node opts;
+    opts["file_style"] = "overlink";
+
+    remove_path_if_exists(filename);
+    io::silo::save_mesh(save_mesh, basename, opts);
+    io::silo::load_mesh(filename, load_mesh);
+    EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+    // make changes to save mesh so the diff will pass
+
+    // The field mat_check has values that are one type and matset_values
+    // that are another type. The silo writer converts both to double arrays
+    // in this case, so we follow suit.
+    Node mat_check_new_values, mat_check_new_matset_values;
+    save_mesh["fields"]["mat_check"]["values"].to_double_array(mat_check_new_values);
+    save_mesh["fields"]["mat_check"]["matset_values"].to_double_array(mat_check_new_matset_values);
+    save_mesh["fields"]["mat_check"]["values"].set_external(mat_check_new_values);
+    save_mesh["fields"]["mat_check"]["matset_values"].set_external(mat_check_new_matset_values);
+
+    overlink_name_changer(save_mesh);
 
     // the loaded mesh will be in the multidomain format
     // but the saved mesh is in the single domain format
@@ -1382,6 +1400,7 @@ TEST(conduit_relay_io_silo, read_silo)
             out_name += "_" + meshname;
         }
 
+        // TODO are these remove paths doing anything? Don't they need filenames?
         remove_path_if_exists(out_name + "_write_blueprint");
         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1255,9 +1255,6 @@ TEST(conduit_relay_io_silo, round_trip_save_option_overlink1)
             int cycle = save_mesh[child]["state"]["cycle"].as_int32();
             save_mesh[child]["state"]["cycle"].reset();
             save_mesh[child]["state"]["cycle"] = (int64) cycle;
-            // overlink preserves volume dependence in VAR_ATTRIBUTES
-            // TODO can I remove this b/c ovl name changer does htis?
-            save_mesh[child]["fields"]["dist"]["volume_dependent"] = "false";
         }
 
         EXPECT_EQ(load_mesh.number_of_children(), save_mesh.number_of_children());


### PR DESCRIPTION
This PR makes numerous changes to bring us in line with the Overlink spec, including changes to reading and writing multimeshes, multimaterials, variable attributes, multivariables, meshes, materials, and variables, both unstructured and structured. The goal of this work is to tighten everything that we have up so that we can move forward with other missing pieces for Overlink.