### PR TITLE
Unscramble face adjsets in to_topo() used in adjset validation program.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Blueprint
 - The `conduit::blueprint::mpi::mesh::partition_map_back()` function was enhanced so it accepts a "field_prefix" value in its options. The prefix is used when looking for the `global_vertex_ids` field, which could have been created with a prefix by the same option in the `conduit::blueprint::mpi::mesh::generate_partition_field()` function.
 - The `conduit::blueprint::mesh::utils::ShapeType` class was enhanced so it can take topologies other than unstructured.
+- The `conduit::blueprint::mesh::utils::topology::unstructured::points()` function was changed so it takes an optional argument that can turn off point uniqueness and sorting so the method can return points for an element as they appear in the connectivity, for non-polyhedral shapes.
 
 ### Fixed
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -555,8 +555,26 @@ namespace topology
         void CONDUIT_BLUEPRINT_API generate_offsets_inline(Node &topo);
 
         //-------------------------------------------------------------------------
+        /**
+         @brief This function returns the points for a specified element index from
+                the given topology. For non-polyhedral element types, the \a unique
+                parameter indicates whether the function will return a unique+sorted
+                vector of point ids. The order can therefore differ from the point
+                order in the connectivity. When \a unique is false, the original
+                cell connectivity is preserved. For polyhedral types, the points
+                are always unique and sorted according to point id.
+
+         @param topo The input topology.
+         @param ei The element index.
+         @param unique Whether points should be unique+sorted. The default is true
+                       to continue earlier behavior.
+
+         @return A vector of point ids for the given element.
+         */
         std::vector<index_t> CONDUIT_BLUEPRINT_API points(const Node &topo,
-                                                          const index_t i);
+                                                          const index_t ei,
+                                                          bool unique = true);
+
         //-------------------------------------------------------------------------
         /**
          * @brief Rewrite the topology's connectivity in terms of the supplied


### PR DESCRIPTION
The adjset validation program can output topologies for adjsets so they can be visualized in VisIt. Element adjsets were getting scrambled because the unstructured::points() function was used to extract an elements points. That function was always returning a unique+sorted list of the points, whereas in this case, we wanted the points in their original order. The unstructured::points() function can now accept a bool argument that lets us select whether we want to get the points unique+sorted or in their original order. I used the new argument to get points in their original order when making a new topology for an element adjset. This makes the validation program output surfaces they way they ought to look.