### PR TITLE
Overlink support 1.0

### DIFF
--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -4526,6 +4526,11 @@ void silo_mesh_write(const Node &mesh_domain,
         }
     }
 
+    // either we are not writing overlink, or there is a matset present
+    // overlink requires a matset
+    CONDUIT_ASSERT(! write_overlink || mesh_domain.has_path("matsets"),
+        "Writing to Overlink requires a matset.");
+
     if (mesh_domain.has_path("matsets")) 
     {
         // We want to enforce that there is only one matset per topo

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -5412,9 +5412,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     // more will happen for this case later
     if (write_overlink)
     {
-        CONDUIT_INFO("Overlink is not yet fully supported. Outputted files "
-                     "with this option will be missing several components "
-                     "that Overlink requires.")
         opts_suffix = "none"; // force no suffix for overlink case
         opts_root_file_ext = "silo"; // force .silo file extension for root file
     }

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -573,14 +573,21 @@ void convert_to_double_array(const Node &n_src,
     }
     else
     {
-        // if it's already a double array, we just need to compact it
-        if (n_src.dtype().is_double())
+        if (n_src.dtype().is_number())
         {
-            conditional_compact(n_src, n_dest);
+            // if it's already a double array, we just need to compact it
+            if (n_src.dtype().is_double())
+            {
+                conditional_compact(n_src, n_dest);
+            }
+            else
+            {
+                n_src.to_double_array(n_dest);
+            }
         }
         else
         {
-            n_src.to_double_array(n_dest);
+            n_dest.set_external(n_src);
         }
     }
 }
