### PR TITLE
Fix issue with MPI tags on some MPI distributions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Changed `conduit::blueprint::mesh::partition_map_back()` function so it will attempt to reuse existing field memory when mapping fields back. This permits `partition_map_back()` to send data from a partitioned mesh into the original mesh where fields were provided from a host code using `Node::set_external()`.
 
 #### Relay
-
+- Changed `conduit::relay::mpi::communicate_using_schema` to avoid an invalid tag MPI error message on some MPI distributions.
 
 ## [0.9.1] - Released 2024-02-09
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_flatten.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_flatten.cpp
@@ -297,29 +297,6 @@ generate_element_centers_impl(const Node &topo, const index_t dimension,
         // Polyhedra must be handled specially.
         if(e.shape.is_polyhedral())
         {
-#if 0
-            std::cout << "entity_id: " << e.entity_id << std::endl;
-            std::cout << "element_ids.size: " << e.element_ids.size() << std::endl;
-            std::cout << "element_ids: [";
-            for(const auto &value : e.element_ids)
-               std::cout << value << ", ";
-            std::cout << "]\n";
-            std::cout << "subelement_ids.size: " << e.subelement_ids.size() << std::endl;
-            std::cout << "subelement_ids:\n";
-            for(const auto &facePointIds : e.subelement_ids)
-            {
-                std::cout << "  -\n    [";
-                for(const auto &id : facePointIds)
-                    std::cout << id << ", ";
-                std::cout << "]\n";
-            }
-            std::cout << "cset_values[0].number_of_elements=" << cset_values[0].number_of_elements() << std::endl;
-            std::cout << "cset_values[1].number_of_elements=" << cset_values[1].number_of_elements() << std::endl;
-            std::cout << "cset_values[2].number_of_elements=" << cset_values[2].number_of_elements() << std::endl;
-            std::cout << "\n\n";
-            std::cout.flush();
-#endif
-
             for(index_t d = 0; d < dimension; d++)
             {
                 OutputType sum = 0;

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
@@ -464,7 +464,7 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
             for (const std::set<uint64>& group : recv_groups)
             {
                 index_t domid = *(group.begin());
-                const int tag = TAG_SHARED_NODE_SYNC + domid * 100 + group_idx;
+                const int tag = conduit::relay::mpi::safe_tag(TAG_SHARED_NODE_SYNC + domid * 100 + group_idx);
                 async_recvs.push_back(MPI_Request{});
                 group_idx++;
                 std::vector<uint64>& recvbuf = groups_2_vids[group];
@@ -484,7 +484,7 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
             for (const std::set<uint64>& group : send_groups)
             {
                 index_t domid = *(group.begin());
-                const int tag = TAG_SHARED_NODE_SYNC + domid * 100 + group_idx;
+                const int tag = conduit::relay::mpi::safe_tag(TAG_SHARED_NODE_SYNC + domid * 100 + group_idx);
                 async_sends.push_back(MPI_Request{});
                 group_idx++;
                 const std::vector<uint64>& sendbuf = groups_2_vids[group];

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
@@ -17,7 +17,7 @@
 #include "conduit_annotations.hpp"
 #include "conduit_relay_mpi.hpp"
 
-//#define DEBUG_PRINT
+// #define DEBUG_PRINT
 #ifdef DEBUG_PRINT
 // NOTE: if DEBUG_PRINT is defined then the library must also depend on conduit_relay
 #include "conduit_relay_io.hpp"
@@ -73,7 +73,7 @@ PointQuery::execute(const std::string &coordsetName)
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
 
-    int rank, size;
+    int rank = 0, size = 1;
     MPI_Comm_rank(m_comm, &rank);
     MPI_Comm_size(m_comm, &size);
 
@@ -323,7 +323,7 @@ MatchQuery::execute()
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
 
-    int rank, size;
+    int rank = 0, size = 1;
     MPI_Comm_rank(m_comm, &rank);
     MPI_Comm_size(m_comm, &size);
 

--- a/src/libs/relay/conduit_relay_mpi.hpp
+++ b/src/libs/relay/conduit_relay_mpi.hpp
@@ -77,6 +77,17 @@ namespace mpi
 /// Standard MPI Send Recv
 //-----------------------------------------------------------------------------
 
+    /**
+      @brief MPI tags can be in the range [0,MPI_TAG_UB]. The values are
+             implementation-dependent. If the tag is not in that range, return
+             MPI_TAG_UB so it is safe to use with MPI functions.
+
+      @param tag The input tag.
+
+      @return A tag value that is safe to use with MPI.
+    */
+    int CONDUIT_RELAY_API safe_tag(int tag);
+
     int CONDUIT_RELAY_API send(const Node &node,
                                 int dest,
                                 int tag,


### PR DESCRIPTION
Some blueprint algorithms use MPI tags to help indicate intent of a message and they may use large numbers for the tags. It turns out that some MPI distributions do not like large tag values. This PR changes a communication helper class in relay so it passes tags through a safe_tag() function that clamps tags at MPI_TAG_UB so they work with MPI rather than having MPI abort.