### PR TITLE
Fix kdtree extents to better support queries of planar arrangements of points in 3D.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - The `conduit::blueprint::mesh::partition()` function no longer issues an error when it receives a "maxshare" adjset.
 - The partitioner is better about outputting a "material_map" node for matsets. The "material_map" node is optional for some varieties of matset but they can also help the `conduit::blueprint::mesh::matset::to_silo()` function generate the right material numbers when a domain does not contain all materials.
 - The `conduit::Node::swap()` and `conduit::Node::move()` functions no longer cause node names to disappear.
+- The `conduit::blueprint::mesh::utils::kdtree` could erroneously return that points were not found when one of the coordset dimensions had a very narrow range of values. This could happen with planar 2D geometries embedded in 3D, such as inside a `MatchQuery` during adjacency set creation.
 
 ## [0.8.8] - Released 2023-05-18
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_kdtree.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_kdtree.hpp
@@ -70,6 +70,7 @@ class kdtree
 public:
     static const conduit::index_t NoChild;
     static const conduit::index_t NotFound;
+    static const CoordinateType   DEFAULT_POINT_TOLERANCE;
 
     using IndexableType = Indexable;
     using BoxType = CoordinateType[NDIMS][2];
@@ -181,6 +182,9 @@ const conduit::index_t kdtree<Indexable, CoordinateType, NDIMS>::NoChild = -1;
 template <typename Indexable, typename CoordinateType, int NDIMS>
 const conduit::index_t kdtree<Indexable, CoordinateType, NDIMS>::NotFound = -1;
 
+template <typename Indexable, typename CoordinateType, int NDIMS>
+const CoordinateType kdtree<Indexable, CoordinateType, NDIMS>::DEFAULT_POINT_TOLERANCE = static_cast<CoordinateType>(1.e-9);
+
 //---------------------------------------------------------------------------
 template <typename Indexable, typename CoordinateType, int NDIMS>
 kdtree<Indexable, CoordinateType, NDIMS>::kdtree() : boxes(), index()
@@ -192,7 +196,6 @@ kdtree<Indexable, CoordinateType, NDIMS>::kdtree() : boxes(), index()
         coords[i] = Indexable{};
     }
     coordlen = 0;
-    constexpr auto DEFAULT_POINT_TOLERANCE = static_cast<CoordinateType>(1.e-9);
     setPointTolerance(DEFAULT_POINT_TOLERANCE);
 }
 
@@ -458,10 +461,13 @@ void kdtree<Indexable, CoordinateType, NDIMS>::calculateExtents()
         }
     }
 
-    // Expand the box a little
+    // Expand the box a little. Note that we have a minimum expansion to account
+    // for when a dimension has all the same values.
+    const CoordinateType minExpansion = DEFAULT_POINT_TOLERANCE * 200.;
     for(int i = 0; i < dims(); i++)
     {
-        CoordinateType d = (box[i][1] - box[i][0]) / static_cast<CoordinateType>(200.);
+        CoordinateType side = std::max(box[i][1] - box[i][0], minExpansion);
+        CoordinateType d = side / static_cast<CoordinateType>(200.);
         box[i][0] -= d;
         box[i][1] += d;
     }


### PR DESCRIPTION
I was running into a weird problem where an element adjacency set produced from generate_faces() was missing certain groups in the adjacency set. I traced this to a problem in the kdtree where the overall bounding box of the points being queried had the same values for one of the dimensions. Later on, this would prevent successful point lookups because the kdtree determined the query point was outside of the dataset.

This change enhances the kdtree logic a little so the bounding box will always have some thickness, even when all of the points it contains are coplanar and contain the same values in x or y or z. I added tests that used to cause this to fail and now they pass with the fix.