### PR TITLE
Silo I/O choose matset type on read

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -802,7 +802,6 @@ namespace field
     void CONDUIT_BLUEPRINT_API to_multi_buffer_full(const conduit::Node &src_matset,
                                                     const conduit::Node &src_field,
                                                     const std::string &dest_matset_name,
-                                                    conduit::Node &dest_matset,
                                                     conduit::Node &dest_field);
 
     //-------------------------------------------------------------------------
@@ -810,7 +809,6 @@ namespace field
     void CONDUIT_BLUEPRINT_API to_sparse_by_element(const conduit::Node &src_matset,
                                                     const conduit::Node &src_field,
                                                     const std::string &dest_matset_name,
-                                                    conduit::Node &dest_matset,
                                                     conduit::Node &dest_field,
                                                     const float64 epsilon = CONDUIT_EPSILON);
 
@@ -819,7 +817,6 @@ namespace field
     void CONDUIT_BLUEPRINT_API to_multi_buffer_by_material(const conduit::Node &src_matset,
                                                            const conduit::Node &src_field,
                                                            const std::string &dest_matset_name,
-                                                           conduit::Node &dest_matset,
                                                            conduit::Node &dest_field,
                                                            const float64 epsilon = CONDUIT_EPSILON);
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -506,35 +506,96 @@ to_silo(const conduit::Node &field,
 //-----------------------------------------------------------------------------
 // venn full -> sparse by element
 void
-multi_buffer_by_element_to_uni_buffer_by_element(const conduit::Node &src_matset,
-                                                 const conduit::Node &src_field,
-                                                 const std::string &dest_matset_name,
-                                                 conduit::Node &dest_matset,
-                                                 conduit::Node &dest_field,
-                                                 const float64 epsilon)
+multi_buffer_by_element_to_uni_buffer_by_element_matset(const conduit::Node &src_matset,
+                                                        conduit::Node &dest_matset,
+                                                        const float64 epsilon)
 {
     dest_matset.reset();
-    dest_field.reset();
 
     // set the topology
     dest_matset["topology"].set(src_matset["topology"]);
 
-    if (src_field.dtype().is_object())
+    std::map<int, double_array> full_vol_fracs;
+    // create the material map
+    auto mat_itr = src_matset["volume_fractions"].children();
+    int mat_id = 0;
+    while (mat_itr.has_next())
     {
-        // copy over info from the old field
-        dest_field["association"].set(src_field["association"]);
-        dest_field["topology"].set(src_field["topology"]);
-        dest_field["matset"] = dest_matset_name;
-        dest_field["values"].set(src_field["values"]);
+        const Node &mat_vol_fracs = mat_itr.next();
+        std::string matname = mat_itr.name();
+        full_vol_fracs[mat_id] = mat_vol_fracs.value();
+        dest_matset["material_map"][matname] = mat_id;
+        mat_id ++;
     }
 
-    std::map<int, double_array> full_vol_fracs;
-    std::map<int, double_array> full_matset_vals;
+    const int nmats = dest_matset["material_map"].number_of_children();
 
-    bool mat_dep_field = src_field.has_child("matset_values");
+    std::vector<double> vol_fracs;
+    std::vector<int> mat_ids;
+    std::vector<int> sizes;
+    std::vector<int> offsets;
 
-    if (mat_dep_field)
+    int num_elems = src_matset["volume_fractions"][0].dtype().number_of_elements();
+    int offset = 0;
+
+    for (int elem_id = 0; elem_id < num_elems; elem_id ++)
     {
+        int size = 0;
+        for (int mat_id = 0; mat_id < nmats; mat_id ++)
+        {
+            float64 vol_frac = full_vol_fracs[mat_id][elem_id];
+            if (vol_frac > epsilon)
+            {
+                vol_fracs.push_back(vol_frac);
+                mat_ids.push_back(mat_id);
+                size ++;
+            }
+        }
+        sizes.push_back(size);
+        offsets.push_back(offset);
+        offset += size;
+    }
+
+    dest_matset["volume_fractions"].set(vol_fracs.data(), vol_fracs.size());
+    dest_matset["material_ids"].set(mat_ids.data(), mat_ids.size());
+    dest_matset["sizes"].set(sizes.data(), sizes.size());
+    dest_matset["offsets"].set(offsets.data(), offsets.size());
+}
+
+//-----------------------------------------------------------------------------
+// venn full -> sparse by element
+void
+multi_buffer_by_element_to_uni_buffer_by_element_field(const conduit::Node &src_matset,
+                                                       const conduit::Node &src_field,
+                                                       const std::string &dest_matset_name,
+                                                       conduit::Node &dest_field,
+                                                       const float64 epsilon)
+{
+    dest_field.reset();
+
+    // if this field is material dependent
+    if (src_field.has_child("matset_values"))
+    {
+        // copy over everything except the matset values and matset name
+        auto field_child_itr = src_field.children();
+        while (field_child_itr.has_next())
+        {
+            const Node &n_field_info = field_child_itr.next();
+            std::string field_child_name = field_child_itr.name();
+
+            if (field_child_name != "matset_values" &&
+                field_child_name != "matset")
+            {
+                dest_field[field_child_name].set(n_field_info);
+            }
+        }
+        dest_field["matset"] = dest_matset_name;
+
+        // map material ids to matset values and volume fractions
+        std::map<int, double_array> full_vol_fracs;
+        std::map<int, double_array> full_matset_vals;
+        std::set<int> mat_ids;
+
         // create the material map
         auto mat_itr = src_matset["volume_fractions"].children();
         auto fmat_itr = src_field["matset_values"].children();
@@ -550,120 +611,55 @@ multi_buffer_by_element_to_uni_buffer_by_element(const conduit::Node &src_matset
             CONDUIT_ASSERT(matname == fmatname, "Materials must be ordered the same in "
                 "material dependent fields and their matsets.");
 
-
             full_vol_fracs[mat_id] = mat_vol_fracs.value();
             full_matset_vals[mat_id] = mat_field_vals.value();
-            dest_matset["material_map"][matname] = mat_id;
+            mat_ids.insert(mat_id);
             mat_id ++;
         }
-    }
-    else
-    {
-        // create the material map
-        auto mat_itr = src_matset["volume_fractions"].children();
-        int mat_id = 0;
-        while (mat_itr.has_next())
-        {
-            const Node &mat_vol_fracs = mat_itr.next();
-            std::string matname = mat_itr.name();
-            full_vol_fracs[mat_id] = mat_vol_fracs.value();
-            dest_matset["material_map"][matname] = mat_id;
-            mat_id ++;
-        }
-    }
 
-    const int nmats = dest_matset["material_map"].number_of_children();
+        std::vector<double> matset_values;
 
-    std::vector<double> vol_fracs;
-    std::vector<int> mat_ids;
-    std::vector<int> sizes;
-    std::vector<int> offsets;
-    std::vector<double> matset_values;
+        const int nmats = static_cast<int>(mat_ids.size());
+        int num_elems = src_matset["volume_fractions"][0].dtype().number_of_elements();
 
-    int num_elems = src_matset["volume_fractions"][0].dtype().number_of_elements();
-    int offset = 0;
-
-    if (mat_dep_field)
-    {
         for (int elem_id = 0; elem_id < num_elems; elem_id ++)
         {
             int size = 0;
-            for (int mat_id = 0; mat_id < nmats; mat_id ++)
+            for (mat_id = 0; mat_id < nmats; mat_id ++)
             {
-                float64 vol_frac = full_vol_fracs[mat_id][elem_id];
                 float64 matset_val = full_matset_vals[mat_id][elem_id];
-                if (vol_frac > epsilon)
-                {
-                    vol_fracs.push_back(vol_frac);
-                    matset_values.push_back(matset_val);
-                    mat_ids.push_back(mat_id);
-                    size ++;
-                }
-            }
-            sizes.push_back(size);
-            offsets.push_back(offset);
-            offset += size;
-        }
-    }
-    else
-    {
-        for (int elem_id = 0; elem_id < num_elems; elem_id ++)
-        {
-            int size = 0;
-            for (int mat_id = 0; mat_id < nmats; mat_id ++)
-            {
                 float64 vol_frac = full_vol_fracs[mat_id][elem_id];
                 if (vol_frac > epsilon)
                 {
-                    vol_fracs.push_back(vol_frac);
-                    mat_ids.push_back(mat_id);
+                    matset_values.push_back(matset_val);
                     size ++;
                 }
             }
-            sizes.push_back(size);
-            offsets.push_back(offset);
-            offset += size;
         }
-    }
 
-    dest_matset["volume_fractions"].set(vol_fracs.data(), vol_fracs.size());
-    dest_matset["material_ids"].set(mat_ids.data(), mat_ids.size());
-    dest_matset["sizes"].set(sizes.data(), sizes.size());
-    dest_matset["offsets"].set(offsets.data(), offsets.size());
-
-    if (mat_dep_field)
-    {
         dest_field["matset_values"].set(matset_values.data(), matset_values.size());
+    }
+    else
+    {
+        dest_field.set(src_field);
     }
 }
 
 //-----------------------------------------------------------------------------
 // venn sparse by element -> full
 void
-uni_buffer_by_element_to_multi_buffer_by_element(const conduit::Node &src_matset,
-                                                 const conduit::Node &src_field,
-                                                 const std::string &dest_matset_name,
-                                                 conduit::Node &dest_matset,
-                                                 conduit::Node &dest_field)
+uni_buffer_by_element_to_multi_buffer_by_element_matset(const conduit::Node &src_matset,
+                                                        conduit::Node &dest_matset)
 {
     dest_matset.reset();
-    dest_field.reset();
 
     // set the topology
     dest_matset["topology"].set(src_matset["topology"]);
 
-    if (src_field.dtype().is_object())
-    {
-        // copy over info from the old field
-        dest_field["association"].set(src_field["association"]);
-        dest_field["topology"].set(src_field["topology"]);
-        dest_field["matset"] = dest_matset_name;
-        dest_field["values"].set(src_field["values"]);
-    }
-
     // map material numbers to material names
     std::map<int, std::string> reverse_matmap;
 
+    // fill out map
     auto matmap_itr = src_matset["material_map"].children();
     while (matmap_itr.has_next())
     {
@@ -673,71 +669,36 @@ uni_buffer_by_element_to_multi_buffer_by_element(const conduit::Node &src_matset
         reverse_matmap[matmap_entry.value()] = matname;
     }
 
-    bool mat_dep_field = src_field.has_child("matset_values");
-
-    double_array matset_values;
-    if (mat_dep_field)
-    {
-        matset_values = src_field["matset_values"].value();
-    }
-
+    // get ptr to vol fracs and mat ids
     double_accessor volume_fractions = src_matset["volume_fractions"].value();
     int_accessor material_ids = src_matset["material_ids"].value();
+    
     o2mrelation::O2MIterator o2m_iter(src_matset);
     int num_elems = o2m_iter.elements(o2mrelation::ONE);
 
+    // create container for new vol fracs and initialize sizes
     std::map<std::string, std::vector<double>> new_vol_fracs;
-    std::map<std::string, std::vector<double>> new_matset_vals;
-    if (mat_dep_field)
+    for (auto & mapitem : reverse_matmap)
     {
-        for (auto & mapitem : reverse_matmap)
-        {
-            const std::string &matname = mapitem.second;
-            new_vol_fracs[matname] = std::vector<double>(num_elems);
-            new_matset_vals[matname] = std::vector<double>(num_elems);
-        }
-
-        while (o2m_iter.has_next(o2mrelation::DATA))
-        {
-            index_t elem_id = o2m_iter.next(o2mrelation::ONE);
-            o2m_iter.to_front(o2mrelation::MANY);
-            while (o2m_iter.has_next(o2mrelation::MANY))
-            {
-                o2m_iter.next(o2mrelation::MANY);
-                index_t data_index = o2m_iter.index(o2mrelation::DATA);
-
-                double vol_frac = volume_fractions[data_index];
-                double matset_val = matset_values[data_index];
-                int mat_id = material_ids[data_index];
-                const std::string &matname = reverse_matmap[mat_id];
-                new_vol_fracs[matname][elem_id] = vol_frac;
-                new_matset_vals[matname][elem_id] = matset_val;
-            }
-        }
+        const std::string &matname = mapitem.second;
+        new_vol_fracs[matname] = std::vector<double>(num_elems);
     }
-    else
+
+    // iterate through matset
+    while (o2m_iter.has_next(o2mrelation::DATA))
     {
-        for (auto & mapitem : reverse_matmap)
+        index_t elem_id = o2m_iter.next(o2mrelation::ONE);
+        o2m_iter.to_front(o2mrelation::MANY);
+        while (o2m_iter.has_next(o2mrelation::MANY))
         {
-            const std::string &matname = mapitem.second;
-            new_vol_fracs[matname] = std::vector<double>(num_elems);
-        }
+            o2m_iter.next(o2mrelation::MANY);
+            index_t data_index = o2m_iter.index(o2mrelation::DATA);
 
-        while (o2m_iter.has_next(o2mrelation::DATA))
-        {
-            index_t elem_id = o2m_iter.next(o2mrelation::ONE);
-            o2m_iter.to_front(o2mrelation::MANY);
-            while (o2m_iter.has_next(o2mrelation::MANY))
-            {
-                o2m_iter.next(o2mrelation::MANY);
-                index_t data_index = o2m_iter.index(o2mrelation::DATA);
-
-                double vol_frac = volume_fractions[data_index];
-                int mat_id = material_ids[data_index];
-                const std::string &matname = reverse_matmap[mat_id];
-                new_vol_fracs[matname][elem_id] = vol_frac;
-                
-            }
+            double vol_frac = volume_fractions[data_index];
+            int mat_id = material_ids[data_index];
+            const std::string &matname = reverse_matmap[mat_id];
+            new_vol_fracs[matname][elem_id] = vol_frac;
+            
         }
     }
 
@@ -748,9 +709,81 @@ uni_buffer_by_element_to_multi_buffer_by_element(const conduit::Node &src_matset
 
         dest_matset["volume_fractions"][matname].set(full_vfs.data(), full_vfs.size());
     }
+}
 
-    if (mat_dep_field)
+//-----------------------------------------------------------------------------
+// venn sparse by element -> full
+void
+uni_buffer_by_element_to_multi_buffer_by_element_field(const conduit::Node &src_matset,
+                                                       const conduit::Node &src_field,
+                                                       const std::string &dest_matset_name,
+                                                       conduit::Node &dest_field)
+{
+    dest_field.reset();
+
+    // if this field is material dependent
+    if (src_field.has_child("matset_values"))
     {
+        // copy over everything except the matset values and matset name
+        auto field_child_itr = src_field.children();
+        while (field_child_itr.has_next())
+        {
+            const Node &n_field_info = field_child_itr.next();
+            std::string field_child_name = field_child_itr.name();
+
+            if (field_child_name != "matset_values" &&
+                field_child_name != "matset")
+            {
+                dest_field[field_child_name].set(n_field_info);
+            }
+        }
+        dest_field["matset"] = dest_matset_name;
+
+        // map material numbers to material names
+        std::map<int, std::string> reverse_matmap;
+
+        // fill out map
+        auto matmap_itr = src_matset["material_map"].children();
+        while (matmap_itr.has_next())
+        {
+            const Node &matmap_entry = matmap_itr.next();
+            const std::string matname = matmap_itr.name();
+
+            reverse_matmap[matmap_entry.value()] = matname;
+        }
+
+        // get ptr to matset values and mat ids
+        double_array matset_values = src_field["matset_values"].value();
+        int_accessor material_ids = src_matset["material_ids"].value();
+
+        o2mrelation::O2MIterator o2m_iter(src_matset);
+        int num_elems = o2m_iter.elements(o2mrelation::ONE);
+
+        // create container for new matset vals and initialize sizes
+        std::map<std::string, std::vector<double>> new_matset_vals;
+        for (auto & mapitem : reverse_matmap)
+        {
+            const std::string &matname = mapitem.second;
+            new_matset_vals[matname] = std::vector<double>(num_elems);
+        }
+
+        // iterate through matset
+        while (o2m_iter.has_next(o2mrelation::DATA))
+        {
+            index_t elem_id = o2m_iter.next(o2mrelation::ONE);
+            o2m_iter.to_front(o2mrelation::MANY);
+            while (o2m_iter.has_next(o2mrelation::MANY))
+            {
+                o2m_iter.next(o2mrelation::MANY);
+                index_t data_index = o2m_iter.index(o2mrelation::DATA);
+
+                double matset_val = matset_values[data_index];
+                int mat_id = material_ids[data_index];
+                const std::string &matname = reverse_matmap[mat_id];
+                new_matset_vals[matname][elem_id] = matset_val;
+            }
+        }
+
         for (auto & mapitem : new_matset_vals)
         {
             const std::string &matname = mapitem.first;
@@ -759,35 +792,27 @@ uni_buffer_by_element_to_multi_buffer_by_element(const conduit::Node &src_matset
             dest_field["matset_values"][matname].set(full_msvs.data(), full_msvs.size());
         }
     }
+    else
+    {
+        dest_field.set(src_field);
+    }
 }
 
 //-----------------------------------------------------------------------------
 // venn sparse by element -> sparse by material
 void
-uni_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_matset,
-                                                  const conduit::Node &src_field,
-                                                  const std::string &dest_matset_name,
-                                                  conduit::Node &dest_matset,
-                                                  conduit::Node &dest_field)
+uni_buffer_by_element_to_multi_buffer_by_material_matset(const conduit::Node &src_matset,
+                                                         conduit::Node &dest_matset)
 {
-
     dest_matset.reset();
-    dest_field.reset();
 
     // set the topology
     dest_matset["topology"].set(src_matset["topology"]);
 
-    if (src_field.dtype().is_object())
-    {
-        // copy over info from the old field
-        dest_field["association"].set(src_field["association"]);
-        dest_field["topology"].set(src_field["topology"]);
-        dest_field["matset"] = dest_matset_name;
-        dest_field["values"].set(src_field["values"]);
-    }
-
+    // map material numbers to material names
     std::map<int, std::string> reverse_matmap;
 
+    // fill out map
     auto matmap_itr = src_matset["material_map"].children();
     while (matmap_itr.has_next())
     {
@@ -797,63 +822,32 @@ uni_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_matse
         reverse_matmap[matmap_entry.value()] = matname;
     }
 
-    bool mat_dep_field = src_field.has_child("matset_values");
-
-    double_array matset_values;
-    if (mat_dep_field)
-    {
-        matset_values = src_field["matset_values"].value();
-    }
-
+    // get ptr to vol fracs and mat ids
     double_accessor volume_fractions = src_matset["volume_fractions"].value();
     int_accessor material_ids = src_matset["material_ids"].value();
+    
+    // create containers for new vol fracs and elem ids
     std::map<std::string, std::vector<double>> new_vol_fracs;
-    std::map<std::string, std::vector<double>> new_mset_vals;
     std::map<std::string, std::vector<int>> new_elem_ids;
 
-    if (mat_dep_field)
+    // iterate through matset
+    o2mrelation::O2MIterator o2m_iter(src_matset);
+    while (o2m_iter.has_next(o2mrelation::DATA))
     {
-        o2mrelation::O2MIterator o2m_iter(src_matset);
-        while (o2m_iter.has_next(o2mrelation::DATA))
+        index_t elem_id = o2m_iter.next(o2mrelation::ONE);
+        o2m_iter.to_front(o2mrelation::MANY);
+        while (o2m_iter.has_next(o2mrelation::MANY))
         {
-            index_t elem_id = o2m_iter.next(o2mrelation::ONE);
-            o2m_iter.to_front(o2mrelation::MANY);
-            while (o2m_iter.has_next(o2mrelation::MANY))
-            {
-                o2m_iter.next(o2mrelation::MANY);
-                index_t data_index = o2m_iter.index(o2mrelation::DATA);
+            o2m_iter.next(o2mrelation::MANY);
+            index_t data_index = o2m_iter.index(o2mrelation::DATA);
 
-                double vol_frac = volume_fractions[data_index];
-                double mset_val = matset_values[data_index];
-                int mat_id = material_ids[data_index];
-                const std::string &matname = reverse_matmap[mat_id];
-                
-                new_vol_fracs[matname].push_back(vol_frac);
-                new_mset_vals[matname].push_back(mset_val);
-                new_elem_ids[matname].push_back(elem_id);
-            }
-        }
-    }
-    else
-    {
-        o2mrelation::O2MIterator o2m_iter(src_matset);
-        while (o2m_iter.has_next(o2mrelation::DATA))
-        {
-            index_t elem_id = o2m_iter.next(o2mrelation::ONE);
-            o2m_iter.to_front(o2mrelation::MANY);
-            while (o2m_iter.has_next(o2mrelation::MANY))
-            {
-                o2m_iter.next(o2mrelation::MANY);
-                index_t data_index = o2m_iter.index(o2mrelation::DATA);
-
-                double vol_frac = volume_fractions[data_index];
-                int mat_id = material_ids[data_index];
-                const std::string &matname = reverse_matmap[mat_id];
-                
-                new_vol_fracs[matname].push_back(vol_frac);
-                new_elem_ids[matname].push_back(elem_id);
-                
-            }
+            double vol_frac = volume_fractions[data_index];
+            int mat_id = material_ids[data_index];
+            const std::string &matname = reverse_matmap[mat_id];
+            
+            new_vol_fracs[matname].push_back(vol_frac);
+            new_elem_ids[matname].push_back(elem_id);
+            
         }
     }
 
@@ -872,9 +866,75 @@ uni_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_matse
 
         dest_matset["element_ids"][matname].set(sbm_eids.data(), sbm_eids.size());
     }
+}
 
-    if (mat_dep_field)
+//-----------------------------------------------------------------------------
+// venn sparse by element -> sparse by material
+void
+uni_buffer_by_element_to_multi_buffer_by_material_field(const conduit::Node &src_matset,
+                                                        const conduit::Node &src_field,
+                                                        const std::string &dest_matset_name,
+                                                        conduit::Node &dest_field)
+{
+    dest_field.reset();
+
+    // if this field is material dependent
+    if (src_field.has_child("matset_values"))
     {
+        // copy over everything except the matset values and matset name
+        auto field_child_itr = src_field.children();
+        while (field_child_itr.has_next())
+        {
+            const Node &n_field_info = field_child_itr.next();
+            std::string field_child_name = field_child_itr.name();
+
+            if (field_child_name != "matset_values" &&
+                field_child_name != "matset")
+            {
+                dest_field[field_child_name].set(n_field_info);
+            }
+        }
+        dest_field["matset"] = dest_matset_name;
+
+        // map material numbers to material names
+        std::map<int, std::string> reverse_matmap;
+
+        // fill out map
+        auto matmap_itr = src_matset["material_map"].children();
+        while (matmap_itr.has_next())
+        {
+            const Node &matmap_entry = matmap_itr.next();
+            const std::string matname = matmap_itr.name();
+
+            reverse_matmap[matmap_entry.value()] = matname;
+        }
+
+        // get ptr to matset values and mat ids
+        double_array matset_values = src_field["matset_values"].value();
+        int_accessor material_ids = src_matset["material_ids"].value();
+
+        // create container for new matset vals
+        std::map<std::string, std::vector<double>> new_mset_vals;
+
+        // iterate through matset
+        o2mrelation::O2MIterator o2m_iter(src_matset);
+        while (o2m_iter.has_next(o2mrelation::DATA))
+        {
+            o2m_iter.next(o2mrelation::ONE);
+            o2m_iter.to_front(o2mrelation::MANY);
+            while (o2m_iter.has_next(o2mrelation::MANY))
+            {
+                o2m_iter.next(o2mrelation::MANY);
+                index_t data_index = o2m_iter.index(o2mrelation::DATA);
+
+                double mset_val = matset_values[data_index];
+                int mat_id = material_ids[data_index];
+                const std::string &matname = reverse_matmap[mat_id];
+                
+                new_mset_vals[matname].push_back(mset_val);
+            }
+        }
+
         for (auto & mapitem : new_mset_vals)
         {
             const std::string &matname = mapitem.first;
@@ -883,37 +943,78 @@ uni_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_matse
             dest_field["matset_values"][matname].set(sbm_msvs.data(), sbm_msvs.size());
         }
     }
+    else
+    {
+        dest_field.set(src_field);
+    }
 }
 
 //-----------------------------------------------------------------------------
 // venn full -> sparse_by_material
 void
-multi_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_matset,
-                                                    const conduit::Node &src_field,
-                                                    const std::string &dest_matset_name,
-                                                    conduit::Node &dest_matset,
-                                                    conduit::Node &dest_field,
-                                                    const float64 epsilon)
+multi_buffer_by_element_to_multi_buffer_by_material_matset(const conduit::Node &src_matset,
+                                                           conduit::Node &dest_matset,
+                                                           const float64 epsilon)
 {
     dest_matset.reset();
-    dest_field.reset();
 
     // set the topology
     dest_matset["topology"].set(src_matset["topology"]);
-
-    if (src_field.dtype().is_object())
+    
+    auto mat_itr = src_matset["volume_fractions"].children();
+    while (mat_itr.has_next())
     {
-        // copy over info from the old field
-        dest_field["association"].set(src_field["association"]);
-        dest_field["topology"].set(src_field["topology"]);
-        dest_field["matset"] = dest_matset_name;
-        dest_field["values"].set(src_field["values"]);
+        const Node &mat_vol_fracs = mat_itr.next();
+        std::string matname = mat_itr.name();
+
+        std::vector<double> vol_fracs;
+        std::vector<int> elem_ids;
+
+        double_accessor full_vol_fracs = mat_vol_fracs.value();
+        int num_elems = full_vol_fracs.dtype().number_of_elements();
+        for (int elem_id = 0; elem_id < num_elems; elem_id ++)
+        {
+            if (full_vol_fracs[elem_id] > epsilon)
+            {
+                vol_fracs.push_back(full_vol_fracs[elem_id]);
+                elem_ids.push_back(elem_id);
+            }
+        }
+
+        dest_matset["volume_fractions"][matname].set(vol_fracs.data(), vol_fracs.size());
+        dest_matset["element_ids"][matname].set(elem_ids.data(), elem_ids.size());
     }
+}
 
