### PR TITLE
Add build_adjsets option to partitioner so user can skip adjset creation.

### DIFF
--- a/src/docs/sphinx/blueprint_mesh_partition.rst
+++ b/src/docs/sphinx/blueprint_mesh_partition.rst
@@ -113,6 +113,11 @@ count domains are combined first.
 |                  | value turns it on and a zero value turns|                                          |
 |                  | it off.                                 |                                          |
 +------------------+-----------------------------------------+------------------------------------------+
+| build_adjsets    | An integer that determines whether      | .. code:: yaml                           |
+|                  | the partitioner should build adjsets,   |                                          |
+|                  | if they are present in the selected     |    build_adjsets: 1                      |
+|                  | topology.                               |                                          |
++------------------+-----------------------------------------+------------------------------------------+
 | merge_tolerance  | A double value that indicates the max   | .. code:: yaml                           |
 |                  | allowable distance between 2 points     |                                          |
 |                  | before they are considered to be        |    merge_tolerance: 0.000001             |

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -2767,41 +2767,7 @@ Partitioner::copy_field(const conduit::Node &n_field,
 
     const conduit::Node &n_values = n_field["values"];
     conduit::Node &new_values = n_new_field["values"];
-    if(n_values.dtype().is_compact()) 
-    {
-        if(n_values.number_of_children() > 0)
-        {
-
-// The vel data must be interleaved. We need to use the DataArray element methods for access.
-
-
-            // mcarray.
-            for(index_t i = 0; i < n_values.number_of_children(); i++)
-            {
-                const conduit::Node &n_vals = n_values[i];
-                conduit::blueprint::mesh::utils::slice_array(n_vals, ids, new_values[n_vals.name()]);
-            }
-        }
-        else
-            conduit::blueprint::mesh::utils::slice_array(n_values, ids, new_values);
-    }
-    else
-    {
-        // otherwise, we need to compact our data first
-        conduit::Node n;
-        n_values.compact_to(n);
-        if(n.number_of_children() > 0)
-        {
-            // mcarray.
-            for(index_t i = 0; i < n.number_of_children(); i++)
-            {
-                const conduit::Node &n_vals = n[i];
-                conduit::blueprint::mesh::utils::slice_array(n_vals, ids, new_values[n_vals.name()]);
-            }
-        }
-        else
-            conduit::blueprint::mesh::utils::slice_array(n, ids, new_values);
-    }
+    conduit::blueprint::mesh::utils::slice_field(n_values, ids, new_values);
 }
 
 //---------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -1701,6 +1701,7 @@ Partitioner::Partitioner()
   selections(),
   selected_fields(),
   mapping(true),
+  build_adjsets(true),
   merge_tolerance(1.e-8)
 {
 }
@@ -1978,6 +1979,11 @@ Partitioner::initialize(const conduit::Node &n_mesh,
     // Get whether we want to preserve old numbering of vertices, elements.
     if(options.has_child("mapping"))
         mapping = options["mapping"].to_unsigned_int() != 0;
+
+    // Get whether we want to build adjsets if they are present. This option
+    // lets us ignore them.
+    if(options.has_child("build_adjsets"))
+        build_adjsets = options["build_adjsets"].to_unsigned_int() != 0;
 
     // Get whether we want to preserve old numbering of vertices, elements.
     if(options.has_child("merge_tolerance"))
@@ -4290,9 +4296,20 @@ Partitioner::execute(conduit::Node &output)
     std::vector<int> dest_rank, dest_domain, offsets;
     map_chunks(chunks, dest_rank, dest_domain, offsets);
 
-    init_chunk_adjsets(chunk_assoc_aset, adjset_data);
-    build_interdomain_adjsets(offsets, domain_to_chunk_map, domain_id_to_node, adjset_data);
-    build_intradomain_adjsets(offsets, domain_to_chunk_map, adjset_data);
+    // It is possible that this topology has no associated adjset. If that is true
+    // then the adjset_data will all be nullptr. We skip adjset construction in
+    // that case since some of the routines iterate over all adjsets, even when
+    // they may not apply. We also skip adjset creation if the user turned it off
+    // in the options.
+    size_t nullCount = 0;
+    for(const auto &value : adjset_data)
+        nullCount += (value == nullptr) ? 1 : 0;
+    if(build_adjsets && nullCount < adjset_data.size())
+    {
+        init_chunk_adjsets(chunk_assoc_aset, adjset_data);
+        build_interdomain_adjsets(offsets, domain_to_chunk_map, domain_id_to_node, adjset_data);
+        build_intradomain_adjsets(offsets, domain_to_chunk_map, adjset_data);
+    }
 
     // Communicate chunks to the right destination ranks
     std::vector<Chunk> chunks_to_assemble;

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
@@ -740,6 +740,7 @@ protected:
     std::vector<std::shared_ptr<Selection> > selections;
     std::vector<std::string>                 selected_fields;
     bool                                     mapping;
+    bool                                     build_adjsets;
     double                                   merge_tolerance;
 };
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -379,9 +379,9 @@ find_domain_id(const Node &node)
 // @brief Slice the n_src array using the indices stored in ids. We use the
 //        array classes for their [] operators that deal with interleaved
 //        and non-interleaved arrays.
-template <typename T, typename IndexType>
+template <typename ArrayType, typename IndexType>
 inline void
-typed_slice_array(const T &src, const std::vector<IndexType> &ids, T &dest)
+typed_slice_array(const ArrayType &src, const std::vector<IndexType> &ids, ArrayType &dest)
 {
     size_t n = ids.size();
     for(size_t i = 0; i < n; i++)
@@ -402,6 +402,11 @@ slice_array_internal(const conduit::Node &n_src_values,
     // before copying it in so assigning to n_dest_values triggers a memory
     // allocation.
     auto dt = n_src_values.dtype();
+
+    // Make sure the destination node is reset so the node will get the
+    // right dtype when we reinitialize it below.
+    n_dest_values.reset();
+    // Allocate the new data.
     n_dest_values = DataType(n_src_values.dtype().id(), ids.size());
 
     // Do the slice.
@@ -564,7 +569,7 @@ slice_field_internal(const conduit::Node &n_src_values,
 {
     if(n_src_values.number_of_children() > 0)
     {
-        // Reorder an mcarray
+        // Slice an mcarray
         for(conduit::index_t ci = 0; ci < n_src_values.number_of_children(); ci++)
         {
             const conduit::Node &comp = n_src_values[ci];


### PR DESCRIPTION
The partitioner unconditionally tries to build adjsets. It even seems to try for topologies that have no adjsets (when there are other adjsets present). I added some logic to skip adjset creation when it appears a topology has no relevant adjsets. I also added a "build_adjsets" option to the partitioner options that lets the user outright skip adjset creation.