### PR TITLE
Slice fix and tests.

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -2767,41 +2767,7 @@ Partitioner::copy_field(const conduit::Node &n_field,
 
     const conduit::Node &n_values = n_field["values"];
     conduit::Node &new_values = n_new_field["values"];
-    if(n_values.dtype().is_compact()) 
-    {
-        if(n_values.number_of_children() > 0)
-        {
-
-// The vel data must be interleaved. We need to use the DataArray element methods for access.
-
-
-            // mcarray.
-            for(index_t i = 0; i < n_values.number_of_children(); i++)
-            {
-                const conduit::Node &n_vals = n_values[i];
-                conduit::blueprint::mesh::utils::slice_array(n_vals, ids, new_values[n_vals.name()]);
-            }
-        }
-        else
-            conduit::blueprint::mesh::utils::slice_array(n_values, ids, new_values);
-    }
-    else
-    {
-        // otherwise, we need to compact our data first
-        conduit::Node n;
-        n_values.compact_to(n);
-        if(n.number_of_children() > 0)
-        {
-            // mcarray.
-            for(index_t i = 0; i < n.number_of_children(); i++)
-            {
-                const conduit::Node &n_vals = n[i];
-                conduit::blueprint::mesh::utils::slice_array(n_vals, ids, new_values[n_vals.name()]);
-            }
-        }
-        else
-            conduit::blueprint::mesh::utils::slice_array(n, ids, new_values);
-    }
+    conduit::blueprint::mesh::utils::slice_field(n_values, ids, new_values);
 }
 
 //---------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -379,9 +379,9 @@ find_domain_id(const Node &node)
 // @brief Slice the n_src array using the indices stored in ids. We use the
 //        array classes for their [] operators that deal with interleaved
 //        and non-interleaved arrays.
-template <typename T, typename IndexType>
+template <typename ArrayType, typename IndexType>
 inline void
-typed_slice_array(const T &src, const std::vector<IndexType> &ids, T &dest)
+typed_slice_array(const ArrayType &src, const std::vector<IndexType> &ids, ArrayType &dest)
 {
     size_t n = ids.size();
     for(size_t i = 0; i < n; i++)
@@ -402,6 +402,11 @@ slice_array_internal(const conduit::Node &n_src_values,
     // before copying it in so assigning to n_dest_values triggers a memory
     // allocation.
     auto dt = n_src_values.dtype();
+
+    // Make sure the destination node is reset so the node will get the
+    // right dtype when we reinitialize it below.
+    n_dest_values.reset();
+    // Allocate the new data.
     n_dest_values = DataType(n_src_values.dtype().id(), ids.size());
 
     // Do the slice.
@@ -564,7 +569,7 @@ slice_field_internal(const conduit::Node &n_src_values,
 {
     if(n_src_values.number_of_children() > 0)
     {
-        // Reorder an mcarray
+        // Slice an mcarray
         for(conduit::index_t ci = 0; ci < n_src_values.number_of_children(); ci++)
         {
             const conduit::Node &comp = n_src_values[ci];


### PR DESCRIPTION
I found that calling slice_array or slice_field where the destination node already had data could result in the node having the wrong array length. I corrected this by resetting the destination node. I also added tests for slice_array and slice_field to make sure they can handle strided external data.