### PR TITLE
Add partition options to set field names for original_element_ids, original_vertex_ids.

### DIFF
--- a/src/docs/sphinx/blueprint_mesh_partition.rst
+++ b/src/docs/sphinx/blueprint_mesh_partition.rst
@@ -72,71 +72,71 @@ count domains are combined first.
 
 .. tabularcolumns:: |p{1.5cm}|p{4cm}|L|
 
-+------------------+-----------------------------------------+------------------------------------------+
-| **Option**       | **Description**                         | **Example**                              |
-+------------------+-----------------------------------------+------------------------------------------+
-| selections       | A list of selection objects that        | .. code:: yaml                           |
-|                  | identify regions of interest from the   |                                          |
-|                  | input domains. Selections can be        |    selections:                           |
-|                  | different on each MPI rank.             |      -                                   |
-|                  |                                         |       type: logical                      |
-|                  |                                         |       start: [0,0,0]                     |
-|                  |                                         |       end: [9,9,9]                       |
-|                  |                                         |       domain_id: 10                      |                     
-+------------------+-----------------------------------------+------------------------------------------+
-| target           | An optional integer that determines the | .. code:: yaml                           |
-|                  | fields containing original domains and  |                                          |
-|                  | number of domains in the output. If     |    target: 4                             |
-|                  | given, the value must be greater than 0.|                                          |
-|                  | Values larger than the number of        |                                          |
-|                  | selections cause domains to be split.   |                                          |
-|                  | Values smaller than the number of       |                                          |
-|                  | selections cause domains to be combined.|                                          |
-|                  | Invalid values are ignored.             |                                          |
-|                  |                                         |                                          |
-|                  | If not given, the output will contain   |                                          |
-|                  | the number of selections. In parallel,  |                                          |
-|                  | the largest target value from the ranks |                                          |
-|                  | will be used for all ranks.             |                                          |
-+------------------+-----------------------------------------+------------------------------------------+
-| fields           | An list of strings that indicate the    | .. code:: yaml                           |
-|                  | names of the fields to extract in the   |                                          |
-|                  | output. If this option is not provided, |    fields: ["dist", "pressure"]          |
-|                  | all fields will be extracted.           |                                          |
-+------------------+-----------------------------------------+------------------------------------------+
-| mapping          | An integer that determines whether      | .. code:: yaml                           |
-|                  | fields containing original domains and  |                                          |
-|                  | ids will be added in the output. These  |    mapping: 0                            |
-|                  | fields enable one to know where each    |                                          |
-|                  | vertex and element came from originally.|                                          |
-|                  | Mapping is on by default. A non-zero    |                                          |
-|                  | value turns it on and a zero value turns|                                          |
-|                  | it off.                                 |                                          |
-+------------------+-----------------------------------------+------------------------------------------+
-| build_adjsets    | An integer that determines whether      | .. code:: yaml                           |
-|                  | the partitioner should build adjsets,   |                                          |
-|                  | if they are present in the selected     |    build_adjsets: 1                      |
-|                  | topology.                               |                                          |
-+------------------+-----------------------------------------+------------------------------------------+
-| merge_tolerance  | A double value that indicates the max   | .. code:: yaml                           |
-|                  | allowable distance between 2 points     |                                          |
-|                  | before they are considered to be        |    merge_tolerance: 0.000001             |
-|                  | separate. 2 points spaced smaller than  |                                          |
-|                  | this distance will be merged when       |                                          |
-|                  | explicit coordsets are combined.        |                                          |
-+------------------+-----------------------------------------+------------------------------------------+
-| original_element_ids | A string value that provides desired   | .. code::yaml                            |
-|                      | field name used to contain original    |                                          |
-|                      | element ids created from partitioning. |    original_element_ids: elem_name       |
-|                      | The default value is                   |                                          |
-|                      | original_element_ids.                  |                                          |
-+----------------------+----------------------------------------+------------------------------------------+
-| original_vertex_ids  | A string value that provides desired   | .. code::yaml                            |
-|                      | field name used to contain original    |                                          |
-|                      | vertex ids created from partitioning.  |    original_vertex_ids: vert_name        |
-|                      | The default value is                   |                                          |
-|                      | original_vertex_ids.                   |                                          |
-+----------------------+----------------------------------------+------------------------------------------+
++---------------------+-----------------------------------------+------------------------------------------+
+| **Option**          | **Description**                         | **Example**                              |
++---------------------+-----------------------------------------+------------------------------------------+
+| selections          | A list of selection objects that        | .. code:: yaml                           |
+|                     | identify regions of interest from the   |                                          |
+|                     | input domains. Selections can be        |    selections:                           |
+|                     | different on each MPI rank.             |      -                                   |
+|                     |                                         |       type: logical                      |
+|                     |                                         |       start: [0,0,0]                     |
+|                     |                                         |       end: [9,9,9]                       |
+|                     |                                         |       domain_id: 10                      |
++---------------------+-----------------------------------------+------------------------------------------+
+| target              | An optional integer that determines the | .. code:: yaml                           |
+|                     | fields containing original domains and  |                                          |
+|                     | number of domains in the output. If     |    target: 4                             |
+|                     | given, the value must be greater than 0.|                                          |
+|                     | Values larger than the number of        |                                          |
+|                     | selections cause domains to be split.   |                                          |
+|                     | Values smaller than the number of       |                                          |
+|                     | selections cause domains to be combined.|                                          |
+|                     | Invalid values are ignored.             |                                          |
+|                     |                                         |                                          |
+|                     | If not given, the output will contain   |                                          |
+|                     | the number of selections. In parallel,  |                                          |
+|                     | the largest target value from the ranks |                                          |
+|                     | will be used for all ranks.             |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
+| fields              | An list of strings that indicate the    | .. code:: yaml                           |
+|                     | names of the fields to extract in the   |                                          |
+|                     | output. If this option is not provided, |    fields: ["dist", "pressure"]          |
+|                     | all fields will be extracted.           |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
+| mapping             | An integer that determines whether      | .. code:: yaml                           |
+|                     | fields containing original domains and  |                                          |
+|                     | ids will be added in the output. These  |    mapping: 0                            |
+|                     | fields enable one to know where each    |                                          |
+|                     | vertex and element came from originally.|                                          |
+|                     | Mapping is on by default. A non-zero    |                                          |
+|                     | value turns it on and a zero value turns|                                          |
+|                     | it off.                                 |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
+| build_adjsets       | An integer that determines whether      | .. code:: yaml                           |
+|                     | the partitioner should build adjsets,   |                                          |
+|                     | if they are present in the selected     |    build_adjsets: 1                      |
+|                     | topology.                               |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
+| merge_tolerance     | A double value that indicates the max   | .. code:: yaml                           |
+|                     | allowable distance between 2 points     |                                          |
+|                     | before they are considered to be        |    merge_tolerance: 0.000001             |
+|                     | separate. 2 points spaced smaller than  |                                          |
+|                     | this distance will be merged when       |                                          |
+|                     | explicit coordsets are combined.        |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
+| original_element_ids| A string value that provides desired    | .. code::yaml                            |
+|                     | field name used to contain original     |                                          |
+|                     | element ids created from partitioning.  |    original_element_ids: elem_name       |
+|                     | The default value is                    |                                          |
+|                     | original_element_ids.                   |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
+| original_vertex_ids | A string value that provides desired    | .. code::yaml                            |
+|                     | field name used to contain original     |                                          |
+|                     | vertex ids created from partitioning.   |    original_vertex_ids: vert_name        |
+|                     | The default value is                    |                                          |
+|                     | original_vertex_ids.                    |                                          |
++---------------------+-----------------------------------------+------------------------------------------+
 
 
 Selections

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -1705,7 +1705,9 @@ Partitioner::Partitioner()
   selected_fields(),
   mapping(true),
   build_adjsets(true),