@@ -3027,7 +3034,6 @@ void** prepare_mixed_field_for_write(const Node &n_var,
                                      const DataType &vals_dtype,
                                      const int &nvars,
                                      bool &convert_to_double_array,
-                                     int &silo_vals_type,
                                      Node &silo_matset,
                                      Node &silo_mixvar_vals_compact,
                                      std::vector<void *> &mixvars_ptrs,
@@ -3044,15 +3050,19 @@ void** prepare_mixed_field_for_write(const Node &n_var,
         conduit::blueprint::mesh::field::to_silo(n_var, n_matset, silo_matset);
 
         DataType mixvar_vals_dtype = silo_matset["field_mixvar_values"].dtype();
-        
-        // if the field is mixed (has both vals and matset vals) and the types
-        // of vals and matset vals DO NOT match, we must convert both to 
-        // double arrays.
-        convert_to_double_array = vals_dtype.id() != mixvar_vals_dtype.id();
+
+        // if we are not already converting to double array, we can do an
+        // additional check to see if we need to
+        if (! convert_to_double_array)
+        {
+            // if the field is mixed (has both vals and matset vals) and the types
+            // of vals and matset vals DO NOT match, we must convert both to 
+            // double arrays.
+            convert_to_double_array = vals_dtype.id() != mixvar_vals_dtype.id();
+        }
         
         if (convert_to_double_array)
         {
-            silo_vals_type = DB_DOUBLE;
             detail::convert_to_double_array(silo_matset["field_mixvar_values"],
                                             silo_mixvar_vals_compact);
         }
@@ -3238,6 +3248,12 @@ void silo_write_field(DBfile *dbfile,
     // matset_values then we want to convert both to double arrays
     bool convert_to_double_array = false;
 
+    // overlink requires doubles
+    if (write_overlink)
+    {
+        convert_to_double_array = true;
+    }
+
     //
     // Prepare Matset Values (if they exist)
     //
@@ -3257,11 +3273,15 @@ void silo_write_field(DBfile *dbfile,
                                       vals_dtype,
                                       nvars,
                                       convert_to_double_array,
-                                      silo_vals_type,
                                       silo_matset,
                                       silo_mixvar_vals_compact,
                                       mixvars_ptrs,
                                       mixlen);
+
+    if (convert_to_double_array)
+    {
+        silo_vals_type = DB_DOUBLE;
+    }
 
     //
     // Prepare Field Values
@@ -3604,33 +3624,6 @@ void silo_write_adjset(DBfile *dbfile,
     }
 
     write_dom_neighbor_nums(num_neighboring_doms, dom_neighbor_nums);
-
-    // std::vector<std::string> elem_name_strings;
-    // elem_name_strings.push_back("num_neighbors");
-    // elem_name_strings.push_back("neighbor_nums");
-    // // package up char ptrs for silo
-    // std::vector<const char *> elem_name_ptrs;
-    // for (size_t i = 0; i < elem_name_strings.size(); i ++)
-    // {
-    //     elem_name_ptrs.push_back(elem_name_strings[i].c_str());
-    // }
-
-    // std::vector<int> elemlengths;
-    // elemlengths.push_back(1);
-    // elemlengths.push_back(num_neighboring_doms);
-
-    // const int nelems = 2;
-    // const int nvalues = num_neighboring_doms + 1;
-
-    // DBPutCompoundarray(dbfile, // dbfile
-    //                    "DOMAIN_NEIGHBOR_NUMS", // name
-    //                    elem_name_ptrs.data(), // elemnames
-    //                    elemlengths.data(), // elemlengths
-    //                    nelems, // nelems
-    //                    static_cast<void *>(dom_neighbor_nums.data()), // values
-    //                    nvalues, // nvalues
-    //                    DB_INT, // datatype
-    //                    NULL); // optlist
 
     // 
     // COMMUNICATIONS LISTS FOR NEIGHBORING DOMAINS
@@ -4176,7 +4169,7 @@ void silo_write_topo(const Node &mesh_domain,
             << " mesh " << topo_name)
 
         // compact arrays
-        Node n_coords_compact, new_coords;
+        Node n_coords_compact, n_coords_compact_final, new_coords;
         
         // here we handle the unstructured points case:
         if (unstructured_points)
@@ -4219,15 +4212,25 @@ void silo_write_topo(const Node &mesh_domain,
             detail::conditional_compact(n_coords["values"], n_coords_compact);
         }
 
+        // overlink requires doubles
+        if (write_overlink)
+        {
+            detail::convert_to_double_array(n_coords_compact, n_coords_compact_final);
+        }
+        else
+        {
+            n_coords_compact_final.set_external(n_coords_compact);
+        }
+
         // get num pts
-        const int num_pts = get_explicit_num_pts(n_coords_compact);
+        const int num_pts = get_explicit_num_pts(n_coords_compact_final);
         n_mesh_info[topo_name]["num_pts"].set(num_pts);
 
         // get coords ptrs
         void *coords_ptrs[3] = {NULL, NULL, NULL};
         int coords_dtype = assign_coords_ptrs(coords_ptrs,
                                               ndims,
-                                              n_coords_compact,
+                                              n_coords_compact_final,
                                               silo_coordset_axis_labels.data());
 
         if (topo_type == "unstructured")
@@ -4321,11 +4324,21 @@ void silo_write_matset(DBfile *dbfile,
                        Node &n_mesh_info)
 {
     // use to_silo utility to create the needed silo arrays
-    Node silo_matset, silo_matset_compact;
+    Node silo_matset, silo_matset_compact, silo_mix_vfs_final;
     conduit::blueprint::mesh::matset::to_silo(n_matset, silo_matset);
 
     // compact the arrays if necessary
     detail::conditional_compact(silo_matset, silo_matset_compact);
+
+    // mix vfs must be doubles for overlink
+    if (write_overlink)
+    {
+        detail::convert_to_double_array(silo_matset_compact["mix_vf"], silo_mix_vfs_final);
+    }
+    else
+    {
+        silo_mix_vfs_final.set_external(silo_matset_compact["mix_vf"]);
+    }
 
     if (!n_matset.has_path("topology"))
     {
@@ -4380,9 +4393,9 @@ void silo_write_matset(DBfile *dbfile,
     const int mixlen = silo_matset_compact["mix_mat"].dtype().number_of_elements();
 
     // get the datatype of the volume fractions
-    const int mat_type = detail::dtype_to_silo_type(silo_matset_compact["mix_vf"].dtype());
+    const int mat_type = detail::dtype_to_silo_type(silo_mix_vfs_final.dtype());
     CONDUIT_ASSERT(mat_type == DB_FLOAT || mat_type == DB_DOUBLE,
-        "Invalid matset volume fraction type: " << silo_matset_compact["mix_vf"].dtype().to_string());
+        "Invalid matset volume fraction type: " << silo_mix_vfs_final.dtype().to_string());
 
     // create optlist and add to it
     detail::SiloObjectWrapperCheckError<DBoptlist, decltype(&DBFreeOptlist)> optlist{
@@ -4426,7 +4439,7 @@ void silo_write_matset(DBfile *dbfile,
                       int_arrays["mix_next"].value(),
                       int_arrays["mix_mat"].value(),
                       NULL, // mix zone is optional
-                      silo_matset_compact["mix_vf"].data_ptr(), // volume fractions
+                      silo_mix_vfs_final.data_ptr(), // volume fractions
                       mixlen, // length of mixed data arrays
                       mat_type, // data type of volume fractions
                       optlist.getSiloObject()); // optlist

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -520,17 +520,42 @@ TEST(conduit_relay_io_silo, round_trip_grid_adjset)
     Node save_mesh, load_mesh, info;
     blueprint::mesh::examples::grid("structured", 3, 3, 1, 2, 2, 1, save_mesh);
 
+    // we need a material in order for this to be valid overlink
+    for (index_t child = 0; child < save_mesh.number_of_children(); child ++)
+    {
+        Node &n_matset = save_mesh[child]["matsets"]["matset"];
+        n_matset["topology"] = "mesh";
+        n_matset["volume_fractions"]["mat_a"].set(DataType::float64(4));
+        n_matset["volume_fractions"]["mat_b"].set(DataType::float64(4));
+
+        double_array a_vfs = n_matset["volume_fractions"]["mat_a"].value();
+        double_array b_vfs = n_matset["volume_fractions"]["mat_b"].value();
+
+        a_vfs[0] = 1.0;
+        a_vfs[1] = 0.0;
+        a_vfs[2] = 1.0;
+        a_vfs[3] = 0.0;
+
+        b_vfs[0] = 0.0;
+        b_vfs[1] = 1.0;
+        b_vfs[2] = 0.0;
+        b_vfs[3] = 1.0;
+    }
+
     const std::string basename = "silo_grid_adjset";
     const std::string filename = basename + "/OvlTop.silo";
 
-    Node opts;
-    opts["file_style"] = "overlink";
-    opts["ovl_topo_name"] = "mesh";
+    Node write_opts;
+    write_opts["file_style"] = "overlink";
+    write_opts["ovl_topo_name"] = "mesh";
+
+    Node read_opts;
+    read_opts["matset_style"] = "multi_buffer_full";
 
     remove_path_if_exists(filename);
-    io::silo::save_mesh(save_mesh, basename, opts);
+    io::silo::save_mesh(save_mesh, basename, write_opts);
     io::blueprint::save_mesh(save_mesh, basename, "hdf5");
-    io::silo::load_mesh(filename, load_mesh);
+    io::silo::load_mesh(filename, read_opts, load_mesh);
     EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
     for (index_t child = 0; child < save_mesh.number_of_children(); child ++)

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1674,11 +1674,14 @@ TEST(conduit_relay_io_silo, read_silo)
         remove_path_if_exists(out_name + "_write_silo");
         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = meshname;
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+        // overlink doesn't have pointmeshes
+        if (basename != "galaxy0000")
+        {
+            remove_path_if_exists(out_name + "_write_overlink");
+            write_opts["file_style"] = "overlink";
+            write_opts["ovl_topo_name"] = meshname;
+            io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+        }
     }
 }
 
@@ -1728,11 +1731,10 @@ TEST(conduit_relay_io_silo, read_fake_overlink)
         remove_path_if_exists(out_name + "_write_silo");
         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = "MMESH";
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+        remove_path_if_exists(out_name + "_write_overlink");
+        write_opts["file_style"] = "overlink";
+        write_opts["ovl_topo_name"] = "MMESH";
+        io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
     }
 }
 
@@ -1787,11 +1789,10 @@ TEST(conduit_relay_io_silo, read_overlink_symlink_format)
         remove_path_if_exists(out_name + "_write_silo");
         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = "MMESH";
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+        remove_path_if_exists(out_name + "_write_overlink");
+        write_opts["file_style"] = "overlink";
+        write_opts["ovl_topo_name"] = "MMESH";
+        io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
     }
 }
 