-    bool mat_dep_field = src_field.has_child("matset_values");
+//-----------------------------------------------------------------------------
+// venn full -> sparse_by_material
+void
+multi_buffer_by_element_to_multi_buffer_by_material_field(const conduit::Node &src_matset,
+                                                          const conduit::Node &src_field,
+                                                          const std::string &dest_matset_name,
+                                                          conduit::Node &dest_field,
+                                                          const float64 epsilon)
+{
+    dest_field.reset();
 
-    if (mat_dep_field)
+    // if this field is material dependent
+    if (src_field.has_child("matset_values"))
     {
+        // copy over everything except the matset values and matset name
+        auto field_child_itr = src_field.children();
+        while (field_child_itr.has_next())
+        {
+            const Node &n_field_info = field_child_itr.next();
+            std::string field_child_name = field_child_itr.name();
+
+            if (field_child_name != "matset_values" &&
+                field_child_name != "matset")
+            {
+                dest_field[field_child_name].set(n_field_info);
+            }
+        }
+        dest_field["matset"] = dest_matset_name;
+
         auto mat_itr = src_matset["volume_fractions"].children();
         auto fmat_itr = src_field["matset_values"].children();
         while (mat_itr.has_next() && fmat_itr.has_next())
@@ -927,8 +1028,6 @@ multi_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_mat
             CONDUIT_ASSERT(matname == fmatname, "Materials must be ordered the same in "
                 "material dependent fields and their matsets.");
 
-            std::vector<double> vol_fracs;
-            std::vector<int> elem_ids;
             std::vector<double> mset_vals;
 
             double_accessor full_vol_fracs = mat_vol_fracs.value();
@@ -938,79 +1037,40 @@ multi_buffer_by_element_to_multi_buffer_by_material(const conduit::Node &src_mat
             {
                 if (full_vol_fracs[elem_id] > epsilon)
                 {
-                    vol_fracs.push_back(full_vol_fracs[elem_id]);
                     mset_vals.push_back(full_mset_vals[elem_id]);
-                    elem_ids.push_back(elem_id);
                 }
             }
 
-            dest_matset["volume_fractions"][matname].set(vol_fracs.data(), vol_fracs.size());
-            dest_matset["element_ids"][matname].set(elem_ids.data(), elem_ids.size());
             dest_field["matset_values"][matname].set(mset_vals.data(), mset_vals.size());
         }
     }
     else
     {
-        auto mat_itr = src_matset["volume_fractions"].children();
-        while (mat_itr.has_next())
-        {
-            const Node &mat_vol_fracs = mat_itr.next();
-            std::string matname = mat_itr.name();
-
-            std::vector<double> vol_fracs;
-            std::vector<int> elem_ids;
-
-            double_accessor full_vol_fracs = mat_vol_fracs.value();
-            int num_elems = full_vol_fracs.dtype().number_of_elements();
-            for (int elem_id = 0; elem_id < num_elems; elem_id ++)
-            {
-                if (full_vol_fracs[elem_id] > epsilon)
-                {
-                    vol_fracs.push_back(full_vol_fracs[elem_id]);
-                    elem_ids.push_back(elem_id);
-                }
-            }
-
-            dest_matset["volume_fractions"][matname].set(vol_fracs.data(), vol_fracs.size());
-            dest_matset["element_ids"][matname].set(elem_ids.data(), elem_ids.size());
-        }
+        dest_field.set(src_field);
     }
 }
 
 //-----------------------------------------------------------------------------
 // venn sparse by material -> full
 void
