### PR TITLE
node diff intel fp issue

### DIFF
--- a/src/tests/conduit/t_conduit_node_compare.cpp
+++ b/src/tests/conduit/t_conduit_node_compare.cpp
@@ -139,7 +139,14 @@ TEST(conduit_node_compare, compare_leaf_numeric)
                 Node info;
                 memset(o.element_ptr(0), 1, 1);
                 memset(o.element_ptr(4), 1, 1);
-                EXPECT_TRUE(diff_nodes(n, o, info));
+                bool diff_res =diff_nodes(n, o, info)
+                EXPECT_TRUE(diff_res);
+                if(!diff_res)
+                {
+                  n.print();
+                  o.print()
+                  info.print();
+                }
 
                 Node &info_diff = info["value"];
                 EXPECT_EQ(info_diff.dtype().id(), leaf_tid);

--- a/src/tests/conduit/t_conduit_node_compare.cpp
+++ b/src/tests/conduit/t_conduit_node_compare.cpp
@@ -137,8 +137,8 @@ TEST(conduit_node_compare, compare_leaf_numeric)
 
             { // Leaf Difference Test //
                 Node info;
-                memset(o.element_ptr(0), 1, 1);
-                memset(o.element_ptr(4), 1, 1);
+                memset(o.element_ptr(0), 1, o.dtype().element_bytes());
+                memset(o.element_ptr(4), 1, o.dtype().element_bytes());
                 bool diff_res =diff_nodes(n, o, info);
                 EXPECT_TRUE(diff_res);
                 if(!diff_res)
@@ -158,6 +158,22 @@ TEST(conduit_node_compare, compare_leaf_numeric)
                                                  o.element_ptr(vi),
                                                  (size_t)type_bytes));
                     EXPECT_EQ(are_uneq, should_uneq);
+                    if(are_uneq != should_uneq)
+                    {
+                      unsigned char *n_ele_ptr = (unsigned char *)(n.element_ptr(vi));
+                      unsigned char *o_ele_ptr = (unsigned char *)(o.element_ptr(vi));
+                      for(int ibytes = 0; ibytes <  o.dtype().element_bytes(); ibytes++)
+                      {
+
+                        std::cout << conduit::utils::to_hex_string( n_ele_ptr[ibytes]) << " ";
+                      }
+                      std::cout << " vs ";
+                      for(int ibytes = 0; ibytes <  o.dtype().element_bytes(); ibytes++)
+                      {
+                        std::cout << conduit::utils::to_hex_string( o_ele_ptr[ibytes]) << " ";
+                      }
+                      std::cout << std::endl;
+                    }
                 }
             }
 

--- a/src/tests/conduit/t_conduit_node_compare.cpp
+++ b/src/tests/conduit/t_conduit_node_compare.cpp
@@ -144,7 +144,7 @@ TEST(conduit_node_compare, compare_leaf_numeric)
                 if(!diff_res)
                 {
                   n.print();
-                  o.print()
+                  o.print();
                   info.print();
                 }
 

--- a/src/tests/conduit/t_conduit_node_compare.cpp
+++ b/src/tests/conduit/t_conduit_node_compare.cpp
@@ -158,19 +158,19 @@ TEST(conduit_node_compare, compare_leaf_numeric)
                                                  o.element_ptr(vi),
                                                  (size_t)type_bytes));
                     EXPECT_EQ(are_uneq, should_uneq);
-                    if(are_uneq != should_uneq)
+                    if(!diff_res)
                     {
                       unsigned char *n_ele_ptr = (unsigned char *)(n.element_ptr(vi));
                       unsigned char *o_ele_ptr = (unsigned char *)(o.element_ptr(vi));
                       for(int ibytes = 0; ibytes <  o.dtype().element_bytes(); ibytes++)
                       {
 
-                        std::cout << conduit::utils::to_hex_string( n_ele_ptr[ibytes]) << " ";
+                        std::cout << conduit::utils::to_hex_string( int(n_ele_ptr[ibytes])) << " ";
                       }
                       std::cout << " vs ";
                       for(int ibytes = 0; ibytes <  o.dtype().element_bytes(); ibytes++)
                       {
-                        std::cout << conduit::utils::to_hex_string( o_ele_ptr[ibytes]) << " ";
+                        std::cout << conduit::utils::to_hex_string( int(o_ele_ptr[ibytes])) << " ";
                       }
                       std::cout << std::endl;
                     }

--- a/src/tests/conduit/t_conduit_node_compare.cpp
+++ b/src/tests/conduit/t_conduit_node_compare.cpp
@@ -139,7 +139,7 @@ TEST(conduit_node_compare, compare_leaf_numeric)
                 Node info;
                 memset(o.element_ptr(0), 1, 1);
                 memset(o.element_ptr(4), 1, 1);
-                bool diff_res =diff_nodes(n, o, info)
+                bool diff_res =diff_nodes(n, o, info);
                 EXPECT_TRUE(diff_res);
                 if(!diff_res)
                 {


### PR DESCRIPTION
resolves #1198 

improves the setup of our nodes diff tests to avoid issue with floating point numeric cases.

We were setting a bit in the first byte, which may diff clean (zero close to zero)

This sets all of the bytes to make sure we have a clear diff.

Also added some diagnostic output to help if cases fail.