-  merge_tolerance(1.e-8)
+  merge_tolerance(1.e-8),
+  original_vertex_ids("original_vertex_ids"),
+  original_element_ids("original_element_ids")
 {
 }
 
@@ -1982,6 +1984,14 @@ Partitioner::initialize(const conduit::Node &n_mesh,
     // Get whether we want to preserve old numbering of vertices, elements.
     if(options.has_child("mapping"))
         mapping = options["mapping"].to_unsigned_int() != 0;
+
+    // Get the name of the original_vertex_ids field.
+    if(options.has_child("original_vertex_ids"))
+        original_vertex_ids = options["original_vertex_ids"].as_string();
+
+    // Get the name of the original_element_ids field.
+    if(options.has_child("original_element_ids"))
+        original_element_ids = options["original_element_ids"].as_string();
 
     // Get whether we want to build adjsets if they are present. This option
     // lets us ignore them.
@@ -2701,7 +2711,7 @@ Partitioner::copy_fields(index_t domain, const std::string &topology,
             if(mapping)
             {
                 // Save the vertex_ids as a new MC field.
-                conduit::Node &n_field = n_output_fields["original_vertex_ids"];
+                conduit::Node &n_field = n_output_fields[original_vertex_ids_name()];
                 n_field["association"] = "vertex";
                 if(!topology.empty())
                     n_field["topology"] = topology;
@@ -2732,7 +2742,7 @@ Partitioner::copy_fields(index_t domain, const std::string &topology,
             if(mapping)
             {
                 // Save the element_ids as a new MC field.
-                conduit::Node &n_field = n_output_fields["original_element_ids"];
+                conduit::Node &n_field = n_output_fields[original_element_ids_name()];
                 n_field["association"] = "element";
                 if(!topology.empty())
                     n_field["topology"] = topology;
@@ -3676,7 +3686,7 @@ Partitioner::wrap(size_t idx, const conduit::Node &n_mesh) const
     // Save the vertex_ids as a new MC field.
     if(nvertices > 0)
     {
-        conduit::Node &n_field = n_new_fields["original_vertex_ids"];
+        conduit::Node &n_field = n_new_fields[original_vertex_ids_name()];
         n_field["association"] = "vertex";
         if(!toponame.empty())
             n_field["topology"] = toponame;
@@ -3691,7 +3701,7 @@ Partitioner::wrap(size_t idx, const conduit::Node &n_mesh) const
     // Save the element_ids as a new MC field.
     if(nelements > 0)
     {
-        conduit::Node &n_field = n_new_fields["original_element_ids"];
+        conduit::Node &n_field = n_new_fields[original_element_ids_name()];
         n_field["association"] = "element";
         if(!toponame.empty())
             n_field["topology"] = toponame;
@@ -6582,6 +6592,8 @@ public:
     bool execute(const std::string &topo_name,
         const std::string &rt,
         const std::vector<const Node *> &n_inputs,
+        const std::string &original_element_ids,
+        const std::string &original_vertex_ids,
         Node &output,
         double merge_tolerance = CONDUIT_EPSILON)
     {
@@ -6769,7 +6781,7 @@ public:
         
         if(mode == CombineImplicitMode::Structured)
         {
-            retval = combine_structured_impl(n_meshes, output);
+            retval = combine_structured_impl(n_meshes, original_element_ids, original_vertex_ids, output);
         }
         else
         {
@@ -7853,6 +7865,8 @@ private:
     bool
     combine_structured_impl(
             const std::vector<const Node *> &n_meshes,
+            const std::string &original_element_ids,
+            const std::string &original_vertex_ids,
             Node &output) const
     {
         // Cannot use axis-aligned bounding boxes for structured grids
@@ -7879,18 +7893,20 @@ private:
                     Node &out_mesh = temp[(i < 10) ? "domain_0000" + std::to_string(i) : "domain_000" + std::to_string(i)];
                     out_mesh.set_external(mesh);
 
-                    out_mesh["fields/original_element_ids/association"] = "element";
-                    out_mesh["fields/original_element_ids/topology"] = "mesh";
+                    Node &oeid = out_mesh["fields/" + original_element_ids];
+                    oeid["association"] = "element";
+                    oeid["topology"] = "mesh";
                     Schema s;
                     const auto N = mesh["topologies/mesh/element_map"].dtype().number_of_elements() / 2;
                     const void *ptr = mesh["topologies/mesh/element_map"].element_ptr(0);
                     s["domains"].set(DataType::index_t(N, 0, 2*sizeof(index_t)));
                     s["ids"].set(DataType::index_t(N, sizeof(index_t), 2*sizeof(index_t)));
-                    out_mesh["fields/original_element_ids/values"].set_external(s, const_cast<void*>(ptr));
+                    oeid["values"].set_external(s, const_cast<void*>(ptr));
 
-                    out_mesh["fields/original_vertex_ids/association"] = "vertex";
-                    out_mesh["fields/original_vertex_ids/topology"] = "mesh";
-                    out_mesh["fields/original_vertex_ids/values"].set_external(mesh["coordsets/coords/pointmaps"]);
+                    Node &ovid = out_mesh["fields/" + original_vertex_ids];
+                    ovid["association"] = "vertex";
+                    ovid["topology"] = "mesh";
+                    ovid["values"].set_external(mesh["coordsets/coords/pointmaps"]);
                 }
                 std::ofstream f_out("combine_structured_iteration." + 
                     ((iteration < 10) ? ("0000" + std::to_string(iteration)) : ("000" + std::to_string(iteration)))
@@ -9895,11 +9911,11 @@ Partitioner::combine(int domain,
     }
 
     // Cleanup the output node, add original cells/verticies in needed
-    if(!output_fields.has_child("original_element_ids"))
+    if(!output_fields.has_child(original_element_ids_name()))
     {
         // Q: What happens in the case of multiple topologies?
         const Node &n_elem_map = output_topologies[0]["element_map"];
-        Node &out_field = output_fields["original_element_ids"];
+        Node &out_field = output_fields[original_element_ids_name()];
         out_field["topology"].set(output_topologies[0].name());
         // utils::ASSOCIATIONS[1]
         out_field["association"].set("element");
@@ -9950,7 +9966,7 @@ Partitioner::combine(int domain,
         output_topologies[i].remove("element_map");
     }
 
-    if(!output_fields.has_child("original_vertex_ids"))
+    if(!output_fields.has_child(original_vertex_ids_name()))
     {
         // Get the pointmaps
         const std::string &coordset_name = output_topologies[0]["coordset"].as_string();
@@ -9966,7 +9982,7 @@ Partitioner::combine(int domain,
             pointmaps.emplace_back(n_pointmaps[i].value());
         }
 
-        Node &out_field = output_fields["original_vertex_ids"];
+        Node &out_field = output_fields[original_vertex_ids_name()];
         out_field["topology"].set(output_topologies[0].name());
         // utils::ASSOCIATIONS[0]
         out_field["association"].set("vertex");
@@ -10031,6 +10047,14 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
     // the below should also init dom_to_rank_map in mpi partitioner
     auto orig_dom_ids = get_global_domids(orig_mesh);
 
+    // Get the name of the original_vertex_ids field.
+    if(options.has_child("original_vertex_ids"))
+        original_vertex_ids = options["original_vertex_ids"].as_string();
+
+    // Get the name of the original_element_ids field.
+    if(options.has_child("original_element_ids"))
+        original_element_ids = options["original_element_ids"].as_string();
+
     unordered_map<index_t, Node*> gid_to_orig_dom;
     for (size_t idom = 0; idom < orig_doms.size(); idom++)
     {
@@ -10080,9 +10104,9 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
     {
         const conduit::Node& dom = *repart_doms[idom];
 
-        if (dom["fields"].has_child("original_element_ids"))
+        if (dom["fields"].has_child(original_element_ids_name()))
         {
-            const Node& orig_v_node = dom["fields/original_element_ids/values"];
+            const Node& orig_v_node = dom["fields/" + original_element_ids_name() + "/values"];
             const index_t_accessor orig_elems_vals = orig_v_node["ids"].value();
             const index_t_accessor orig_doms_vals = orig_v_node["domains"].value();
             for (index_t ielem = 0; ielem < orig_elems_vals.number_of_elements(); ielem++)
@@ -10096,12 +10120,15 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
                 map_tgt_domains[idom].emplace_back(slice_map.first);
             }
         }
+#if 0
+// Or, the domain just does not have the field.
         else
         {
             CONDUIT_ERROR(
                 "Map-back requires that mesh repartitioning is performed with "
-                "the mapping option enabled. (missing original_element_ids)");
+                "the mapping option enabled. (missing " << original_element_ids_name() << ")");
         }
+#endif
     }
 
     // TODO: this is a lot of bookkeeping to do if we aren't mapping back a
@@ -10207,6 +10234,8 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
             const vector<index_t>& sel_verts = map_sel_verts[idom][tgt_dom];
             for (const std::string& field_name : field_names)
             {
+if(dom["fields"].has_child(field_name))
+{
                 const Node& field = dom["fields"][field_name];
                 const std::string& assoc = field["association"].as_string();
                 if (assoc == "vertex")
@@ -10223,6 +10252,11 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
                         conduit_fmt::format("Encountered field with unsupported association."
                                             " (field: {} association: {}", field_name, assoc));
                 }
+}
+else
+{
+    std::cout << "!! Skipping " << field_name << " because it is not in this domain."  << std::endl;
+}
             }
             // Add target element indices to the node
             remap_dom_ent["elem_map"].set(map_tgt_elems[idom][tgt_dom]);
@@ -10232,8 +10266,9 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
 
     // If we're multi-process, redistribute target field chunks to original
     // domain homes
+std::cout << "!! Before communicate_mapback\n";
     communicate_mapback(packed_fields);
-
+std::cout << "!! After communicate_mapback\n";
     for (const auto& orig_dom : packed_fields)
     {
         // Precompute final element count
@@ -10280,6 +10315,8 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
         {
             const vector<const Node*>& src_fields = fg.second;
             const string& field_name = fg.first;
+std::cout << "!! Reassemble " << field_name << "\n";
+
             const string& assoc = src_fields[0]->child("association").as_string();
             const string& assoc_topo = src_fields[0]->child("topology").as_string();
 
@@ -10309,7 +10346,7 @@ Partitioner::combine_as_structured(const std::string &topo_name,
     Node &output)
 {
     mesh::utils::combine_implicit_topologies combine;
-    return combine.execute(topo_name, rt, n_inputs, output);
+    return combine.execute(topo_name, rt, n_inputs, original_element_ids_name(), original_vertex_ids_name(), output);
 }
 
 //-------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.cpp
@@ -10120,15 +10120,12 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
                 map_tgt_domains[idom].emplace_back(slice_map.first);
             }
         }
-#if 0
-// Or, the domain just does not have the field.
         else
         {
             CONDUIT_ERROR(
                 "Map-back requires that mesh repartitioning is performed with "
                 "the mapping option enabled. (missing " << original_element_ids_name() << ")");
         }
-#endif
     }
 
     // TODO: this is a lot of bookkeeping to do if we aren't mapping back a
@@ -10234,8 +10231,6 @@ Partitioner::map_back_fields(const conduit::Node& repart_mesh,
             const vector<index_t>& sel_verts = map_sel_verts[idom][tgt_dom];
             for (const std::string& field_name : field_names)
             {
-if(dom["fields"].has_child(field_name))
-{
                 const Node& field = dom["fields"][field_name];
                 const std::string& assoc = field["association"].as_string();
                 if (assoc == "vertex")
@@ -10252,11 +10247,6 @@ if(dom["fields"].has_child(field_name))
                         conduit_fmt::format("Encountered field with unsupported association."
                                             " (field: {} association: {}", field_name, assoc));
                 }
-}
-else
-{
-    std::cout << "!! Skipping " << field_name << " because it is not in this domain."  << std::endl;
-}
             }
             // Add target element indices to the node
             remap_dom_ent["elem_map"].set(map_tgt_elems[idom][tgt_dom]);
@@ -10266,9 +10256,7 @@ else
 
     // If we're multi-process, redistribute target field chunks to original
     // domain homes
-std::cout << "!! Before communicate_mapback\n";
     communicate_mapback(packed_fields);
-std::cout << "!! After communicate_mapback\n";
     for (const auto& orig_dom : packed_fields)
     {
         // Precompute final element count
@@ -10315,7 +10303,6 @@ std::cout << "!! After communicate_mapback\n";
         {
             const vector<const Node*>& src_fields = fg.second;
             const string& field_name = fg.first;
-std::cout << "!! Reassemble " << field_name << "\n";
 
             const string& assoc = src_fields[0]->child("association").as_string();
             const string& assoc_topo = src_fields[0]->child("topology").as_string();

--- a/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_partition.hpp
@@ -734,6 +734,26 @@ protected:
         const std::vector<std::vector<index_t>>& remap_to_local_doms,
         std::map<index_t, std::vector<index_t>>& orig_dom_gvids);
 
+    /**
+     @brief Return the name of the field that contains original vertex ids.
+
+     @return The name of the field to use for original vertex ids.
+     */
+    const std::string &original_vertex_ids_name() const
+    {
+        return original_vertex_ids;
+    }
+
+    /**
+     @brief Return the name of the field that contains original element ids.
+
+     @return The name of the field to use for original element ids.
+     */
+    const std::string &original_element_ids_name() const
+    {
+        return original_element_ids;
+    }
+
     int rank, size;
     unsigned int target;
     std::vector<const Node *>                meshes;
@@ -742,6 +762,8 @@ protected:
     bool                                     mapping;
     bool                                     build_adjsets;
     double                                   merge_tolerance;
+    std::string                              original_vertex_ids;
+    std::string                              original_element_ids;
 };
 
 }

--- a/src/tests/blueprint/t_blueprint_mesh_partition.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_partition.cpp
@@ -2859,13 +2859,21 @@ TEST(conduit_blueprint_mesh_partition, map_back_set_external)
     conduit::Node part, options;
     options["target"] = 2;
     options["mapping"] = 1;
+    options["original_element_ids"] = "eids";
+    options["original_vertex_ids"] = "vids";
     //std::cout << "Calling partition" << std::endl;
     //options.print();
     conduit::blueprint::mesh::partition(mesh, options, part);
 
-    // Compute the fields on the part mesh.
     auto domains = conduit::blueprint::mesh::domains(part);
     EXPECT_EQ(domains.size(), 2);
+    for(auto &dom : domains)
+    {
+        EXPECT_TRUE(dom->has_path("fields/eids/values"));
+        EXPECT_TRUE(dom->has_path("fields/vids/values"));
+    }
+
+    // Compute the fields on the part mesh.
     for(auto &dom : domains)
     {
         compute_nodal_field(*dom, dom->fetch_existing("fields/nodal"));
@@ -2881,6 +2889,8 @@ TEST(conduit_blueprint_mesh_partition, map_back_set_external)
     mbopts["fields"].append().set("zonal");
     mbopts["fields"].append().set("nodalvec");
     mbopts["fields"].append().set("zonalvec");
+    mbopts["original_element_ids"] = "eids";
+    mbopts["original_vertex_ids"] = "vids";
     //std::cout << "Calling partition_map_back" << std::endl;
     //mbopts.print();
     conduit::blueprint::mesh::partition_map_back(part, mbopts, mesh);


### PR DESCRIPTION
When partitioning multiple topologies is can be helpful to be able to specify the names of the fields for original_element_ids, original_vertex_ids so all topologies and their respective "original" fields can all live in the same Conduit node.