@@ -1845,11 +1846,10 @@ TEST(conduit_relay_io_silo, read_overlink_directly)
         remove_path_if_exists(out_name + "_write_silo");
         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // TODO uncomment when overlink is fully supported
-        // remove_path_if_exists(out_name + "_write_overlink");
-        // write_opts["file_style"] = "overlink";
-        // write_opts["ovl_topo_name"] = "MMESH";
-        // io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
+        remove_path_if_exists(out_name + "_write_overlink");
+        write_opts["file_style"] = "overlink";
+        write_opts["ovl_topo_name"] = "MMESH";
+        io::silo::save_mesh(load_mesh, out_name + "_write_overlink", write_opts);
     }
 }
 

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1624,17 +1624,49 @@ TEST(conduit_relay_io_silo, round_trip_save_option_overlink4)
 
         Node save_mesh, load_mesh, info;
         blueprint::mesh::examples::braid(mesh_type, nx, ny, nz, save_mesh);
+        index_t nele_x = nx - 1;
+        index_t nele_y = ny - 1;
+        index_t nele_z = (dim == "2" ? 0 : nz - 1);
+
+        // provide a matset for braid
+        {
+            index_t nele = nele_x * nele_y * ((nele_z > 0) ? nele_z : 1);
+
+            save_mesh["matsets"]["matset"]["topology"] = "mesh";
+
+            Node &vfs = save_mesh["matsets"]["matset"]["volume_fractions"];
+            vfs["mat1"].set(DataType::float64(nele));
+            vfs["mat2"].set(DataType::float64(nele));
+
+            float64_array mat1_vals = vfs["mat1"].value();
+            float64_array mat2_vals = vfs["mat2"].value();
+
+            for (index_t k = 0, idx = 0; (idx == 0 || k < nele_z); k++)
+            {
+                for (index_t j = 0; (idx == 0 || j < nele_y) ; j++)
+                {
+                    for (index_t i = 0; (idx == 0 || i < nele_x) ; i++, idx++)
+                    {
+                        float64 mv = (nele_x == 1) ? 0.5 : i / (nele_x - 1.0);
+
+                        mat1_vals[idx] = mv;
+                        mat2_vals[idx] = 1.0 - mv;
+                    }
+                }
+            }
+        }
 
         const std::string basename = "silo_save_option_overlink_braid_" + mesh_type + "_" + dim + "D";
         const std::string filename = basename + "/OvlTop.silo";
 
