### PR TITLE
Changed partition_map_back() so it tries to reuse node memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### Blueprint
 - Fixed partitioner so it reverses vertex order as needed in polyhedral face definitions when extracting mesh elements.
+- Changed `conduit::blueprint::mesh::partition_map_back()` function so it will attempt to reuse existing field memory when mapping fields back. This permits `partition_map_back()` to send data from a partitioned mesh into the original mesh where fields were provided from a host code using `Node::set_external()`.
 
 #### Relay
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -8656,15 +8656,7 @@ determine_schema(const Node &in,
         for(index_t i = 1; i < num_children; i++)
             same_types = (in[i].dtype().id() == in[0].dtype().id());
 
-        // Check whether components appear interleaved.
-        bool interleaved = true;
-        for(index_t i = 1; i < num_children; i++)
-        {
-            const auto dI = in[i].dtype().element_index(0) - in[i - 1].dtype().element_index(0);
-            interleaved &= (dI == in[i].dtype().element_bytes());
-        }
-
-        if(same_types && interleaved)
+        if(same_types && conduit::blueprint::mcarray::is_interleaved(in))
         {
             // NOTE: In practice, we don't seem to get here yet from partition_map_back.
             //       The reason is that the mapback routine ends up calling copy_field

--- a/src/tests/blueprint/t_blueprint_mesh_partition.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_partition.cpp
@@ -13,13 +13,15 @@
 #include "conduit_blueprint.hpp"
 #include "conduit_blueprint_mesh_partition.hpp"
 #include "conduit_blueprint_mesh_utils.hpp"
+#include "conduit_blueprint_mesh_utils_iterate_elements.hpp"
 #include "conduit_relay.hpp"
 #include "conduit_log.hpp"
 
 #include <math.h>
-#include <iostream>
 #include <array>
 #include <cmath>
+#include <iostream>
+#include <numeric>
 #include <set>
 
 #include "gtest/gtest.h"
@@ -2701,4 +2703,228 @@ TEST(conduit_blueprint_mesh_partition, generate_boundary_partition)
     {
         EXPECT_EQ(bparts_baseline[i], bparts[i]);
     }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_partition, map_back_set_external)
+{
+    auto blend = [](double x0, double x1, int n)
+    {
+        std::vector<double> values(n);
+        for(int i = 0; i < n; i++)
+        {
+            double t = static_cast<double>(i) / static_cast<double>(n - 1);
+            values[i] = (1. - t) * x0 + t * x1;
+        }
+        return values;
+    };
+
+#define F_XYC(X,Y,C) (static_cast<double>((C) + 1) * sqrt((X)*(X) + (Y)*(Y)))
+
+    auto compute_nodal_field = [](conduit::Node &mesh, conduit::Node &f)
+    {
+        std::string type = mesh["coordsets/coords/type"].as_string();
+        const auto x = mesh["coordsets/coords/values/x"].as_double_accessor();
+        const auto y = mesh["coordsets/coords/values/y"].as_double_accessor();
+        conduit::Node &values = f["values"];
+        int nc = std::max(1, static_cast<int>(values.number_of_children()));
+        bool single = values.number_of_children() == 0;
+
+        if(type == "rectilinear")
+        {
+            for(int c = 0; c < nc; c++)
+            {
+                auto comp = single ? values.as_double_array() : values[c].as_double_array();
+                int idx =0 ;
+                for(int j = 0; j < y.number_of_elements(); j++)
+                for(int i = 0; i < x.number_of_elements(); i++, idx++)
+                    comp[idx] = F_XYC(x[i], y[j], c);
+            }
+        }
+        else if(type == "unstructured")
+        {
+            for(int c = 0; c < nc; c++)
+            {
+                auto comp = single ? values.as_double_array() : values[c].as_double_array();
+                for(int i = 0; i < x.number_of_elements(); i++)
+                    comp[i] = F_XYC(x[i], y[i], c);
+            }
+        }
+    };
+
+    auto compute_zonal_field = [](conduit::Node &mesh, conduit::Node &f)
+    {
+        namespace topoutils = conduit::blueprint::mesh::utils::topology;
+
+        // Turn to explicit coordinates just in case.
+        conduit::Node expcoords;
+        conduit::blueprint::mesh::coordset::to_explicit(mesh["coordsets/coords"], expcoords);
+        const auto x = expcoords["values/x"].as_double_accessor();
+        const auto y = expcoords["values/y"].as_double_accessor();
+        conduit::Node &values = f["values"];
+        topoutils::iterate_elements(mesh["topologies/main"],
+            [&](const topoutils::entity &e)
+        {
+            // Make a zone center.
+            double w = 1. / static_cast<double>(e.element_ids.size());
+            double zc[] = {0., 0., 0.};
+            for(const auto id : e.element_ids)
+            {
+                zc[0] = w * x[id];
+                zc[1] = w * y[id];
+            }
+
+            int nc = std::max(1, static_cast<int>(values.number_of_children()));
+            bool single = values.number_of_children() == 0;
+
+            for(int c = 0; c < nc; c++)
+            {
+                auto comp = single ? values.as_double_array() : values[c].as_double_array();
+                comp[e.entity_id] = F_XYC(zc[0], zc[1], c);
+            }
+        });
+    };
+
+    auto wrap = [](conduit::Node &root,
+                   std::vector<double> &nodal,
+                   std::vector<double> &zonal,
+                   std::vector<double> &nodalvec,
+                   std::vector<double> &zonalvec,
+                   int nnodes, int nzones)
+    {
+        root["fields/nodal/topology"] = "main";
+        root["fields/nodal/association"] = "vertex";
+        root["fields/nodal/values"].set_external(&nodal[0], nnodes);
+
+        root["fields/zonal/topology"] = "main";
+        root["fields/zonal/association"] = "element";
+        root["fields/zonal/values"].set_external(&zonal[0], nzones);
+
+        root["fields/nodalvec/topology"] = "main";
+        root["fields/nodalvec/association"] = "vertex";
+        root["fields/nodalvec/values/x"].set_external(&nodalvec[0], nnodes, 0, 2*sizeof(double));
+        root["fields/nodalvec/values/y"].set_external(&nodalvec[0], nnodes, sizeof(double), 2*sizeof(double));
+
+        root["fields/zonalvec/topology"] = "main";
+        root["fields/zonalvec/association"] = "element";
+        root["fields/zonalvec/values/cx"].set_external(&zonalvec[0], nzones, 0, 2*sizeof(double));
+        root["fields/zonalvec/values/cy"].set_external(&zonalvec[0], nzones, sizeof(double), 2*sizeof(double));
+    };
+
+    const double extents[] = {-2., 2., -2., 2.};
+    constexpr int dims[] = {15,10};
+    constexpr int nnodes = dims[0] * dims[1];
+    constexpr int nzones = (dims[0] - 1) * (dims[1] - 1);
+
+    conduit::Node mesh;
+    mesh["coordsets/coords/type"] = "rectilinear";
+    mesh["coordsets/coords/values/x"].set(blend(extents[0], extents[1], dims[0]));
+    mesh["coordsets/coords/values/y"].set(blend(extents[2], extents[3], dims[1]));
+
+    mesh["topologies/main/type"] = "rectilinear";
+    mesh["topologies/main/coordset"] = "coords";
+
+    mesh["state/cycle"] = 123;
+    mesh["state/domain_id"] = 0;
+
+    // Make a global vertex field or we get a failure during map_back.
+    mesh["fields/global_vertex_ids/topology"] = "main";
+    mesh["fields/global_vertex_ids/association"] = "vertex";
+    mesh["fields/global_vertex_ids/values"].set(conduit::DataType::int32(nnodes));
+    int *gids = mesh["fields/global_vertex_ids/values"].as_int_ptr();
+    std::iota(gids, gids + nnodes, 0);
+
+    // Make external fields.
+    std::vector<double> nodal(nnodes, 0.), zonal(nzones, 0.),
+                        nodalvec(nnodes * 2., 0.), zonalvec(nzones * 2, 0.);
+    wrap(mesh, nodal, zonal, nodalvec, zonalvec, nnodes, nzones);
+    //mesh.print();
+
+    // Make results vectors
+    std::vector<double> nodal_result(nnodes, 0.), zonal_result(nzones, 0.),
+                        nodalvec_result(nnodes * 2, 0.), zonalvec_result(nzones * 2, 0.);
+    conduit::Node results;
+    results["coordsets"].set_external_node(mesh["coordsets"]);
+    results["topologies"].set_external_node(mesh["topologies"]);
+    wrap(results, nodal_result, zonal_result, nodalvec_result, zonalvec_result, nnodes, nzones);
+
+    // Compute values into the results.
+    compute_nodal_field(results, results["fields/nodal"]);
+    compute_zonal_field(results, results["fields/zonal"]);
+    compute_nodal_field(results, results["fields/nodalvec"]);
+    compute_zonal_field(results, results["fields/zonalvec"]);
+    //results.print();
+
+    // Partition the mesh into 2 domains.
+    conduit::Node part, options;
+    options["target"] = 2;
+    options["mapping"] = 1;
+    //std::cout << "Calling partition" << std::endl;
+    //options.print();
+    conduit::blueprint::mesh::partition(mesh, options, part);
+
+    // Compute the fields on the part mesh.
+    auto domains = conduit::blueprint::mesh::domains(part);
+    EXPECT_EQ(domains.size(), 2);
+    for(auto &dom : domains)
+    {
+        compute_nodal_field(*dom, dom->fetch_existing("fields/nodal"));
+        compute_zonal_field(*dom, dom->fetch_existing("fields/zonal"));
+        compute_nodal_field(*dom, dom->fetch_existing("fields/nodalvec"));
+        compute_zonal_field(*dom, dom->fetch_existing("fields/zonalvec"));
+        //dom->print();
+    }
+
+    // Map the fields back to the original mesh.
+    conduit::Node mbopts;
+    mbopts["fields"].append().set("nodal");
+    mbopts["fields"].append().set("zonal");
+    mbopts["fields"].append().set("nodalvec");
+    mbopts["fields"].append().set("zonalvec");
+    //std::cout << "Calling partition_map_back" << std::endl;
+    //mbopts.print();
+    conduit::blueprint::mesh::partition_map_back(part, mbopts, mesh);
+
+    // Printing the nodal field, it should not contain non-zero values.
+    //std::cout << "After map_back" << std::endl;
+    //mesh["fields/nodal"].print();
+
+    // Make sure mapping back the fields did not change addresses of the fields
+    // in the original mesh. Y components should be at index 1.
+    EXPECT_EQ(&nodal[0], mesh["fields/nodal/values"].as_double_ptr());
+    EXPECT_EQ(&zonal[0], mesh["fields/zonal/values"].as_double_ptr());
+    EXPECT_EQ(&nodalvec[0], mesh["fields/nodalvec/values/x"].as_double_ptr());
+    EXPECT_EQ(&nodalvec[1], mesh["fields/nodalvec/values/y"].as_double_ptr());
+    EXPECT_EQ(&zonalvec[0], mesh["fields/zonalvec/values/cx"].as_double_ptr());
+    EXPECT_EQ(&zonalvec[1], mesh["fields/zonalvec/values/cy"].as_double_ptr());
+
+    // Check lengths
+    EXPECT_EQ(mesh["fields/nodal/values"].dtype().number_of_elements(), nnodes);
+    EXPECT_EQ(mesh["fields/zonal/values"].dtype().number_of_elements(), nzones);
+    EXPECT_EQ(mesh["fields/nodalvec/values/x"].dtype().number_of_elements(), nnodes);
+    EXPECT_EQ(mesh["fields/nodalvec/values/y"].dtype().number_of_elements(), nnodes);
+    EXPECT_EQ(mesh["fields/zonalvec/values/cx"].dtype().number_of_elements(), nzones);
+    EXPECT_EQ(mesh["fields/zonalvec/values/cy"].dtype().number_of_elements(), nzones);
+
+    // Check that the vectors are interleaved.
+    EXPECT_EQ(mesh["fields/nodalvec/values/x"].dtype().offset(), 0);
+    EXPECT_EQ(mesh["fields/nodalvec/values/x"].dtype().stride(), 2 * sizeof(double));
+    EXPECT_EQ(mesh["fields/nodalvec/values/y"].dtype().offset(), sizeof(double));
+    EXPECT_EQ(mesh["fields/nodalvec/values/y"].dtype().stride(), 2 * sizeof(double));
+    EXPECT_EQ(mesh["fields/zonalvec/values/cx"].dtype().offset(), 0);
+    EXPECT_EQ(mesh["fields/zonalvec/values/cx"].dtype().stride(), 2 * sizeof(double));
+    EXPECT_EQ(mesh["fields/zonalvec/values/cy"].dtype().offset(), sizeof(double));
+    EXPECT_EQ(mesh["fields/zonalvec/values/cy"].dtype().stride(), 2 * sizeof(double));
+
+    // Make sure that the field values are the same as the results.
+    const std::vector<std::string> fieldNames{"nodal", "zonal", "nodalve", "zonalvec"};
+    for(const auto &name : fieldNames)
+    {
+        conduit::Node info;
+        bool different = results["fields"][name].diff(mesh["fields"][name], info);
+        if(different)
+            info.print();
+        EXPECT_FALSE(different);
+    }
+#undef F_XYC
 }


### PR DESCRIPTION
This change makes partition_map_back() attempt to reuse the original field memory that it's mapping values back into rather than resetting the node. If the field is not allocated or won't fit then allocation does take place. This change makes it work better with source meshes whose fields were provided using set_external(), as in host codes.