### PR TITLE
Move H5Sclose call to proper scope

### DIFF
--- a/src/libs/relay/conduit_relay_io_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_io_hdf5.cpp
@@ -1837,8 +1837,8 @@ write_conduit_leaf_to_hdf5_dataset(const Node &node,
         }
 
         H5Sclose(nodespace);
-        H5Sclose(dataspace);
     }
+    H5Sclose(dataspace);
 
     // check write result
     CONDUIT_CHECK_HDF5_ERROR_WITH_FILE_AND_REF_PATH(h5_status,


### PR DESCRIPTION
Follow-up to #1277 , the `H5SClose(dataspace)` call was in the `else` block of an if-else statement, so the object was never closed in the `if (true)` case.