-        Node opts;
-        opts["file_style"] = "overlink";
+        Node write_opts, read_opts;
+        write_opts["file_style"] = "overlink";
+        read_opts["matset_style"] = "multi_buffer_full";
 
         // remove existing root file, directory and any output files
         remove_path_if_exists(filename);
-        io::silo::save_mesh(save_mesh, basename, opts);
-        io::silo::load_mesh(filename, load_mesh);
+        io::silo::save_mesh(save_mesh, basename, write_opts);
+        io::silo::load_mesh(filename, read_opts, load_mesh);
         EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
 
         Node &field_vel = save_mesh["fields"]["vel"];

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1715,9 +1715,9 @@ TEST(conduit_relay_io_silo, read_silo)
     const std::vector<std::vector<std::string>> file_info = {
         {".",                  "multi_curv3d", ".silo", ""            }, // test default case
         {".",                  "multi_curv3d", ".silo", "mesh1"       },
-        {".",                  "multi_curv3d", ".silo", "mesh1_back"  },
+        // {".",                  "multi_curv3d", ".silo", "mesh1_back"  }, // this multimesh points to paths that do not exist
         {".",                  "multi_curv3d", ".silo", "mesh1_dup"   },
-        {".",                  "multi_curv3d", ".silo", "mesh1_front" },
+        // {".",                  "multi_curv3d", ".silo", "mesh1_front" }, // same here
         {".",                  "multi_curv3d", ".silo", "mesh1_hidden"},
         {".",                  "tire",         ".silo", ""            }, // test default case
         {".",                  "tire",         ".silo", "tire"        },
@@ -1728,6 +1728,9 @@ TEST(conduit_relay_io_silo, read_silo)
         {"multidir_test_data", "multidir0000", ".root", ""            }, // test default case
         {"multidir_test_data", "multidir0000", ".root", "Mesh"        },
     };
+
+    // TODO what to do in the case where a multimesh points to no data? (mesh1_back)
+    // fail silently, as we do now?
 
     for (int i = 0; i < file_info.size(); i ++) 
     {
@@ -1759,8 +1762,8 @@ TEST(conduit_relay_io_silo, read_silo)
         remove_path_if_exists(out_name + "_write_silo");
         io::silo::save_mesh(load_mesh, out_name + "_write_silo");
 
-        // overlink doesn't have pointmeshes
-        if (basename != "galaxy0000")
+        // overlink requires matsets and does not support point meshes
+        if (load_mesh[0].has_child("matsets") && basename != "galaxy0000")
         {
             remove_path_if_exists(out_name + "_write_overlink");
             write_opts["file_style"] = "overlink";


### PR DESCRIPTION
Finished the last few things needed for Overlink support:

- require matsets to be present to write overlink
- convert data arrays to doubles since overlink does not support floats
- remove warning saying overlink is not fully supported
- update tests to add matsets where needed to make overlink save happy
- verified that all files we write to overlink in tests pass Jeff's overlink file format validator