-multi_buffer_by_material_to_multi_buffer_by_element(const conduit::Node &src_matset,
-                                                    const conduit::Node &src_field,
-                                                    const std::string &dest_matset_name,
-                                                    conduit::Node &dest_matset,
-                                                    conduit::Node &dest_field)
+multi_buffer_by_material_to_multi_buffer_by_element_matset(const conduit::Node &src_matset,
+                                                           conduit::Node &dest_matset)
 {
     dest_matset.reset();
-    dest_field.reset();
 
     // set the topology
     dest_matset["topology"].set(src_matset["topology"]);
 
-    if (src_field.dtype().is_object())
-    {
-        // copy over info from the old field
-        dest_field["association"].set(src_field["association"]);
-        dest_field["topology"].set(src_field["topology"]);
-        dest_field["matset"] = dest_matset_name;
-        dest_field["values"].set(src_field["values"]);
-    }
-
     // sparse by material representation
-    // we map material names to volume fractions, element ids, and matset values
-    std::map<std::string, std::tuple<double_array, int_array, double_array>> sbm_rep;
+    // we map material names to volume fractions and element ids
+    std::map<std::string, std::pair<double_array, int_array>> sbm_rep;
 
     auto vf_itr = src_matset["volume_fractions"].children();
     while (vf_itr.has_next())
     {
         const Node &mat_vol_fracs = vf_itr.next();
         const std::string matname = vf_itr.name();
-        std::get<0>(sbm_rep[matname]) = mat_vol_fracs.value();
+        sbm_rep[matname].first = mat_vol_fracs.value();
     }
 
     auto eid_itr = src_matset["element_ids"].children();
@@ -1018,20 +1078,7 @@ multi_buffer_by_material_to_multi_buffer_by_element(const conduit::Node &src_mat
     {
         const Node &mat_elem_ids = eid_itr.next();
         const std::string matname = eid_itr.name();
-        std::get<1>(sbm_rep[matname]) = mat_elem_ids.value();
-    }
-
-    bool mat_dep_field = src_field.has_child("matset_values");
-
-    if (mat_dep_field)
-    {
-        auto mvals_itr = src_field["matset_values"].children();
-        while (mvals_itr.has_next())
-        {
-            const Node &matset_vals = mvals_itr.next();
-            const std::string matname = mvals_itr.name();
-            std::get<2>(sbm_rep[matname]) = matset_vals.value();
-        }
+        sbm_rep[matname].second = mat_elem_ids.value();
     }
 
     // load the element ids into a set to find out how many there are
@@ -1057,84 +1104,138 @@ multi_buffer_by_material_to_multi_buffer_by_element(const conduit::Node &src_mat
 
     const int num_elems = determine_num_elems(src_matset["element_ids"]);
 
-    if (mat_dep_field)
+    for (auto &mapitem : sbm_rep)
     {
+        std::vector<double> vol_fracs(num_elems, 0.0);
+        
+        const std::string &matname = mapitem.first;
+        double_array sbm_vfs = std::get<0>(mapitem.second);
+        int_array sbm_eids = std::get<1>(mapitem.second);
+        
+        int num_vf = sbm_vfs.dtype().number_of_elements();
+        for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
+        {
+            int elem_id = sbm_eids[mat_vf_id];
+            double vol_frac = sbm_vfs[mat_vf_id];
+
+            vol_fracs[elem_id] = vol_frac;
+        }
+
+        dest_matset["volume_fractions"][matname].set(vol_fracs.data(), vol_fracs.size());
+    }
+}
+
+//-----------------------------------------------------------------------------
+// venn sparse by material -> full
+void
+multi_buffer_by_material_to_multi_buffer_by_element_field(const conduit::Node &src_matset,
+                                                          const conduit::Node &src_field,
+                                                          const std::string &dest_matset_name,
+                                                          conduit::Node &dest_field)
+{
+    dest_field.reset();
+
+    // if this field is material dependent
+    if (src_field.has_child("matset_values"))
+    {
+        // copy over everything except the matset values and matset name
+        auto field_child_itr = src_field.children();
+        while (field_child_itr.has_next())
+        {
+            const Node &n_field_info = field_child_itr.next();
+            std::string field_child_name = field_child_itr.name();
+
+            if (field_child_name != "matset_values" &&
+                field_child_name != "matset")
+            {
+                dest_field[field_child_name].set(n_field_info);
+            }
+        }
+        dest_field["matset"] = dest_matset_name;
+
+        // sparse by material representation
+        // we map material names to element ids and matset values
+        std::map<std::string, std::pair<int_array, double_array>> sbm_rep;
+
+        auto eid_itr = src_matset["element_ids"].children();
+        while (eid_itr.has_next())
+        {
+            const Node &mat_elem_ids = eid_itr.next();
+            const std::string matname = eid_itr.name();
+            sbm_rep[matname].first = mat_elem_ids.value();
+        }
+
+        auto mvals_itr = src_field["matset_values"].children();
+        while (mvals_itr.has_next())
+        {
+            const Node &matset_vals = mvals_itr.next();
+            const std::string matname = mvals_itr.name();
+            sbm_rep[matname].second = matset_vals.value();
+        }
+
+        // load the element ids into a set to find out how many there are
+        auto determine_num_elems = [](const conduit::Node &elem_ids)
+        {
+            std::set<int> elem_ids_set;
+
+            auto eid_itr = elem_ids.children();
+            while (eid_itr.has_next())
+            {
+                const Node &mat_elem_ids = eid_itr.next();
+                const std::string matname = eid_itr.name();
+                int_accessor mat_elem_ids_vals = mat_elem_ids.value();
+                int num_vf = mat_elem_ids_vals.dtype().number_of_elements();
+                for (int i = 0; i < num_vf; i ++)
+                {
+                    elem_ids_set.insert(mat_elem_ids_vals[i]);
+                }
+            }
+
+            return static_cast<int>(elem_ids_set.size());
+        };
+
+        const int num_elems = determine_num_elems(src_matset["element_ids"]);
+
         for (auto &mapitem : sbm_rep)
         {
-            std::vector<double> vol_fracs(num_elems, 0.0);
             std::vector<double> mset_vals(num_elems, 0.0);
             
             const std::string &matname = mapitem.first;
-            double_array sbm_vfs = std::get<0>(mapitem.second);
-            int_array sbm_eids = std::get<1>(mapitem.second);
-            double_array sbm_mvals = std::get<2>(mapitem.second);
+            int_array sbm_eids = mapitem.second.first;
+            double_array sbm_mvals = mapitem.second.second;
             
-            int num_vf = sbm_vfs.dtype().number_of_elements();
+            int num_vf = sbm_mvals.dtype().number_of_elements();
             for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
             {
                 int elem_id = sbm_eids[mat_vf_id];
-                double vol_frac = sbm_vfs[mat_vf_id];
                 double mset_val = sbm_mvals[mat_vf_id];
 
-                vol_fracs[elem_id] = vol_frac;
                 mset_vals[elem_id] = mset_val;
             }
 
-            dest_matset["volume_fractions"][matname].set(vol_fracs.data(), vol_fracs.size());
             dest_field["matset_values"][matname].set(mset_vals.data(), mset_vals.size());
         }
     }
     else
     {
-        for (auto &mapitem : sbm_rep)
-        {
-            std::vector<double> vol_fracs(num_elems, 0.0);
-            
-            const std::string &matname = mapitem.first;
-            double_array sbm_vfs = std::get<0>(mapitem.second);
-            int_array sbm_eids = std::get<1>(mapitem.second);
-            
-            int num_vf = sbm_vfs.dtype().number_of_elements();
-            for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
-            {
-                int elem_id = sbm_eids[mat_vf_id];
-                double vol_frac = sbm_vfs[mat_vf_id];
-
-                vol_fracs[elem_id] = vol_frac;
-            }
-
-            dest_matset["volume_fractions"][matname].set(vol_fracs.data(), vol_fracs.size());
-        }
+        dest_field.set(src_field);
     }
 }
 
 //-----------------------------------------------------------------------------
 // venn sparse by material -> sparse by element
 void
-multi_buffer_by_material_to_uni_buffer_by_element(const conduit::Node &src_matset,
-                                                  const conduit::Node &src_field,
-                                                  const std::string &dest_matset_name,
-                                                  conduit::Node &dest_matset,
-                                                  conduit::Node &dest_field)
+multi_buffer_by_material_to_uni_buffer_by_element_matset(const conduit::Node &src_matset,
+                                                         conduit::Node &dest_matset)
 {
     dest_matset.reset();
-    dest_field.reset();
 
     // set the topology
     dest_matset["topology"].set(src_matset["topology"]);
 
-    if (src_field.dtype().is_object())
-    {
-        // copy over info from the old field
-        dest_field["association"].set(src_field["association"]);
-        dest_field["topology"].set(src_field["topology"]);
-        dest_field["matset"] = dest_matset_name;
-        dest_field["values"].set(src_field["values"]);
-    }
-
     // sparse by material representation
-    // we map material names to volume fractions, element ids, and matset values
-    std::map<std::string, std::tuple<double_array, int_array, double_array>> sbm_rep;
+    // we map material names to volume fractions and element ids
+    std::map<std::string, std::pair<double_array, int_array>> sbm_rep;
     std::map<std::string, int> matmap;
 
     int mat_id = 0;
@@ -1143,7 +1244,7 @@ multi_buffer_by_material_to_uni_buffer_by_element(const conduit::Node &src_matse
     {
         const Node &mat_vol_fracs = vf_itr.next();
         const std::string matname = vf_itr.name();
-        std::get<0>(sbm_rep[matname]) = mat_vol_fracs.value();
+        sbm_rep[matname].first = mat_vol_fracs.value();
         dest_matset["material_map"][matname] = mat_id;
         matmap[matname] = mat_id;
         mat_id ++;
@@ -1154,20 +1255,7 @@ multi_buffer_by_material_to_uni_buffer_by_element(const conduit::Node &src_matse
     {
         const Node &mat_elem_ids = eid_itr.next();
         const std::string matname = eid_itr.name();
-        std::get<1>(sbm_rep[matname]) = mat_elem_ids.value();
-    }
-
-    bool mat_dep_field = src_field.has_child("matset_values");
-
-    if (mat_dep_field)
-    {
-        auto mvals_itr = src_field["matset_values"].children();
-        while (mvals_itr.has_next())
-        {
-            const Node &matset_vals = mvals_itr.next();
-            const std::string matname = mvals_itr.name();
-            std::get<2>(sbm_rep[matname]) = matset_vals.value();
-        }
+        sbm_rep[matname].second = mat_elem_ids.value();
     }
 
     // load the element ids into a set to find out how many there are
@@ -1198,51 +1286,23 @@ multi_buffer_by_material_to_uni_buffer_by_element(const conduit::Node &src_matse
     // in which volume fractions are packed by element. Later we smooth this out.
     std::vector<std::vector<double>> intermediate_vol_fracs(num_elems);
     std::vector<std::vector<int>> intermediate_mat_ids(num_elems);
-    std::vector<std::vector<double>> intermediate_mset_vals(num_elems);
 
-    if (mat_dep_field)
+    for (auto &mapitem : sbm_rep)
     {
-        for (auto &mapitem : sbm_rep)
+        const std::string &matname = mapitem.first;
+        int mat_id = matmap[matname];
+
+        double_array sbm_vfs = std::get<0>(mapitem.second);
+        int_array sbm_eids = std::get<1>(mapitem.second);
+        
+        int num_vf = sbm_vfs.dtype().number_of_elements();
+        for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
         {
-            const std::string &matname = mapitem.first;
-            int mat_id = matmap[matname];
+            int elem_id = sbm_eids[mat_vf_id];
+            double vol_frac = sbm_vfs[mat_vf_id];
 
-            double_array sbm_vfs = std::get<0>(mapitem.second);
-            int_array sbm_eids = std::get<1>(mapitem.second);
-            double_array sbm_mvals = std::get<2>(mapitem.second);
-            
-            int num_vf = sbm_vfs.dtype().number_of_elements();
-            for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
-            {
-                int elem_id = sbm_eids[mat_vf_id];
-                double vol_frac = sbm_vfs[mat_vf_id];
-                double mset_val = sbm_mvals[mat_vf_id];
-
-                intermediate_vol_fracs[elem_id].push_back(vol_frac);
-                intermediate_mset_vals[elem_id].push_back(mset_val);
-                intermediate_mat_ids[elem_id].push_back(mat_id);
-            }
-        }
-    }
-    else
-    {
-        for (auto &mapitem : sbm_rep)
-        {
-            const std::string &matname = mapitem.first;
-            int mat_id = matmap[matname];
-
-            double_array sbm_vfs = std::get<0>(mapitem.second);
-            int_array sbm_eids = std::get<1>(mapitem.second);
-            
-            int num_vf = sbm_vfs.dtype().number_of_elements();
-            for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
-            {
-                int elem_id = sbm_eids[mat_vf_id];
-                double vol_frac = sbm_vfs[mat_vf_id];
-
-                intermediate_vol_fracs[elem_id].push_back(vol_frac);
-                intermediate_mat_ids[elem_id].push_back(mat_id);
-            }
+            intermediate_vol_fracs[elem_id].push_back(vol_frac);
+            intermediate_mat_ids[elem_id].push_back(mat_id);
         }
     }
 
@@ -1250,179 +1310,137 @@ multi_buffer_by_material_to_uni_buffer_by_element(const conduit::Node &src_matse
     std::vector<int> mat_ids;
     std::vector<int> sizes;
     std::vector<int> offsets;
-    std::vector<double> mset_vals;
 
-    if (mat_dep_field)
+    // final pass
+    int offset = 0;
+    for (int elem_id = 0; elem_id < num_elems; elem_id ++)
     {
-        // final pass
-        int offset = 0;
-        for (int elem_id = 0; elem_id < num_elems; elem_id ++)
+        int size = static_cast<int>(intermediate_vol_fracs[elem_id].size());
+        for (int mat_vf_id = 0; mat_vf_id < size; mat_vf_id ++)
         {
-            int size = static_cast<int>(intermediate_vol_fracs[elem_id].size());
-            for (int mat_vf_id = 0; mat_vf_id < size; mat_vf_id ++)
-            {
-                vol_fracs.push_back(intermediate_vol_fracs[elem_id][mat_vf_id]);
-                mset_vals.push_back(intermediate_mset_vals[elem_id][mat_vf_id]);
-                mat_ids.push_back(intermediate_mat_ids[elem_id][mat_vf_id]);
-            }
-            sizes.push_back(size);
-            offsets.push_back(offset);
-            offset += size;
+            vol_fracs.push_back(intermediate_vol_fracs[elem_id][mat_vf_id]);
+            mat_ids.push_back(intermediate_mat_ids[elem_id][mat_vf_id]);
         }
+        sizes.push_back(size);
+        offsets.push_back(offset);
+        offset += size;
     }
-    else
-    {
-        // final pass
-        int offset = 0;
-        for (int elem_id = 0; elem_id < num_elems; elem_id ++)
-        {
-            int size = static_cast<int>(intermediate_vol_fracs[elem_id].size());
-            for (int mat_vf_id = 0; mat_vf_id < size; mat_vf_id ++)
-            {
-                vol_fracs.push_back(intermediate_vol_fracs[elem_id][mat_vf_id]);
-                mat_ids.push_back(intermediate_mat_ids[elem_id][mat_vf_id]);
-            }
-            sizes.push_back(size);
-            offsets.push_back(offset);
-            offset += size;
-        }
-    }
+
 
     dest_matset["volume_fractions"].set(vol_fracs.data(), vol_fracs.size());
     dest_matset["material_ids"].set(mat_ids.data(), mat_ids.size());
     dest_matset["sizes"].set(sizes.data(), sizes.size());
     dest_matset["offsets"].set(offsets.data(), offsets.size());
+}
 
-    if (mat_dep_field)
+//-----------------------------------------------------------------------------
+// venn sparse by material -> sparse by element
+void
+multi_buffer_by_material_to_uni_buffer_by_element_field(const conduit::Node &src_matset,
+                                                        const conduit::Node &src_field,
+                                                        const std::string &dest_matset_name,
+                                                        conduit::Node &dest_field)
+{
+    dest_field.reset();
+
+    // if this field is material dependent
+    if (src_field.has_child("matset_values"))
     {
+        // copy over everything except the matset values and matset name
+        auto field_child_itr = src_field.children();
+        while (field_child_itr.has_next())
+        {
+            const Node &n_field_info = field_child_itr.next();
+            std::string field_child_name = field_child_itr.name();
+
+            if (field_child_name != "matset_values" &&
+                field_child_name != "matset")
+            {
+                dest_field[field_child_name].set(n_field_info);
+            }
+        }
+        dest_field["matset"] = dest_matset_name;
+
+        // sparse by material representation
+        // we map material names to element ids and matset values
+        std::map<std::string, std::pair<int_array, double_array>> sbm_rep;
+
+        auto eid_itr = src_matset["element_ids"].children();
+        while (eid_itr.has_next())
+        {
+            const Node &mat_elem_ids = eid_itr.next();
+            const std::string matname = eid_itr.name();
+            sbm_rep[matname].first = mat_elem_ids.value();
+        }
+
+        auto mvals_itr = src_field["matset_values"].children();
+        while (mvals_itr.has_next())
+        {
+            const Node &matset_vals = mvals_itr.next();
+            const std::string matname = mvals_itr.name();
+            sbm_rep[matname].second = matset_vals.value();
+        }
+
+        // load the element ids into a set to find out how many there are
+        auto determine_num_elems = [](const conduit::Node &elem_ids)
+        {
+            std::set<int> elem_ids_set;
+
+            auto eid_itr = elem_ids.children();
+            while (eid_itr.has_next())
+            {
+                const Node &mat_elem_ids = eid_itr.next();
+                const std::string matname = eid_itr.name();
+                int_accessor mat_elem_ids_vals = mat_elem_ids.value();
+                int num_vf = mat_elem_ids_vals.dtype().number_of_elements();
+                for (int i = 0; i < num_vf; i ++)
+                {
+                    elem_ids_set.insert(mat_elem_ids_vals[i]);
+                }
+            }
+
+            return static_cast<int>(elem_ids_set.size());
+        };
+
+        const int num_elems = determine_num_elems(src_matset["element_ids"]);
+
+        // There is no way to pack the matset values correctly without
+        // first knowing the sizes. So we create an intermediate representation
+        // in which matset values are packed by element. Later we smooth this out.
+        std::vector<std::vector<double>> intermediate_mset_vals(num_elems);
+
+        for (auto &mapitem : sbm_rep)
+        {
+            int_array sbm_eids = mapitem.second.first;
+            double_array sbm_mvals = mapitem.second.second;
+            
+            int num_vf = sbm_mvals.dtype().number_of_elements();
+            for (int mat_vf_id = 0; mat_vf_id < num_vf; mat_vf_id ++)
+            {
+                int elem_id = sbm_eids[mat_vf_id];
+                double mset_val = sbm_mvals[mat_vf_id];
+
+                intermediate_mset_vals[elem_id].push_back(mset_val);
+            }
+        }
+
+        std::vector<double> mset_vals;
+
+        // final pass
+        for (int elem_id = 0; elem_id < num_elems; elem_id ++)
+        {
+            int size = static_cast<int>(intermediate_mset_vals[elem_id].size());
+            for (int mat_vf_id = 0; mat_vf_id < size; mat_vf_id ++)
+            {
+                mset_vals.push_back(intermediate_mset_vals[elem_id][mat_vf_id]);
+            }
+        }
+
         dest_field["matset_values"].set(mset_vals.data(), mset_vals.size());
     }
-}
-
-//-----------------------------------------------------------------------------
-void
-to_multi_buffer_full(const conduit::Node &src_matset,
-                     const conduit::Node &src_field,
-                     const std::string &dest_matset_name,
-                     conduit::Node &dest_matset,
-                     conduit::Node &dest_field)
-{
-    // full
-    if (is_element_dominant(src_matset) && is_multi_buffer(src_matset))
-    {
-        // nothing to do
-        dest_matset.set(src_matset);
-        dest_field.set(src_field);
-        dest_field["matset"].reset();
-        dest_field["matset"] = dest_matset_name;
-    }
-    // sparse_by_element
-    else if (is_element_dominant(src_matset))
-    {
-        detail::uni_buffer_by_element_to_multi_buffer_by_element(src_matset, 
-                                                                 src_field, 
-                                                                 dest_matset_name,
-                                                                 dest_matset,
-                                                                 dest_field);
-    }
-    // sparse_by_material
-    else if (is_material_dominant(src_matset))
-    {
-        detail::multi_buffer_by_material_to_multi_buffer_by_element(src_matset,
-                                                                    src_field,
-                                                                    dest_matset_name,
-                                                                    dest_matset,
-                                                                    dest_field);
-    }
     else
     {
-        CONDUIT_ERROR("Unknown matset type.");
-    }
-}
-
-//-----------------------------------------------------------------------------
-void
-to_sparse_by_element(const conduit::Node &src_matset,
-                     const conduit::Node &src_field,
-                     const std::string &dest_matset_name,
-                     conduit::Node &dest_matset,
-                     conduit::Node &dest_field,
-                     const float64 epsilon)
-{
-    // full
-    if (is_element_dominant(src_matset) && is_multi_buffer(src_matset))
-    {
-        detail::multi_buffer_by_element_to_uni_buffer_by_element(src_matset, 
-                                                                 src_field,
-                                                                 dest_matset_name,
-                                                                 dest_matset, 
-                                                                 dest_field,
-                                                                 epsilon);
-    }
-    // sparse_by_element
-    else if (is_element_dominant(src_matset))
-    {
-        // nothing to do
-        dest_matset.set(src_matset);
         dest_field.set(src_field);
-        dest_field["matset"].reset();
-        dest_field["matset"] = dest_matset_name;
-    }
-    // sparse_by_material
-    else if (is_material_dominant(src_matset))
-    {
-        detail::multi_buffer_by_material_to_uni_buffer_by_element(src_matset,
-                                                                  src_field,
-                                                                  dest_matset_name,
-                                                                  dest_matset,
-                                                                  dest_field);
-    }
-    else
-    {
-        CONDUIT_ERROR("Unknown matset type.");
-    }
-}
-
-//-----------------------------------------------------------------------------
-void
-to_multi_buffer_by_material(const conduit::Node &src_matset,
-                            const conduit::Node &src_field,
-                            const std::string &dest_matset_name,
-                            conduit::Node &dest_matset,
-                            conduit::Node &dest_field,
-                            const float64 epsilon)
-{
-    // full
-    if (is_element_dominant(src_matset) && is_multi_buffer(src_matset))
-    {
-        detail::multi_buffer_by_element_to_multi_buffer_by_material(src_matset, 
-                                                                    src_field,
-                                                                    dest_matset_name,
-                                                                    dest_matset, 
-                                                                    dest_field,
-                                                                    epsilon);
-    }
-    // sparse_by_element
-    else if (is_element_dominant(src_matset))
-    {
-        detail::uni_buffer_by_element_to_multi_buffer_by_material(src_matset,
-                                                                  src_field,
-                                                                  dest_matset_name,
-                                                                  dest_matset,
-                                                                  dest_field);
-    }
-    // sparse_by_material
-    else if (is_material_dominant(src_matset))
-    {
-        // nothing to do
-        dest_matset.set(src_matset);
-        dest_field.set(src_field);
-        dest_field["matset"].reset();
-        dest_field["matset"] = dest_matset_name;
-    }
-    else
-    {
-        CONDUIT_ERROR("Unknown matset type.");
     }
 }
 
@@ -1467,14 +1485,28 @@ to_multi_buffer_full(const conduit::Node &src_matset,
                       " passed matset node must be a valid matset tree.");
     }
 
-    conduit::Node src_field, dest_field;
-    std::string dest_matset_name = "";
-
-    detail::to_multi_buffer_full(src_matset,
-                                 src_field,
-                                 dest_matset_name,
-                                 dest_matset,
-                                 dest_field);
+    // full
+    if (is_element_dominant(src_matset) && is_multi_buffer(src_matset))
+    {
+        // nothing to do
+        dest_matset.set(src_matset);
+    }
+    // sparse_by_element
+    else if (is_element_dominant(src_matset))
+    {
+        detail::uni_buffer_by_element_to_multi_buffer_by_element_matset(src_matset, 
+                                                                        dest_matset);
+    }
+    // sparse_by_material
+    else if (is_material_dominant(src_matset))
+    {
+        detail::multi_buffer_by_material_to_multi_buffer_by_element_matset(src_matset,
+                                                                           dest_matset);
+    }
+    else
+    {
+        CONDUIT_ERROR("Unknown matset type.");
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -1490,15 +1522,29 @@ to_sparse_by_element(const conduit::Node &src_matset,
                       " passed matset node must be a valid matset tree.");
     }
 
-    conduit::Node src_field, dest_field;
-    std::string dest_matset_name = "";
-
-    detail::to_sparse_by_element(src_matset,
-                                 src_field,
-                                 dest_matset_name,
-                                 dest_matset,
-                                 dest_field,
-                                 epsilon);
+    // full
+    if (is_element_dominant(src_matset) && is_multi_buffer(src_matset))
+    {
+        detail::multi_buffer_by_element_to_uni_buffer_by_element_matset(src_matset, 
+                                                                        dest_matset, 
+                                                                        epsilon);
+    }
+    // sparse_by_element
+    else if (is_element_dominant(src_matset))
+    {
+        // nothing to do
+        dest_matset.set(src_matset);
+    }
+    // sparse_by_material
+    else if (is_material_dominant(src_matset))
+    {
+        detail::multi_buffer_by_material_to_uni_buffer_by_element_matset(src_matset,
+                                                                         dest_matset);
+    }
+    else
+    {
+        CONDUIT_ERROR("Unknown matset type.");
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -1514,15 +1560,29 @@ to_multi_buffer_by_material(const conduit::Node &src_matset,
                       " passed matset node must be a valid matset tree.");
     }
 
-    conduit::Node src_field, dest_field;
-    std::string dest_matset_name = "";
-
-    detail::to_multi_buffer_by_material(src_matset,
-                                        src_field,
-                                        dest_matset_name,
-                                        dest_matset,
-                                        dest_field,
-                                        epsilon);
+    // full
+    if (is_element_dominant(src_matset) && is_multi_buffer(src_matset))
+    {
+        detail::multi_buffer_by_element_to_multi_buffer_by_material_matset(src_matset, 
+                                                                           dest_matset, 
+                                                                           epsilon);
+    }
+    // sparse_by_element
+    else if (is_element_dominant(src_matset))
+    {
+        detail::uni_buffer_by_element_to_multi_buffer_by_material_matset(src_matset,
+                                                                         dest_matset);
+    }
+    // sparse_by_material
+    else if (is_material_dominant(src_matset))
+    {
+        // nothing to do
+        dest_matset.set(src_matset);
+    }
+    else
+    {
+        CONDUIT_ERROR("Unknown matset type.");
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -1572,7 +1632,6 @@ void
 to_multi_buffer_full(const conduit::Node &src_matset,
                      const conduit::Node &src_field,
                      const std::string &dest_matset_name,
-                     conduit::Node &dest_matset,
                      conduit::Node &dest_field)
 {
     // extra seat belt here
@@ -1585,14 +1644,34 @@ to_multi_buffer_full(const conduit::Node &src_matset,
     if (! src_field.dtype().is_object())
     {
         CONDUIT_ERROR("blueprint::mesh::field::to_multi_buffer_full"
-                      " passed field node must be a valid matset tree.");
+                      " passed field node must be a valid field tree.");
     }
 
-    conduit::blueprint::mesh::matset::detail::to_multi_buffer_full(src_matset,
-                                                                   src_field,
-                                                                   dest_matset_name,
-                                                                   dest_matset,
-                                                                   dest_field);
+    // full
+    if (conduit::blueprint::mesh::matset::is_element_dominant(src_matset) && 
+        conduit::blueprint::mesh::matset::is_multi_buffer(src_matset))
+    {
+        // nothing to do
+        dest_field.set(src_field);
+        dest_field["matset"].reset();
+        dest_field["matset"] = dest_matset_name;
+    }
+    // sparse_by_element
+    else if (conduit::blueprint::mesh::matset::is_element_dominant(src_matset))
+    {
+        conduit::blueprint::mesh::matset::detail::uni_buffer_by_element_to_multi_buffer_by_element_field(
+            src_matset, src_field, dest_matset_name, dest_field);
+    }
+    // sparse_by_material
+    else if (conduit::blueprint::mesh::matset::is_material_dominant(src_matset))
+    {
+        conduit::blueprint::mesh::matset::detail::multi_buffer_by_material_to_multi_buffer_by_element_field(
+            src_matset, src_field, dest_matset_name, dest_field);
+    }
+    else
+    {
+        CONDUIT_ERROR("Unknown matset type.");
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -1600,7 +1679,6 @@ void
 to_sparse_by_element(const conduit::Node &src_matset,
                      const conduit::Node &src_field,
                      const std::string &dest_matset_name,
-                     conduit::Node &dest_matset,
                      conduit::Node &dest_field,
                      const float64 epsilon)
 {
@@ -1614,15 +1692,34 @@ to_sparse_by_element(const conduit::Node &src_matset,
     if (! src_field.dtype().is_object())
     {
         CONDUIT_ERROR("blueprint::mesh::field::to_sparse_by_element"
-                      " passed field node must be a valid matset tree.");
+                      " passed field node must be a valid field tree.");
     }
 
-    conduit::blueprint::mesh::matset::detail::to_sparse_by_element(src_matset,
-                                                                   src_field,
-                                                                   dest_matset_name,
-                                                                   dest_matset,
-                                                                   dest_field,
-                                                                   epsilon);
+    // full
+    if (conduit::blueprint::mesh::matset::is_element_dominant(src_matset) && 
+        conduit::blueprint::mesh::matset::is_multi_buffer(src_matset))
+    {
+        conduit::blueprint::mesh::matset::detail::multi_buffer_by_element_to_uni_buffer_by_element_field(
+            src_matset, src_field, dest_matset_name, dest_field, epsilon);
+    }
+    // sparse_by_element
+    else if (conduit::blueprint::mesh::matset::is_element_dominant(src_matset))
+    {
+        // nothing to do
+        dest_field.set(src_field);
+        dest_field["matset"].reset();
+        dest_field["matset"] = dest_matset_name;
+    }
+    // sparse_by_material
+    else if (conduit::blueprint::mesh::matset::is_material_dominant(src_matset))
+    {
+        conduit::blueprint::mesh::matset::detail::multi_buffer_by_material_to_uni_buffer_by_element_field(
+            src_matset, src_field, dest_matset_name, dest_field);
+    }
+    else
+    {
+        CONDUIT_ERROR("Unknown matset type.");
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -1630,7 +1727,6 @@ void
 to_multi_buffer_by_material(const conduit::Node &src_matset,
                             const conduit::Node &src_field,
                             const std::string &dest_matset_name,
-                            conduit::Node &dest_matset,
                             conduit::Node &dest_field,
                             const float64 epsilon)
 {
@@ -1644,15 +1740,34 @@ to_multi_buffer_by_material(const conduit::Node &src_matset,
     if (! src_field.dtype().is_object())
     {
         CONDUIT_ERROR("blueprint::mesh::field::to_multi_buffer_by_material"
-                      " passed field node must be a valid matset tree.");
+                      " passed field node must be a valid field tree.");
     }
 
-    conduit::blueprint::mesh::matset::detail::to_multi_buffer_by_material(src_matset,
-                                                                          src_field,
-                                                                          dest_matset_name,
-                                                                          dest_matset,
-                                                                          dest_field,
-                                                                          epsilon);
+    // full
+    if (conduit::blueprint::mesh::matset::is_element_dominant(src_matset) && 
+        conduit::blueprint::mesh::matset::is_multi_buffer(src_matset))
+    {
+        conduit::blueprint::mesh::matset::detail::multi_buffer_by_element_to_multi_buffer_by_material_field(
+            src_matset, src_field, dest_matset_name, dest_field, epsilon);
+    }
+    // sparse_by_element
+    else if (conduit::blueprint::mesh::matset::is_element_dominant(src_matset))
+    {
+        conduit::blueprint::mesh::matset::detail::uni_buffer_by_element_to_multi_buffer_by_material_field(
+            src_matset, src_field, dest_matset_name, dest_field);
+    }
+    // sparse_by_material
+    else if (conduit::blueprint::mesh::matset::is_material_dominant(src_matset))
+    {
+        // nothing to do
+        dest_field.set(src_field);
+        dest_field["matset"].reset();
+        dest_field["matset"] = dest_matset_name;
+    }
+    else
+    {
+        CONDUIT_ERROR("Unknown matset type.");
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -1541,9 +1541,6 @@ read_variable_domain(const int vartype,
         // collect the sparse by element matset we generated
         const Node &original_matset = matset_field_reconstruction["original_matset"];
 
-        // a throwaway to make the transform happy
-        Node dest_matset;
-
         if (opts_matset_style == "default" || opts_matset_style == "sparse_by_element")
         {
             field_out.move(intermediate_field);
@@ -1553,7 +1550,6 @@ read_variable_domain(const int vartype,
             conduit::blueprint::mesh::field::to_multi_buffer_full(original_matset,
                                                                   intermediate_field,
                                                                   matset_name,
-                                                                  dest_matset,
                                                                   field_out);
         }
         else // "multi_buffer_by_material"
@@ -1561,7 +1557,6 @@ read_variable_domain(const int vartype,
             conduit::blueprint::mesh::field::to_multi_buffer_by_material(original_matset,
                                                                          intermediate_field,
                                                                          matset_name,
-                                                                         dest_matset,
                                                                          field_out);
         }
     }

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -1458,7 +1458,7 @@ read_variable_domain(const int vartype,
                      const std::string &multivar_name,
                      const std::string &bottom_level_mesh_name,
                      const std::string &volume_dependent,
-                     const std::string &opts_matset_type,
+                     const std::string &opts_matset_style,
                      const Node &matset_field_reconstruction,
                      Node &mesh_out)
 {
@@ -1544,11 +1544,11 @@ read_variable_domain(const int vartype,
         // a throwaway to make the transform happy
         Node dest_matset;
 
-        if (opts_matset_type == "default" || opts_matset_type == "sparse_by_element")
+        if (opts_matset_style == "default" || opts_matset_style == "sparse_by_element")
         {
             field_out.set(intermediate_field);
         }
-        else if (opts_matset_type == "multi_buffer_full")
+        else if (opts_matset_style == "multi_buffer_full")
         {
             conduit::blueprint::mesh::field::to_multi_buffer_full(original_matset,
                                                                   intermediate_field,
@@ -1581,7 +1581,7 @@ read_matset_domain(DBfile* matset_domain_file_to_use,
                    const std::string &multimesh_name,
                    const std::string &multimat_name,
                    const std::string &bottom_level_mesh_name,
-                   const std::string &opts_matset_type,
+                   const std::string &opts_matset_style,
                    Node &matset_field_reconstruction,
                    Node &mesh_out)
 {
@@ -1799,11 +1799,11 @@ read_matset_domain(DBfile* matset_domain_file_to_use,
     // create an entry for this matset in the output
     Node &matset_out = mesh_out["matsets"][multimat_name];
 
-    if (opts_matset_type == "default" || opts_matset_type == "sparse_by_element")
+    if (opts_matset_style == "default" || opts_matset_style == "sparse_by_element")
     {
         matset_out.set(intermediate_matset);
     }
-    else if (opts_matset_type == "multi_buffer_full")
+    else if (opts_matset_style == "multi_buffer_full")
     {
         conduit::blueprint::mesh::matset::to_multi_buffer_full(intermediate_matset, matset_out);
     }
@@ -2541,22 +2541,22 @@ read_root_silo_index(const std::string &root_file_path,
                         root_node);
 
     // Get the selected matset flavor
-    if (opts.has_child("matset_type") && opts["matset_type"].dtype().is_string())
+    if (opts.has_child("matset_style") && opts["matset_style"].dtype().is_string())
     {
-        std::string opts_matset_type = opts["matset_type"].as_string();
-        if (opts_matset_type != "default" && 
-            opts_matset_type != "multi_buffer_full" &&
-            opts_matset_type != "sparse_by_element" &&
-            opts_matset_type != "multi_buffer_by_material")
+        std::string opts_matset_style = opts["matset_style"].as_string();
+        if (opts_matset_style != "default" && 
+            opts_matset_style != "multi_buffer_full" &&
+            opts_matset_style != "sparse_by_element" &&
+            opts_matset_style != "multi_buffer_by_material")
         {
-            CONDUIT_INFO("read_mesh invalid matset_type option: \"" 
-                         << opts_matset_type << "\"\n"
+            CONDUIT_INFO("read_mesh invalid matset_style option: \"" 
+                         << opts_matset_style << "\"\n"
                          " expected: \"default\", \"multi_buffer_full\", "
                          "\"sparse_by_element\", or \"multi_buffer_by_material\"");
         }
         else
         {
-            root_node[multimesh_name]["matset_type"] = opts_matset_type;
+            root_node[multimesh_name]["matset_style"] = opts_matset_style;
         }
 
     }
@@ -2598,7 +2598,7 @@ read_root_silo_index(const std::string &root_file_path,
     //             c: 0
     //             ...
     //       ...
-    //    matset_type: "default", OR "multi_buffer_full", OR "sparse_by_element", OR "multi_buffer_by_material"
+    //    matset_style: "default", OR "multi_buffer_full", OR "sparse_by_element", OR "multi_buffer_by_material"
 
     return true;
 }
@@ -2610,7 +2610,7 @@ read_root_silo_index(const std::string &root_file_path,
 ///          provide explicit mesh name, for cases where silo data includes
 ///           more than one mesh.
 ///
-///      matset_type: "default", "multi_buffer_full", "sparse_by_element", 
+///      matset_style: "default", "multi_buffer_full", "sparse_by_element", 
 ///            "multi_buffer_by_material"
 ///            "default"   ==> "sparse_by_element"
 ///
@@ -2726,10 +2726,10 @@ read_mesh(const std::string &root_file_path,
     domain_end = rank_offset + read_size;
 #endif
 
-    std::string opts_matset_type = "default";
-    if (mesh_index.has_child("matset_type"))
+    std::string opts_matset_style = "default";
+    if (mesh_index.has_child("matset_style"))
     {
-        opts_matset_type = mesh_index["matset_type"].as_string();
+        opts_matset_style = mesh_index["matset_style"].as_string();
     }
 
     bool mesh_nameschemes = false;
@@ -2885,7 +2885,7 @@ read_mesh(const std::string &root_file_path,
                 // be one matset in our newly created blueprint mesh.
                 if (read_matset_domain(matset_domain_file_to_use, n_matset, matset_name,
                                        multimesh_name, multimat_name, bottom_level_mesh_name,
-                                       opts_matset_type, matset_field_reconstruction, mesh_out))
+                                       opts_matset_style, matset_field_reconstruction, mesh_out))
                 {
                     break;
                 }
@@ -2953,7 +2953,7 @@ read_mesh(const std::string &root_file_path,
                 // last thing in the loop iteration
                 read_variable_domain(vartype, var_domain_file_to_use, var_name,
                     multimesh_name, multivar_name, bottom_level_mesh_name,
-                    volume_dependent, opts_matset_type,
+                    volume_dependent, opts_matset_style,
                     matset_field_reconstruction, mesh_out);
             }
         }
@@ -2988,7 +2988,7 @@ void load_mesh(const std::string &root_file_path,
 ///          provide explicit mesh name, for cases where silo data includes
 ///           more than one mesh.
 ///
-///      matset_type: "default", "multi_buffer_full", "sparse_by_element", 
+///      matset_style: "default", "multi_buffer_full", "sparse_by_element", 
 ///            "multi_buffer_by_material"
 ///            "default"   ==> "sparse_by_element"
 ///

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -2549,10 +2549,10 @@ read_root_silo_index(const std::string &root_file_path,
             opts_matset_style != "sparse_by_element" &&
             opts_matset_style != "multi_buffer_by_material")
         {
-            CONDUIT_INFO("read_mesh invalid matset_style option: \"" 
-                         << opts_matset_style << "\"\n"
-                         " expected: \"default\", \"multi_buffer_full\", "
-                         "\"sparse_by_element\", or \"multi_buffer_by_material\"");
+            CONDUIT_ERROR("read_mesh invalid matset_style option: \"" 
+                          << opts_matset_style << "\"\n"
+                          " expected: \"default\", \"multi_buffer_full\", "
+                          "\"sparse_by_element\", or \"multi_buffer_by_material\"");
         }
         else
         {

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -1546,7 +1546,7 @@ read_variable_domain(const int vartype,
 
         if (opts_matset_style == "default" || opts_matset_style == "sparse_by_element")
         {
-            field_out.set(intermediate_field);
+            field_out.move(intermediate_field);
         }
         else if (opts_matset_style == "multi_buffer_full")
         {
@@ -1567,7 +1567,7 @@ read_variable_domain(const int vartype,
     }
     else
     {
-        field_out.set(intermediate_field);
+        field_out.move(intermediate_field);
     }
 
     return true;

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -278,14 +278,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_multi_buffer_full(mset, converted_mset);
         blueprint::mesh::field::to_multi_buffer_full(mset, 
                                                      field, 
                                                      converted_matset_name, 
-                                                     converted_mset, 
                                                      converted_field);
-        blueprint::mesh::matset::to_multi_buffer_full(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -293,7 +292,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         full_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(full_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(full_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(full_field_baseline, info));
     }
 
@@ -310,14 +308,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_sparse_by_element(mset, converted_mset);
         blueprint::mesh::field::to_sparse_by_element(mset, 
                                                      field, 
                                                      converted_matset_name, 
-                                                     converted_mset, 
                                                      converted_field);
-        blueprint::mesh::matset::to_sparse_by_element(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -325,7 +322,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         sbe_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(sbe_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(sbe_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(sbe_field_baseline, info));
     }
 
@@ -342,14 +338,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_multi_buffer_by_material(mset, converted_mset);
         blueprint::mesh::field::to_multi_buffer_by_material(mset, 
                                                             field, 
                                                             converted_matset_name, 
-                                                            converted_mset, 
                                                             converted_field);
-        blueprint::mesh::matset::to_multi_buffer_by_material(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -357,7 +352,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         sbm_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(sbm_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(sbm_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(sbm_field_baseline, info));
     }
 
@@ -374,14 +368,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_multi_buffer_full(mset, converted_mset);
         blueprint::mesh::field::to_multi_buffer_full(mset, 
                                                      field, 
                                                      converted_matset_name, 
-                                                     converted_mset, 
                                                      converted_field);
-        blueprint::mesh::matset::to_multi_buffer_full(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -389,7 +382,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         full_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(full_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(full_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(full_field_baseline, info));
     }
 
@@ -406,14 +398,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_multi_buffer_by_material(mset, converted_mset);
         blueprint::mesh::field::to_multi_buffer_by_material(mset, 
                                                             field, 
                                                             converted_matset_name, 
-                                                            converted_mset, 
                                                             converted_field);
-        blueprint::mesh::matset::to_multi_buffer_by_material(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -421,7 +412,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         sbm_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(sbm_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(sbm_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(sbm_field_baseline, info));
     }
 
@@ -438,14 +428,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_multi_buffer_full(mset, converted_mset);
         blueprint::mesh::field::to_multi_buffer_full(mset, 
                                                      field, 
                                                      converted_matset_name, 
-                                                     converted_mset, 
                                                      converted_field);
-        blueprint::mesh::matset::to_multi_buffer_full(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -453,7 +442,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         full_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(full_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(full_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(full_field_baseline, info));
     }
 
@@ -470,14 +458,13 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         std::cout << mset.to_yaml() << std::endl;
         std::cout << field.to_yaml() << std::endl;
 
-        Node converted_mset, converted_mset2, converted_field;
+        Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
+        blueprint::mesh::matset::to_sparse_by_element(mset, converted_mset);
         blueprint::mesh::field::to_sparse_by_element(mset, 
                                                      field, 
                                                      converted_matset_name, 
-                                                     converted_mset, 
                                                      converted_field);
-        blueprint::mesh::matset::to_sparse_by_element(mset, converted_mset2);
         std::cout << converted_mset.to_yaml() << std::endl;
         std::cout << converted_field.to_yaml() << std::endl;
 
@@ -485,7 +472,6 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
         sbe_field_baseline["matset"] = "matset2";
 
         EXPECT_FALSE(converted_mset.diff(sbe_mset_baseline, info));
-        EXPECT_FALSE(converted_mset2.diff(sbe_mset_baseline, info));
         EXPECT_FALSE(converted_field.diff(sbe_field_baseline, info));
     }
 }

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -978,6 +978,10 @@ TEST(conduit_relay_io_silo, unstructured_points)
 ///      mesh_name: "{name}"
 ///          provide explicit mesh name, for cases where silo data includes
 ///           more than one mesh.
+///
+///      matset_type: "default", "multi_buffer_full", "sparse_by_element", 
+///            "multi_buffer_by_material"
+///            "default"   ==> "sparse_by_element"
 
 //-----------------------------------------------------------------------------
 TEST(conduit_relay_io_silo, round_trip_save_option_file_style)

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -327,18 +327,24 @@ TEST(conduit_relay_io_silo, round_trip_julia)
 // test material write and read
 TEST(conduit_relay_io_silo, round_trip_venn)
 {
-    const std::vector<std::string> matset_types = {
-        "full",
-        "sparse_by_material",
-        "sparse_by_element",
+    // the matset type and the type we are requesting on read
+    const std::vector<std::pair<std::string, std::string>> matset_types = {
+        std::make_pair("full", "full"),
+        std::make_pair("sparse_by_material", "sparse_by_material"),
+        std::make_pair("sparse_by_element", "sparse_by_element"),
+        std::make_pair("sparse_by_element", "full"),
+        std::make_pair("sparse_by_material", "sparse_by_element"),
+        std::make_pair("sparse_by_material", "default"),
     };
 
     for (int i = 0; i < matset_types.size(); i ++)
     {
-        std::string matset_type = matset_types[i];
+        std::string matset_type = matset_types[i].first;
+        std::string matset_request = matset_types[i].second;
+
         for (int j = 0; j < 2; j ++)
         {
-            Node save_mesh, sbe, load_mesh, info;
+            Node mesh_full, mesh_sbe, mesh_sbm, baseline_mesh, load_mesh, info;
             std::string size;
             int nx, ny;
             const double radius = 0.25;
@@ -352,29 +358,65 @@ TEST(conduit_relay_io_silo, round_trip_venn)
                 size = "large";
                 nx = ny = 100;
             }
-            blueprint::mesh::examples::venn(matset_type, nx, ny, radius, save_mesh);
-            // TODO remove this later when we support creating "full" and "sparse_by_material"
-            // on read
-            if (matset_type != "sparse_by_element")
+
+            blueprint::mesh::examples::venn("full", nx, ny, radius, mesh_full);
+            blueprint::mesh::examples::venn("sparse_by_material", nx, ny, radius, mesh_sbm);
+            blueprint::mesh::examples::venn("sparse_by_element", nx, ny, radius, mesh_sbe);
+
+            if (matset_type == "full")
             {
-                // I create a second venn that is sparse by element b/c load_mesh will
-                // convert silo data to sparse by element blueprint data. I need this to
-                // diff successfully.
-                blueprint::mesh::examples::venn("sparse_by_element", nx, ny, radius, sbe);
+                baseline_mesh.set_external(mesh_full);
+            }
+            else if (matset_type == "sparse_by_material")
+            {
+                baseline_mesh.set_external(mesh_sbm);
+            }
+            else // (matset_type == "sparse_by_element")
+            {
+                baseline_mesh.set_external(mesh_sbe);
+            }
+
+            Node opts;
+            if (matset_request == "full")
+            {
+                opts["matset_style"] = "multi_buffer_full";
+            }
+            else if (matset_request == "sparse_by_material")
+            {
+                opts["matset_style"] = "multi_buffer_by_material";
+            }
+            else if (matset_request == "sparse_by_element")
+            {
+                opts["matset_style"] = "sparse_by_element";
+            }
+            else
+            {
+                opts["matset_style"] = "default";
             }
 
             const std::string basename = "silo_venn_" + matset_type + "_" + size;
             const std::string filename = basename + ".root";
 
             remove_path_if_exists(filename);
-            io::silo::save_mesh(save_mesh, basename);
-            io::silo::load_mesh(filename, load_mesh);
+            io::silo::save_mesh(baseline_mesh, basename);
+            io::silo::load_mesh(filename, opts, load_mesh);
             EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
-            // The silo reader creates sparse_by_element data
-            if (matset_type != "sparse_by_element")
+            if (matset_request == "full")
             {
-                save_mesh.set_external(sbe);
+                baseline_mesh.set_external(mesh_full);
+            }
+            else if (matset_request == "sparse_by_material")
+            {
+                baseline_mesh.set_external(mesh_sbm);
+            }
+            else if (matset_request == "sparse_by_element")
+            {
+                baseline_mesh.set_external(mesh_sbe);
+            }
+            else
+            {
+                baseline_mesh.set_external(mesh_sbe);
             }
 
             // make changes to save mesh so the diff will pass
@@ -383,18 +425,31 @@ TEST(conduit_relay_io_silo, round_trip_venn)
             // that are another type. The silo writer converts both to double arrays
             // in this case, so we follow suit.
             Node mat_check_new_values, mat_check_new_matset_values;
-            save_mesh["fields"]["mat_check"]["values"].to_double_array(mat_check_new_values);
-            save_mesh["fields"]["mat_check"]["matset_values"].to_double_array(mat_check_new_matset_values);
-            save_mesh["fields"]["mat_check"]["values"].set_external(mat_check_new_values);
-            save_mesh["fields"]["mat_check"]["matset_values"].set_external(mat_check_new_matset_values);
+            baseline_mesh["fields"]["mat_check"]["values"].to_double_array(mat_check_new_values);
+            if (baseline_mesh["fields"]["mat_check"]["matset_values"].dtype().is_object())
+            {
+                auto mat_vals_itr = baseline_mesh["fields"]["mat_check"]["matset_values"].children();
+                while (mat_vals_itr.has_next())
+                {
+                    Node &mat_vals_for_mat = mat_vals_itr.next();
+                    const std::string mat_name = mat_vals_itr.name();
+                    mat_vals_for_mat.to_double_array(mat_check_new_matset_values[mat_name]);
+                }
+            }
+            else
+            {
+                baseline_mesh["fields"]["mat_check"]["matset_values"].to_double_array(mat_check_new_matset_values);
+            }
+            baseline_mesh["fields"]["mat_check"]["values"].set_external(mat_check_new_values);
+            baseline_mesh["fields"]["mat_check"]["matset_values"].set_external(mat_check_new_matset_values);
 
-            silo_name_changer("mesh", save_mesh);
+            silo_name_changer("mesh", baseline_mesh);
 
             // the loaded mesh will be in the multidomain format
             // but the saved mesh is in the single domain format
             EXPECT_EQ(load_mesh.number_of_children(), 1);
-            EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
-            EXPECT_FALSE(load_mesh[0].diff(save_mesh, info, CONDUIT_EPSILON, true));
+            EXPECT_EQ(load_mesh[0].number_of_children(), baseline_mesh.number_of_children());
+            EXPECT_FALSE(load_mesh[0].diff(baseline_mesh, info, CONDUIT_EPSILON, true));
         }
     }
 }
@@ -979,7 +1034,7 @@ TEST(conduit_relay_io_silo, unstructured_points)
 ///          provide explicit mesh name, for cases where silo data includes
 ///           more than one mesh.
 ///
-///      matset_type: "default", "multi_buffer_full", "sparse_by_element", 
+///      matset_style: "default", "multi_buffer_full", "sparse_by_element", 
 ///            "multi_buffer_by_material"
 ///            "default"   ==> "sparse_by_element"
 


### PR DESCRIPTION
Now when you read silo, you have the option to choose the kind of matset you want it to produce in blueprint.

The downside are all the intermediate matsets and fields that have to be created. Maybe there should be converters that just convert material dependent fields between the types? They still need a matset to do it, but maybe they don't have to produce a matset as a side effect.

Things to discuss:
- I have to save a copy of the sbe matset for the mat-dependent fields to use later when they get converted. Then I have to create temporary matsets for the field converters to use that just get thrown away.
- I have to create intermediate fields and intermediate matsets for all cases. Then I use expensive `set`s when I know what to do. This bothers me, but I'm not sure there's a clean way to do this. Maybe some ugly pointers + logic for setting them.
- Do I error if I get a bad option for the `matset_style`? Or just keep going?