### PR TITLE
Silo/Overlink I/O: Fix matmap logic and support separation of non-scalar vars for overlink case

### DIFF
--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -4394,6 +4394,7 @@ write_multivars(DBfile *dbfile,
             {
                 std::string linked_topo_name = n_var["topology"].as_string();
 
+                // TODO do we need this check?
                 if (! write_overlink || linked_topo_name == ovl_topo_name)
                 {
                     std::string safe_varname = detail::sanitize_silo_varname(var_name);

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -2992,6 +2992,7 @@ void silo_write_field(DBfile *dbfile,
     }
     if (write_overlink && nvars != 1)
     {
+        // TODO convert to multiple vars
         CONDUIT_INFO("Overlink requires scalar variables. " << 
             var_name << " is not a scalar variable. Skipping.");
         return;

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -4487,8 +4487,6 @@ write_pad_dims(DBfile *dbfile,
                const std::string &opts_mesh_name,
                const Node &root)
 {
-    // TODO_PADDIMS add tests for this
-
     const Node &n_mesh = root["blueprint_index"][opts_mesh_name];
     // this only applies to structured topos 
     // (quadmeshes, so rectilinear, uniform, and structured)

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -3261,6 +3261,7 @@ void silo_write_field(DBfile *dbfile,
     {
         for (int comp_id = 0; comp_id < nvars; comp_id ++)
         {
+            // TODO can't this be simplified?
             Node bookkeeping_info;
             bookkeeping_info["comp_info"]["comp"] = "vars";
             bookkeeping_info["comp_info"]["comp_name"] = var_name + "_" + comp_name_strings[comp_id];

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -1590,7 +1590,6 @@ read_matset_domain(DBfile* matset_domain_file_to_use,
     // we are choosing to do sparse by element
     // TODO later support sparse by material and full
 
-    // ignore what is here and use what was found in the multimat
     Node &material_map = matset_out["material_map"];  
     // if we have material map information from the multimat, we want to use that instead
     if (n_matset.has_child("material_map"))
@@ -2390,7 +2389,6 @@ read_root_silo_index(const std::string &root_file_path,
     //             - "domain_000000.silo:material"
     //             - "domain_000001.silo:material"
     //               ...
-    //          material_map_status: "not provided", or "provided"
     //          material_map: // (optional) this can be reconstructed if dboptions are present
     //             a: 1
     //             b: 2    

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -1590,6 +1590,11 @@ read_matset_domain(DBfile* matset_domain_file_to_use,
     // we are choosing to do sparse by element
     // TODO later support sparse by material and full
 
+    // TODO if multimat info does not have material ids or does not have matnames
+    // then error
+    // If I do have one or both of those, then I won't worry about reading what is
+    // at the domain level
+
     Node &material_map = matset_out["material_map"];
     // if we have material map information from the multimat, we want to use that instead
     // if the multimat was missing matnames and we have them here, we want to use them
@@ -3125,7 +3130,8 @@ void silo_write_field(DBfile *dbfile,
         var_type = DB_UCDVAR;
 
         // TODO do I actually need to do this? Or am I just letting the overlink spec bully me?
-        // TODO does overlink support non scalars?????
+        // TODO ask Jeff if I need to write out individiual components of vectors
+        // TODO does overlink support non scalars????? - probably no it does not
         // use the scalar variant for writing scalars
         // this will make overlink happy
         if (nvars == 1)
@@ -3245,7 +3251,6 @@ void silo_write_field(DBfile *dbfile,
     {
         if (write_overlink)
         {
-            // TODO what I should probably do is force conversion to a ucd point var
             CONDUIT_ERROR("Cannot write point var " << topo_name << " to overlink."
                           << " Only DB_UCDVAR and DB_QUADVAR are supported.");
         }
@@ -3857,7 +3862,6 @@ void silo_write_topo(const Node &mesh_domain,
         {
             if (write_overlink)
             {
-                // TODO what I should probably do is force conversion to a ucd point mesh
                 CONDUIT_ERROR("Cannot write point mesh " << topo_name << " to overlink."
                               << " Only DB_UCDMESH and DB_QUADMESH are supported.");
             }
@@ -4613,7 +4617,6 @@ write_var_attributes(DBfile *dbfile,
             // field value in each zone for a second order remap of the values.
             // The first order remap is less accurate since it treats the value 
             // as constant within the zone.
-            // TODO do we want to store any of this info in the state node on read?
             var_attr_values.push_back(1);
 
             // 

--- a/src/tests/relay/silo_test_utils.hpp
+++ b/src/tests/relay/silo_test_utils.hpp
@@ -281,7 +281,6 @@ overlink_name_changer(conduit::Node &save_mesh)
 
             // there are only scalar variables for overlink so we do not
             // need to worry about renaming vector components.
-            // we need to rename vector components
             if (n_field["values"].dtype().is_object())
             {
                 CONDUIT_ERROR("Overlink only allows scalar variables. You are doing this wrong.");

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1364,12 +1364,12 @@ TEST(conduit_relay_io_silo, read_silo)
         {".",                  "multi_curv3d", ".silo", "mesh1_dup"   },
         {".",                  "multi_curv3d", ".silo", "mesh1_front" },
         {".",                  "multi_curv3d", ".silo", "mesh1_hidden"},
-        // {".",                  "tire",         ".silo", ""            }, // test default case
-        // {".",                  "tire",         ".silo", "tire"        },
-        // {".",                  "galaxy0000",   ".silo", ""            }, // test default case
-        // {".",                  "galaxy0000",   ".silo", "StarMesh"    },
-        // {".",                  "emptydomains", ".silo", ""            }, // test default case
-        // {".",                  "emptydomains", ".silo", "mesh"        },
+        {".",                  "tire",         ".silo", ""            }, // test default case
+        {".",                  "tire",         ".silo", "tire"        },
+        {".",                  "galaxy0000",   ".silo", ""            }, // test default case
+        {".",                  "galaxy0000",   ".silo", "StarMesh"    },
+        {".",                  "emptydomains", ".silo", ""            }, // test default case
+        {".",                  "emptydomains", ".silo", "mesh"        },
         {"multidir_test_data", "multidir0000", ".root", ""            }, // test default case
         {"multidir_test_data", "multidir0000", ".root", "Mesh"        },
     };
@@ -1412,182 +1412,182 @@ TEST(conduit_relay_io_silo, read_silo)
     }
 }
 
-// //-----------------------------------------------------------------------------
-// // test that we can read the fake overlink files from the visit test data
-// TEST(conduit_relay_io_silo, read_fake_overlink)
-// {
-//     const std::vector<std::vector<std::string>> file_info = {
-//      // {"ev_0_0_100",              "OvlTop", ".silo", ""     }, // test default case
-//      // {"ev_0_0_100",              "OvlTop", ".silo", "MMESH"},
-//         // uncomment once silo ucdmesh phzones are supported
-//         {"hl18spec",                "OvlTop", ".silo", ""     }, // test default case
-//         {"hl18spec",                "OvlTop", ".silo", "MMESH"},
-//      // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", ""     }, // test default case
-//      // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", "MMESH"},
-//         // uncomment once silo ucdmesh phzones are supported
-//         {"utpyr4",                  "OvlTop", ".silo", ""     }, // test default case
-//         {"utpyr4",                  "OvlTop", ".silo", "MMESH"},
-//     };
+//-----------------------------------------------------------------------------
+// test that we can read the fake overlink files from the visit test data
+TEST(conduit_relay_io_silo, read_fake_overlink)
+{
+    const std::vector<std::vector<std::string>> file_info = {
+     // {"ev_0_0_100",              "OvlTop", ".silo", ""     }, // test default case
+     // {"ev_0_0_100",              "OvlTop", ".silo", "MMESH"},
+        // uncomment once silo ucdmesh phzones are supported
+        {"hl18spec",                "OvlTop", ".silo", ""     }, // test default case
+        {"hl18spec",                "OvlTop", ".silo", "MMESH"},
+     // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", ""     }, // test default case
+     // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", "MMESH"},
+        // uncomment once silo ucdmesh phzones are supported
+        {"utpyr4",                  "OvlTop", ".silo", ""     }, // test default case
+        {"utpyr4",                  "OvlTop", ".silo", "MMESH"},
+    };
 
-//     for (int i = 0; i < file_info.size(); i ++) 
-//     {
-//         const std::string dirname  = file_info[i][0];
-//         const std::string basename = file_info[i][1];
-//         const std::string fileext  = file_info[i][2];
-//         const std::string meshname = file_info[i][3];
+    for (int i = 0; i < file_info.size(); i ++) 
+    {
+        const std::string dirname  = file_info[i][0];
+        const std::string basename = file_info[i][1];
+        const std::string fileext  = file_info[i][2];
+        const std::string meshname = file_info[i][3];
 
-//         Node load_mesh, info, read_opts, write_opts;
-//         std::string filepath = utils::join_file_path(dirname, basename) + fileext;
-//         filepath = utils::join_file_path("fake_overlink", filepath);
-//         std::string input_file = relay_test_silo_data_path(filepath);
+        Node load_mesh, info, read_opts, write_opts;
+        std::string filepath = utils::join_file_path(dirname, basename) + fileext;
+        filepath = utils::join_file_path("fake_overlink", filepath);
+        std::string input_file = relay_test_silo_data_path(filepath);
 
-//         read_opts["mesh_name"] = meshname;
+        read_opts["mesh_name"] = meshname;
 
-//         io::silo::load_mesh(input_file, read_opts, load_mesh);
-//         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+        io::silo::load_mesh(input_file, read_opts, load_mesh);
+        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-//         std::string out_name = "read_fake_overlink_" + dirname;
-//         if (!meshname.empty())
-//         {
-//             out_name += "_" + meshname;
-//         }
+        std::string out_name = "read_fake_overlink_" + dirname;
+        if (!meshname.empty())
+        {
+            out_name += "_" + meshname;
+        }
 
-//         remove_path_if_exists(out_name + "_write_blueprint");
-//         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
+        remove_path_if_exists(out_name + "_write_blueprint");
+        io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 
-//         remove_path_if_exists(out_name + "_write_silo");
-//         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
+        remove_path_if_exists(out_name + "_write_silo");
+        io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-//         // TODO uncomment when overlink is fully supported
-//         // remove_path_if_exists(out_name + "_write_overlink");
-//         // write_opts["file_style"] = "overlink";
-//         // write_opts["ovl_topo_name"] = "MMESH";
-//         // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
-//     }
-// }
+        // TODO uncomment when overlink is fully supported
+        // remove_path_if_exists(out_name + "_write_overlink");
+        // write_opts["file_style"] = "overlink";
+        // write_opts["ovl_topo_name"] = "MMESH";
+        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+    }
+}
 
-// //-----------------------------------------------------------------------------
-// // read overlink files in symlink format
-// // should be similar to reading raw silo
-// TEST(conduit_relay_io_silo, read_overlink_symlink_format)
-// {
-//     const std::vector<std::vector<std::string>> file_info = {
-//         {".", "box2d",                  ".silo", ""     }, // test default case
-//         {".", "box2d",                  ".silo", "MMESH"},
-//         {".", "box3d",                  ".silo", ""     }, // test default case
-//         {".", "box3d",                  ".silo", "MMESH"},
-//      // {".", "diamond",                ".silo", ""     }, // test default case
-//      // {".", "diamond",                ".silo", "MMESH"},
-//         // fails b/c polytopal not yet supported
-//         {".", "testDisk2D_a",           ".silo", ""     }, // test default case
-//         {".", "testDisk2D_a",           ".silo", "MMESH"},
-//      // {".", "donordiv.s2_materials2", ".silo", ""     }, // test default case
-//      // {".", "donordiv.s2_materials2", ".silo", "MMESH"},
-//         // fails b/c polytopal not yet supported
-//         {".", "donordiv.s2_materials3", ".silo", ""     }, // test default case
-//         {".", "donordiv.s2_materials3", ".silo", "MMESH"},
-//     };
+//-----------------------------------------------------------------------------
+// read overlink files in symlink format
+// should be similar to reading raw silo
+TEST(conduit_relay_io_silo, read_overlink_symlink_format)
+{
+    const std::vector<std::vector<std::string>> file_info = {
+        {".", "box2d",                  ".silo", ""     }, // test default case
+        {".", "box2d",                  ".silo", "MMESH"},
+        {".", "box3d",                  ".silo", ""     }, // test default case
+        {".", "box3d",                  ".silo", "MMESH"},
+     // {".", "diamond",                ".silo", ""     }, // test default case
+     // {".", "diamond",                ".silo", "MMESH"},
+        // fails b/c polytopal not yet supported
+        {".", "testDisk2D_a",           ".silo", ""     }, // test default case
+        {".", "testDisk2D_a",           ".silo", "MMESH"},
+     // {".", "donordiv.s2_materials2", ".silo", ""     }, // test default case
+     // {".", "donordiv.s2_materials2", ".silo", "MMESH"},
+        // fails b/c polytopal not yet supported
+        {".", "donordiv.s2_materials3", ".silo", ""     }, // test default case
+        {".", "donordiv.s2_materials3", ".silo", "MMESH"},
+    };
 
-//     for (int i = 0; i < file_info.size(); i ++) 
-//     {
-//         const std::string dirname  = file_info[i][0];
-//         const std::string basename = file_info[i][1];
-//         const std::string fileext  = file_info[i][2];
-//         const std::string meshname = file_info[i][3];
+    for (int i = 0; i < file_info.size(); i ++) 
+    {
+        const std::string dirname  = file_info[i][0];
+        const std::string basename = file_info[i][1];
+        const std::string fileext  = file_info[i][2];
+        const std::string meshname = file_info[i][3];
 
-//         Node load_mesh, info, read_opts, write_opts;
-//         std::string filepath = utils::join_file_path(dirname, basename) + fileext;
-//         filepath = utils::join_file_path("overlink", filepath);
-//         std::string input_file = relay_test_silo_data_path(filepath);
+        Node load_mesh, info, read_opts, write_opts;
+        std::string filepath = utils::join_file_path(dirname, basename) + fileext;
+        filepath = utils::join_file_path("overlink", filepath);
+        std::string input_file = relay_test_silo_data_path(filepath);
 
-//         read_opts["mesh_name"] = meshname;
+        read_opts["mesh_name"] = meshname;
 
-//         io::silo::load_mesh(input_file, read_opts, load_mesh);
-//         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+        io::silo::load_mesh(input_file, read_opts, load_mesh);
+        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-//         std::string out_name = "read_overlink_symlink_" + basename;
-//         if (!meshname.empty())
-//         {
-//             out_name += "_" + meshname;
-//         }
+        std::string out_name = "read_overlink_symlink_" + basename;
+        if (!meshname.empty())
+        {
+            out_name += "_" + meshname;
+        }
 
-//         remove_path_if_exists(out_name + "_write_blueprint");
-//         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
+        remove_path_if_exists(out_name + "_write_blueprint");
+        io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 
-//         remove_path_if_exists(out_name + "_write_silo");
-//         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
+        remove_path_if_exists(out_name + "_write_silo");
+        io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-//         // TODO uncomment when overlink is fully supported
-//         // remove_path_if_exists(out_name + "_write_overlink");
-//         // write_opts["file_style"] = "overlink";
-//         // write_opts["ovl_topo_name"] = "MMESH";
-//         // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
-//     }
-// }
+        // TODO uncomment when overlink is fully supported
+        // remove_path_if_exists(out_name + "_write_overlink");
+        // write_opts["file_style"] = "overlink";
+        // write_opts["ovl_topo_name"] = "MMESH";
+        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+    }
+}
 
-// //-----------------------------------------------------------------------------
-// // read overlink directly from ovltop.silo
-// // this case is tricky and involves messing with paths
-// TEST(conduit_relay_io_silo, read_overlink_directly)
-// {
-//     const std::vector<std::vector<std::string>> file_info = {
-//         {"box2d",                  "OvlTop", ".silo", ""     }, // test default case
-//         {"box2d",                  "OvlTop", ".silo", "MMESH"},
-//         {"box3d",                  "OvlTop", ".silo", ""     }, // test default case
-//         {"box3d",                  "OvlTop", ".silo", "MMESH"},
-//      // {"diamond",                "OvlTop", ".silo", ""     }, // test default case
-//      // {"diamond",                "OvlTop", ".silo", "MMESH"},
-//         {"testDisk2D_a",           "OvlTop", ".silo", ""     }, // test default case
-//         {"testDisk2D_a",           "OvlTop", ".silo", "MMESH"},
-//      // {"donordiv.s2_materials2", "OvlTop", ".silo", ""     }, // test default case
-//      // {"donordiv.s2_materials2", "OvlTop", ".silo", "MMESH"},
-//         {"donordiv.s2_materials3", "OvlTop", ".silo", ""     }, // test default case
-//         {"donordiv.s2_materials3", "OvlTop", ".silo", "MMESH"},
-//     };
+//-----------------------------------------------------------------------------
+// read overlink directly from ovltop.silo
+// this case is tricky and involves messing with paths
+TEST(conduit_relay_io_silo, read_overlink_directly)
+{
+    const std::vector<std::vector<std::string>> file_info = {
+        {"box2d",                  "OvlTop", ".silo", ""     }, // test default case
+        {"box2d",                  "OvlTop", ".silo", "MMESH"},
+        {"box3d",                  "OvlTop", ".silo", ""     }, // test default case
+        {"box3d",                  "OvlTop", ".silo", "MMESH"},
+     // {"diamond",                "OvlTop", ".silo", ""     }, // test default case
+     // {"diamond",                "OvlTop", ".silo", "MMESH"},
+        {"testDisk2D_a",           "OvlTop", ".silo", ""     }, // test default case
+        {"testDisk2D_a",           "OvlTop", ".silo", "MMESH"},
+     // {"donordiv.s2_materials2", "OvlTop", ".silo", ""     }, // test default case
+     // {"donordiv.s2_materials2", "OvlTop", ".silo", "MMESH"},
+        {"donordiv.s2_materials3", "OvlTop", ".silo", ""     }, // test default case
+        {"donordiv.s2_materials3", "OvlTop", ".silo", "MMESH"},
+    };
 
-//     for (int i = 0; i < file_info.size(); i ++) 
-//     {
-//         const std::string dirname  = file_info[i][0];
-//         const std::string basename = file_info[i][1];
-//         const std::string fileext  = file_info[i][2];
-//         const std::string meshname = file_info[i][3];
+    for (int i = 0; i < file_info.size(); i ++) 
+    {
+        const std::string dirname  = file_info[i][0];
+        const std::string basename = file_info[i][1];
+        const std::string fileext  = file_info[i][2];
+        const std::string meshname = file_info[i][3];
 
-//         Node load_mesh, info, read_opts, write_opts;
+        Node load_mesh, info, read_opts, write_opts;
 
-//         std::string filepath = utils::join_file_path(dirname, basename) + fileext;
-//         filepath = utils::join_file_path("overlink", filepath);
-//         std::string input_file = relay_test_silo_data_path(filepath);
+        std::string filepath = utils::join_file_path(dirname, basename) + fileext;
+        filepath = utils::join_file_path("overlink", filepath);
+        std::string input_file = relay_test_silo_data_path(filepath);
 
-//         read_opts["mesh_name"] = meshname;
+        read_opts["mesh_name"] = meshname;
 
-//         io::silo::load_mesh(input_file, read_opts, load_mesh);
-//         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+        io::silo::load_mesh(input_file, read_opts, load_mesh);
+        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-//         std::string out_name = "read_overlink_direct_" + dirname;
-//         if (!meshname.empty())
-//         {
-//             out_name += "_" + meshname;
-//         }
+        std::string out_name = "read_overlink_direct_" + dirname;
+        if (!meshname.empty())
+        {
+            out_name += "_" + meshname;
+        }
 
-//         remove_path_if_exists(out_name + "_write_blueprint");
-//         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
+        remove_path_if_exists(out_name + "_write_blueprint");
+        io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 
-//         remove_path_if_exists(out_name + "_write_silo");
-//         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
+        remove_path_if_exists(out_name + "_write_silo");
+        io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-//         // TODO uncomment when overlink is fully supported
-//         // remove_path_if_exists(out_name + "_write_overlink");
-//         // write_opts["file_style"] = "overlink";
-//         // write_opts["ovl_topo_name"] = "MMESH";
-//         // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
-//     }
-// }
+        // TODO uncomment when overlink is fully supported
+        // remove_path_if_exists(out_name + "_write_overlink");
+        // write_opts["file_style"] = "overlink";
+        // write_opts["ovl_topo_name"] = "MMESH";
+        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+    }
+}
 
-// // TODO add tests for...
-// //  - polytopal meshes once they are supported
-// //  - units once they are supported
-// //  - etc.
+// TODO add tests for...
+//  - polytopal meshes once they are supported
+//  - units once they are supported
+//  - etc.
 
-// // TODO what are those bonus tar files doing in the overlink data dir?
+// TODO what are those bonus tar files doing in the overlink data dir?
 
-// // TODO somewhere I need to error on overlink when there are different var or mesh types across domains
+// TODO somewhere I need to error on overlink when there are different var or mesh types across domains

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1364,12 +1364,12 @@ TEST(conduit_relay_io_silo, read_silo)
         {".",                  "multi_curv3d", ".silo", "mesh1_dup"   },
         {".",                  "multi_curv3d", ".silo", "mesh1_front" },
         {".",                  "multi_curv3d", ".silo", "mesh1_hidden"},
-        {".",                  "tire",         ".silo", ""            }, // test default case
-        {".",                  "tire",         ".silo", "tire"        },
-        {".",                  "galaxy0000",   ".silo", ""            }, // test default case
-        {".",                  "galaxy0000",   ".silo", "StarMesh"    },
-        {".",                  "emptydomains", ".silo", ""            }, // test default case
-        {".",                  "emptydomains", ".silo", "mesh"        },
+        // {".",                  "tire",         ".silo", ""            }, // test default case
+        // {".",                  "tire",         ".silo", "tire"        },
+        // {".",                  "galaxy0000",   ".silo", ""            }, // test default case
+        // {".",                  "galaxy0000",   ".silo", "StarMesh"    },
+        // {".",                  "emptydomains", ".silo", ""            }, // test default case
+        // {".",                  "emptydomains", ".silo", "mesh"        },
         {"multidir_test_data", "multidir0000", ".root", ""            }, // test default case
         {"multidir_test_data", "multidir0000", ".root", "Mesh"        },
     };
@@ -1412,182 +1412,182 @@ TEST(conduit_relay_io_silo, read_silo)
     }
 }
 
-//-----------------------------------------------------------------------------
-// test that we can read the fake overlink files from the visit test data
-TEST(conduit_relay_io_silo, read_fake_overlink)
-{
-    const std::vector<std::vector<std::string>> file_info = {
-     // {"ev_0_0_100",              "OvlTop", ".silo", ""     }, // test default case
-     // {"ev_0_0_100",              "OvlTop", ".silo", "MMESH"},
-        // uncomment once silo ucdmesh phzones are supported
-        {"hl18spec",                "OvlTop", ".silo", ""     }, // test default case
-        {"hl18spec",                "OvlTop", ".silo", "MMESH"},
-     // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", ""     }, // test default case
-     // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", "MMESH"},
-        // uncomment once silo ucdmesh phzones are supported
-        {"utpyr4",                  "OvlTop", ".silo", ""     }, // test default case
-        {"utpyr4",                  "OvlTop", ".silo", "MMESH"},
-    };
+// //-----------------------------------------------------------------------------
+// // test that we can read the fake overlink files from the visit test data
+// TEST(conduit_relay_io_silo, read_fake_overlink)
+// {
+//     const std::vector<std::vector<std::string>> file_info = {
+//      // {"ev_0_0_100",              "OvlTop", ".silo", ""     }, // test default case
+//      // {"ev_0_0_100",              "OvlTop", ".silo", "MMESH"},
+//         // uncomment once silo ucdmesh phzones are supported
+//         {"hl18spec",                "OvlTop", ".silo", ""     }, // test default case
+//         {"hl18spec",                "OvlTop", ".silo", "MMESH"},
+//      // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", ""     }, // test default case
+//      // {"regrovl_qh_1000_10001_4", "OvlTop", ".silo", "MMESH"},
+//         // uncomment once silo ucdmesh phzones are supported
+//         {"utpyr4",                  "OvlTop", ".silo", ""     }, // test default case
+//         {"utpyr4",                  "OvlTop", ".silo", "MMESH"},
+//     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
-    {
-        const std::string dirname  = file_info[i][0];
-        const std::string basename = file_info[i][1];
-        const std::string fileext  = file_info[i][2];
-        const std::string meshname = file_info[i][3];
+//     for (int i = 0; i < file_info.size(); i ++) 
+//     {
+//         const std::string dirname  = file_info[i][0];
+//         const std::string basename = file_info[i][1];
+//         const std::string fileext  = file_info[i][2];
+//         const std::string meshname = file_info[i][3];
 
-        Node load_mesh, info, read_opts, write_opts;
-        std::string filepath = utils::join_file_path(dirname, basename) + fileext;
-        filepath = utils::join_file_path("fake_overlink", filepath);
-        std::string input_file = relay_test_silo_data_path(filepath);
+//         Node load_mesh, info, read_opts, write_opts;
+//         std::string filepath = utils::join_file_path(dirname, basename) + fileext;
+//         filepath = utils::join_file_path("fake_overlink", filepath);
+//         std::string input_file = relay_test_silo_data_path(filepath);
 
-        read_opts["mesh_name"] = meshname;
+//         read_opts["mesh_name"] = meshname;
 
-        io::silo::load_mesh(input_file, read_opts, load_mesh);
-        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+//         io::silo::load_mesh(input_file, read_opts, load_mesh);
+//         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-        std::string out_name = "read_fake_overlink_" + dirname;
-        if (!meshname.empty())
-        {
-            out_name += "_" + meshname;
-        }
+//         std::string out_name = "read_fake_overlink_" + dirname;
+//         if (!meshname.empty())
+//         {
+//             out_name += "_" + meshname;
+//         }
 
-        remove_path_if_exists(out_name + "_write_blueprint");
-        io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
+//         remove_path_if_exists(out_name + "_write_blueprint");
+//         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 
-        remove_path_if_exists(out_name + "_write_silo");
-        io::silo::save_mesh(load_mesh, out_name + "_write_silo");
+//         remove_path_if_exists(out_name + "_write_silo");
+//         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = "MMESH";
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
-    }
-}
+//         // TODO uncomment when overlink is fully supported
+//         // remove_path_if_exists(out_name + "_write_overlink");
+//         // write_opts["file_style"] = "overlink";
+//         // write_opts["ovl_topo_name"] = "MMESH";
+//         // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+//     }
+// }
 
-//-----------------------------------------------------------------------------
-// read overlink files in symlink format
-// should be similar to reading raw silo
-TEST(conduit_relay_io_silo, read_overlink_symlink_format)
-{
-    const std::vector<std::vector<std::string>> file_info = {
-        {".", "box2d",                  ".silo", ""     }, // test default case
-        {".", "box2d",                  ".silo", "MMESH"},
-        {".", "box3d",                  ".silo", ""     }, // test default case
-        {".", "box3d",                  ".silo", "MMESH"},
-     // {".", "diamond",                ".silo", ""     }, // test default case
-     // {".", "diamond",                ".silo", "MMESH"},
-        // fails b/c polytopal not yet supported
-        {".", "testDisk2D_a",           ".silo", ""     }, // test default case
-        {".", "testDisk2D_a",           ".silo", "MMESH"},
-     // {".", "donordiv.s2_materials2", ".silo", ""     }, // test default case
-     // {".", "donordiv.s2_materials2", ".silo", "MMESH"},
-        // fails b/c polytopal not yet supported
-        {".", "donordiv.s2_materials3", ".silo", ""     }, // test default case
-        {".", "donordiv.s2_materials3", ".silo", "MMESH"},
-    };
+// //-----------------------------------------------------------------------------
+// // read overlink files in symlink format
+// // should be similar to reading raw silo
+// TEST(conduit_relay_io_silo, read_overlink_symlink_format)
+// {
+//     const std::vector<std::vector<std::string>> file_info = {
+//         {".", "box2d",                  ".silo", ""     }, // test default case
+//         {".", "box2d",                  ".silo", "MMESH"},
+//         {".", "box3d",                  ".silo", ""     }, // test default case
+//         {".", "box3d",                  ".silo", "MMESH"},
+//      // {".", "diamond",                ".silo", ""     }, // test default case
+//      // {".", "diamond",                ".silo", "MMESH"},
+//         // fails b/c polytopal not yet supported
+//         {".", "testDisk2D_a",           ".silo", ""     }, // test default case
+//         {".", "testDisk2D_a",           ".silo", "MMESH"},
+//      // {".", "donordiv.s2_materials2", ".silo", ""     }, // test default case
+//      // {".", "donordiv.s2_materials2", ".silo", "MMESH"},
+//         // fails b/c polytopal not yet supported
+//         {".", "donordiv.s2_materials3", ".silo", ""     }, // test default case
+//         {".", "donordiv.s2_materials3", ".silo", "MMESH"},
+//     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
-    {
-        const std::string dirname  = file_info[i][0];
-        const std::string basename = file_info[i][1];
-        const std::string fileext  = file_info[i][2];
-        const std::string meshname = file_info[i][3];
+//     for (int i = 0; i < file_info.size(); i ++) 
+//     {
+//         const std::string dirname  = file_info[i][0];
+//         const std::string basename = file_info[i][1];
+//         const std::string fileext  = file_info[i][2];
+//         const std::string meshname = file_info[i][3];
 
-        Node load_mesh, info, read_opts, write_opts;
-        std::string filepath = utils::join_file_path(dirname, basename) + fileext;
-        filepath = utils::join_file_path("overlink", filepath);
-        std::string input_file = relay_test_silo_data_path(filepath);
+//         Node load_mesh, info, read_opts, write_opts;
+//         std::string filepath = utils::join_file_path(dirname, basename) + fileext;
+//         filepath = utils::join_file_path("overlink", filepath);
+//         std::string input_file = relay_test_silo_data_path(filepath);
 
-        read_opts["mesh_name"] = meshname;
+//         read_opts["mesh_name"] = meshname;
 
-        io::silo::load_mesh(input_file, read_opts, load_mesh);
-        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+//         io::silo::load_mesh(input_file, read_opts, load_mesh);
+//         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-        std::string out_name = "read_overlink_symlink_" + basename;
-        if (!meshname.empty())
-        {
-            out_name += "_" + meshname;
-        }
+//         std::string out_name = "read_overlink_symlink_" + basename;
+//         if (!meshname.empty())
+//         {
+//             out_name += "_" + meshname;
+//         }
 
-        remove_path_if_exists(out_name + "_write_blueprint");
-        io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
+//         remove_path_if_exists(out_name + "_write_blueprint");
+//         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 
-        remove_path_if_exists(out_name + "_write_silo");
-        io::silo::save_mesh(load_mesh, out_name + "_write_silo");
+//         remove_path_if_exists(out_name + "_write_silo");
+//         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = "MMESH";
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
-    }
-}
+//         // TODO uncomment when overlink is fully supported
+//         // remove_path_if_exists(out_name + "_write_overlink");
+//         // write_opts["file_style"] = "overlink";
+//         // write_opts["ovl_topo_name"] = "MMESH";
+//         // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+//     }
+// }
 
-//-----------------------------------------------------------------------------
-// read overlink directly from ovltop.silo
-// this case is tricky and involves messing with paths
-TEST(conduit_relay_io_silo, read_overlink_directly)
-{
-    const std::vector<std::vector<std::string>> file_info = {
-        {"box2d",                  "OvlTop", ".silo", ""     }, // test default case
-        {"box2d",                  "OvlTop", ".silo", "MMESH"},
-        {"box3d",                  "OvlTop", ".silo", ""     }, // test default case
-        {"box3d",                  "OvlTop", ".silo", "MMESH"},
-     // {"diamond",                "OvlTop", ".silo", ""     }, // test default case
-     // {"diamond",                "OvlTop", ".silo", "MMESH"},
-        {"testDisk2D_a",           "OvlTop", ".silo", ""     }, // test default case
-        {"testDisk2D_a",           "OvlTop", ".silo", "MMESH"},
-     // {"donordiv.s2_materials2", "OvlTop", ".silo", ""     }, // test default case
-     // {"donordiv.s2_materials2", "OvlTop", ".silo", "MMESH"},
-        {"donordiv.s2_materials3", "OvlTop", ".silo", ""     }, // test default case
-        {"donordiv.s2_materials3", "OvlTop", ".silo", "MMESH"},
-    };
+// //-----------------------------------------------------------------------------
+// // read overlink directly from ovltop.silo
+// // this case is tricky and involves messing with paths
+// TEST(conduit_relay_io_silo, read_overlink_directly)
+// {
+//     const std::vector<std::vector<std::string>> file_info = {
+//         {"box2d",                  "OvlTop", ".silo", ""     }, // test default case
+//         {"box2d",                  "OvlTop", ".silo", "MMESH"},
+//         {"box3d",                  "OvlTop", ".silo", ""     }, // test default case
+//         {"box3d",                  "OvlTop", ".silo", "MMESH"},
+//      // {"diamond",                "OvlTop", ".silo", ""     }, // test default case
+//      // {"diamond",                "OvlTop", ".silo", "MMESH"},
+//         {"testDisk2D_a",           "OvlTop", ".silo", ""     }, // test default case
+//         {"testDisk2D_a",           "OvlTop", ".silo", "MMESH"},
+//      // {"donordiv.s2_materials2", "OvlTop", ".silo", ""     }, // test default case
+//      // {"donordiv.s2_materials2", "OvlTop", ".silo", "MMESH"},
+//         {"donordiv.s2_materials3", "OvlTop", ".silo", ""     }, // test default case
+//         {"donordiv.s2_materials3", "OvlTop", ".silo", "MMESH"},
+//     };
 
-    for (int i = 0; i < file_info.size(); i ++) 
-    {
-        const std::string dirname  = file_info[i][0];
-        const std::string basename = file_info[i][1];
-        const std::string fileext  = file_info[i][2];
-        const std::string meshname = file_info[i][3];
+//     for (int i = 0; i < file_info.size(); i ++) 
+//     {
+//         const std::string dirname  = file_info[i][0];
+//         const std::string basename = file_info[i][1];
+//         const std::string fileext  = file_info[i][2];
+//         const std::string meshname = file_info[i][3];
 
-        Node load_mesh, info, read_opts, write_opts;
+//         Node load_mesh, info, read_opts, write_opts;
 
-        std::string filepath = utils::join_file_path(dirname, basename) + fileext;
-        filepath = utils::join_file_path("overlink", filepath);
-        std::string input_file = relay_test_silo_data_path(filepath);
+//         std::string filepath = utils::join_file_path(dirname, basename) + fileext;
+//         filepath = utils::join_file_path("overlink", filepath);
+//         std::string input_file = relay_test_silo_data_path(filepath);
 
-        read_opts["mesh_name"] = meshname;
+//         read_opts["mesh_name"] = meshname;
 
-        io::silo::load_mesh(input_file, read_opts, load_mesh);
-        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+//         io::silo::load_mesh(input_file, read_opts, load_mesh);
+//         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-        std::string out_name = "read_overlink_direct_" + dirname;
-        if (!meshname.empty())
-        {
-            out_name += "_" + meshname;
-        }
+//         std::string out_name = "read_overlink_direct_" + dirname;
+//         if (!meshname.empty())
+//         {
+//             out_name += "_" + meshname;
+//         }
 
-        remove_path_if_exists(out_name + "_write_blueprint");
-        io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
+//         remove_path_if_exists(out_name + "_write_blueprint");
+//         io::blueprint::save_mesh(load_mesh, out_name + "_write_blueprint", "hdf5");
 
-        remove_path_if_exists(out_name + "_write_silo");
-        io::silo::save_mesh(load_mesh, out_name + "_write_silo");
+//         remove_path_if_exists(out_name + "_write_silo");
+//         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = "MMESH";
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
-    }
-}
+//         // TODO uncomment when overlink is fully supported
+//         // remove_path_if_exists(out_name + "_write_overlink");
+//         // write_opts["file_style"] = "overlink";
+//         // write_opts["ovl_topo_name"] = "MMESH";
+//         // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+//     }
+// }
 
-// TODO add tests for...
-//  - polytopal meshes once they are supported
-//  - units once they are supported
-//  - etc.
+// // TODO add tests for...
+// //  - polytopal meshes once they are supported
+// //  - units once they are supported
+// //  - etc.
 
-// TODO what are those bonus tar files doing in the overlink data dir?
+// // TODO what are those bonus tar files doing in the overlink data dir?
 
-// TODO somewhere I need to error on overlink when there are different var or mesh types across domains
+// // TODO somewhere I need to error on overlink when there are different var or mesh types across domains

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -216,8 +216,6 @@ TEST(conduit_relay_io_silo, round_trip_braid)
         Node save_mesh, load_mesh, info;
         blueprint::mesh::examples::braid(mesh_type, nx, ny, nz, save_mesh);
 
-        std::cout << save_mesh.to_yaml() << std::endl;
-
         const std::string basename = "silo_braid_" + mesh_type + "_" + dim + "D";
         const std::string filename = basename + ".cycle_000100.root";
 
@@ -1414,6 +1412,78 @@ TEST(conduit_relay_io_silo, round_trip_save_option_overlink3)
     EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
 
     EXPECT_FALSE(load_mesh[0].diff(save_mesh, info));
+}
+
+//-----------------------------------------------------------------------------
+// we are testing vector fields get converted to scalars
+TEST(conduit_relay_io_silo, round_trip_save_option_overlink4)
+{
+    const std::vector<std::pair<std::string, std::string>> mesh_types = {
+        std::make_pair("rectilinear", "2"), std::make_pair("rectilinear", "3"),
+        std::make_pair("structured", "2"), std::make_pair("structured", "3"),
+        std::make_pair("quads", "2"),
+        std::make_pair("hexs", "3"),
+    };
+    for (int i = 0; i < mesh_types.size(); ++i)
+    {
+        std::string dim = mesh_types[i].second;
+        index_t nx = 3;
+        index_t ny = 4;
+        index_t nz = (dim == "2" ? 0 : 2);
+
+        std::string mesh_type = mesh_types[i].first;
+
+        Node save_mesh, load_mesh, info;
+        blueprint::mesh::examples::braid(mesh_type, nx, ny, nz, save_mesh);
+
+        const std::string basename = "silo_save_option_overlink_braid_" + mesh_type + "_" + dim + "D";
+        const std::string filename = basename + "/OvlTop.silo";
+
+        Node opts;
+        opts["file_style"] = "overlink";
+
+        // remove existing root file, directory and any output files
+        remove_path_if_exists(filename);
+
+        io::silo::save_mesh(save_mesh, basename, opts);
+        io::silo::load_mesh(filename, load_mesh);
+        EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+        Node &field_vel = save_mesh["fields"]["vel"];
+        Node &field_vel_u = save_mesh["fields"]["vel_u"];
+        Node &field_vel_v = save_mesh["fields"]["vel_v"];
+
+        field_vel_u["topology"].set(field_vel["topology"]);
+        field_vel_u["association"].set(field_vel["association"]);
+        field_vel_u["values"].set(field_vel["values/u"]);
+        field_vel_v["topology"].set(field_vel["topology"]);
+        field_vel_v["association"].set(field_vel["association"]);
+        field_vel_v["values"].set(field_vel["values/v"]);
+
+        if (dim == "3")
+        {
+            Node &field_vel_w = save_mesh["fields"]["vel_w"];
+            field_vel_w["topology"].set(field_vel["topology"]);
+            field_vel_w["association"].set(field_vel["association"]);
+            field_vel_w["values"].set(field_vel["values/w"]);
+        }
+
+        save_mesh["fields"].remove_child("vel");
+
+        // make changes to save mesh so the diff will pass
+        overlink_name_changer(save_mesh);
+        // TODO can't the following be handled in the silo name changer
+        int cycle = save_mesh["state"]["cycle"].as_uint64();
+        save_mesh["state"]["cycle"].reset();
+        save_mesh["state"]["cycle"] = (int64) cycle;
+        
+        // the loaded mesh will be in the multidomain format
+        // but the saved mesh is in the single domain format
+        EXPECT_EQ(load_mesh.number_of_children(), 1);
+        EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
+
+        EXPECT_FALSE(load_mesh[0].diff(save_mesh, info));
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -216,6 +216,8 @@ TEST(conduit_relay_io_silo, round_trip_braid)
         Node save_mesh, load_mesh, info;
         blueprint::mesh::examples::braid(mesh_type, nx, ny, nz, save_mesh);
 
+        std::cout << save_mesh.to_yaml() << std::endl;
+
         const std::string basename = "silo_braid_" + mesh_type + "_" + dim + "D";
         const std::string filename = basename + ".cycle_000100.root";
 


### PR DESCRIPTION
- Use simplified material map logic as discussed; defer to multi materials if information is present.
- Separate non-scalar fields into multiple scalar fields for writing.
- Tests for the latter.