### PR TITLE
Fix Fortran fetch int* procedure pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 ### Fixed
 
+#### General
+- The Fortran `node` procedures for fetching integer pointers are now associated with the correct routines.
+
 #### Blueprint
 - The `conduit::blueprint::mesh::partition()` function no longer issues an error when it receives a "maxshare" adjset.
 - The partitioner is better about outputting a "material_map" node for matsets. The "material_map" node is optional for some varieties of matset but they can also help the `conduit::blueprint::mesh::matset::to_silo()` function generate the right material numbers when a domain does not contain all materials.

--- a/src/libs/conduit/fortran/conduit_fortran_obj.f90
+++ b/src/libs/conduit/fortran/conduit_fortran_obj.f90
@@ -107,7 +107,7 @@ module conduit_obj
         procedure :: as_int32_ptr  => conduit_node_obj_as_int32_ptr
         !----------------------------------------------------------------------
         procedure :: fetch_path_as_int32 => conduit_node_obj_fetch_path_as_int32
-        procedure :: fetch_path_as_int32_ptr => conduit_node_obj_fetch_path_as_int32
+        procedure :: fetch_path_as_int32_ptr => conduit_node_obj_fetch_path_as_int32_ptr
         !----------------------------------------------------------------------
         ! end int32 cases
         !----------------------------------------------------------------------
@@ -129,7 +129,7 @@ module conduit_obj
         procedure :: as_int64_ptr  => conduit_node_obj_as_int64_ptr
         !----------------------------------------------------------------------
         procedure :: fetch_path_as_int64 => conduit_node_obj_fetch_path_as_int64
-        procedure :: fetch_path_as_int64_ptr => conduit_node_obj_fetch_path_as_int64
+        procedure :: fetch_path_as_int64_ptr => conduit_node_obj_fetch_path_as_int64_ptr
         !----------------------------------------------------------------------
         ! end int64 cases
         !----------------------------------------------------------------------

--- a/src/tests/conduit/fortran/t_f_conduit_node_obj.f90
+++ b/src/tests/conduit/fortran/t_f_conduit_node_obj.f90
@@ -155,10 +155,111 @@ contains
     end subroutine t_node_obj_set_float64
 
     !--------------------------------------------------------------------------
+    subroutine t_node_obj_set_and_fetch_path_int32_ptr
+        type(node) n
+        integer(4), dimension(5) :: data
+        integer i
+        integer(4), pointer :: f_arr(:)
+        
+        !----------------------------------------------------------------------
+        call set_case_name("t_node_obj_set_and_fetch_path_int32_ptr")
+        !----------------------------------------------------------------------
+        
+        ! fill our array
+        do i = 1,5
+            data(i) = i
+        enddo
+        ! create node and set data in the tree
+        n = conduit_node_obj_create()
+        call n%set_path_int32_ptr("sub/path/test",data,5_8)
+
+        ! fetch pointer to the data from comparison 
+        call n%fetch_path_as_int32_ptr("sub/path/test",f_arr)
+        
+        ! check size of fetched array
+        call assert_equals(size(data),size(f_arr));
+        
+        ! check array value equiv
+        do i = 1,5
+            call assert_equals(f_arr(i),data(i))
+        enddo
+        ! cleanup
+        call conduit_node_obj_destroy(n)
+    end subroutine t_node_obj_set_and_fetch_path_int32_ptr
+
+    !--------------------------------------------------------------------------
+    subroutine t_node_obj_set_and_fetch_path_int64_ptr
+        type(node) n
+        integer(8), dimension(5) :: data
+        integer i
+        integer(8), pointer :: f_arr(:)
+        
+        !----------------------------------------------------------------------
+        call set_case_name("t_node_obj_set_and_fetch_path_int64_ptr")
+        !----------------------------------------------------------------------
+        
+        ! fill our array
+        do i = 1,5
+            data(i) = i
+        enddo
+        ! create node and set data in the tree
+        n = conduit_node_obj_create()
+        call n%set_path_int64_ptr("sub/path/test",data,5_8)
+
+        ! fetch pointer to the data from comparison 
+        call n%fetch_path_as_int64_ptr("sub/path/test",f_arr)
+        
+        ! check size of fetched array
+        call assert_equals(size(data),size(f_arr));
+        
+        !=======
+        ! NOTE:  fruit doesn't support assert_equals with integer(8)
+        !=======
+        ! check array value equiv
+        do i = 1,5
+            call assert_equals(int(f_arr(i),4),int(data(i),4))
+        enddo
+        ! cleanup
+        call conduit_node_obj_destroy(n)
+    end subroutine t_node_obj_set_and_fetch_path_int64_ptr
+
+    !--------------------------------------------------------------------------
+    subroutine t_node_obj_set_and_fetch_path_float32_ptr
+        type(node) n
+        real(4), dimension(5) :: data
+        integer i
+        real(4), pointer :: f_arr(:)
+        
+        !----------------------------------------------------------------------
+        call set_case_name("t_node_obj_set_and_fetch_path_float32_ptr")
+        !----------------------------------------------------------------------
+        
+        ! fill our array
+        do i = 1,5
+            data(i) = i
+        enddo
+        ! create node and set data in the tree
+        n = conduit_node_obj_create()
+        call n%set_path_float32_ptr("sub/path/test",data,5_8)
+
+        ! fetch pointer to the data from comparison 
+        call n%fetch_path_as_float32_ptr("sub/path/test",f_arr)
+        
+        ! check size of fetched array
+        call assert_equals(size(data),size(f_arr));
+        
+        ! check array value equiv
+        do i = 1,5
+            call assert_equals(f_arr(i),data(i))
+        enddo
+        ! cleanup
+        call conduit_node_obj_destroy(n)
+    end subroutine t_node_obj_set_and_fetch_path_float32_ptr
+
+    !--------------------------------------------------------------------------
     subroutine t_node_obj_set_and_fetch_path_float64_ptr
         type(node) n
         real(8), dimension(5) :: data
-        real(8) res
         integer i
         real(8), pointer :: f_arr(:)
         
@@ -981,6 +1082,9 @@ program fortran_test
   call t_node_obj_set_int32
   call t_node_obj_set_double
   call t_node_obj_set_float64
+  call t_node_obj_set_and_fetch_path_int32_ptr
+  call t_node_obj_set_and_fetch_path_int64_ptr
+  call t_node_obj_set_and_fetch_path_float32_ptr
   call t_node_obj_set_and_fetch_path_float64_ptr
   call t_node_obj_fetch_int32
   call t_node_obj_set_int32_ptr


### PR DESCRIPTION
The fetch_path_as_int*_ptr methods on the Fortran node type were pointing to the non-ptr versions.  Compilation would fail when attempting to use the routines.