### PR TITLE
fix missing py bp table examples cmake dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Relaxed strict header check for C++14 back to C++11. A downstream consumer of Conduit has C++11 hardcoded into their build system and patching for related deployments is intractable.
 
 
+#### Blueprint
+- Fixed missing build dependency relationship with the python conduit blueprint table examples module.
+
 ## [0.9.0] - Released 2024-02-05
 
 ### Added

--- a/src/libs/blueprint/python/CMakeLists.txt
+++ b/src/libs/blueprint/python/CMakeLists.txt
@@ -16,7 +16,6 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_python
 # compiled modules depend on output dir structure created by main module setup
 add_dependencies( conduit_blueprint_python conduit_python_py_setup)
 
-
 # link with the proper libs (beyond python)
 target_link_libraries(conduit_blueprint_python conduit conduit_blueprint conduit_python_build)
 
@@ -34,7 +33,6 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_python
 
 # compiled modules depend on output dir structure created by main module setup
 add_dependencies( conduit_blueprint_mcarray_python conduit_python_py_setup)
-
 
 # link with the proper libs (beyond python)
 target_link_libraries(conduit_blueprint_mcarray_python conduit conduit_blueprint conduit_python_build)
@@ -112,6 +110,9 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_table_examples_python
                            SOURCES       conduit_blueprint_table_examples_python.cpp
                                          ${CMAKE_CURRENT_BINARY_DIR}/conduit_blueprint_python_exports.h
                            FOLDER        libs/python)
+
+# compiled modules depend on output dir structure created by main module setup
+add_dependencies( conduit_blueprint_table_examples_python conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
 target_link_libraries(conduit_blueprint_table_examples_python conduit conduit_blueprint conduit_python_build)


### PR DESCRIPTION
fix a missing python module cmake dependence that can undermine builds at high build concurrency 