### PR TITLE
Fixes for tags that affected PointQuery on some systems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Conduit
 - Changed the MPI CMake target used by conduit from `MPI:MPI_CXX` to `MPI:MPI_C` to provide better compatibility with downstream tools.
 
+#### Blueprint
+- Certain algorithms that use MPI tags had their tag values lowered since some MPI implementations do not support large values.
+
+#### Relay
+- User-supplied warning and error handlers are suspended during `conduit::relay::communicate_using_schema::execute()` so exceptions will be thrown properly when there is an MPI error. The handlers are restored before the execute method returns.
+- `conduit::relay::communicate_using_schema::execute()` flushes logs as they are generated, in case of error. This is mostly to facilitate internal debugging.
+- Changes were made to how Relay queries the upper limit for MPI tags to work around problems on some systems.
+
 ## [0.9.2] - Released 2024-05-21
 
 ### Added

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
@@ -375,7 +375,7 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
 
     if (adjset_name != "")
     {
-        const int TAG_SHARED_NODE_SYNC = 0;
+        const int TAG_SHARED_NODE_SYNC = 175;
         // map of groups -> global vtx ids
         std::map<std::set<uint64>, std::vector<uint64>> groups_2_vids;
         // map of rank -> sends to/recvs from that rank of global vtx ids for

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp
@@ -375,7 +375,7 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
 
     if (adjset_name != "")
     {
-        const int TAG_SHARED_NODE_SYNC = 175000000;
+        const int TAG_SHARED_NODE_SYNC = 0;
         // map of groups -> global vtx ids
         std::map<std::set<uint64>, std::vector<uint64>> groups_2_vids;
         // map of rank -> sends to/recvs from that rank of global vtx ids for
@@ -464,7 +464,7 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
             for (const std::set<uint64>& group : recv_groups)
             {
                 index_t domid = *(group.begin());
-                const int tag = conduit::relay::mpi::safe_tag(TAG_SHARED_NODE_SYNC + domid * 100 + group_idx);
+                const int tag = conduit::relay::mpi::safe_tag(TAG_SHARED_NODE_SYNC + domid * 100 + group_idx, comm);
                 async_recvs.push_back(MPI_Request{});
                 group_idx++;
                 std::vector<uint64>& recvbuf = groups_2_vids[group];
@@ -484,7 +484,7 @@ void generate_global_element_and_vertex_ids(conduit::Node &mesh,
             for (const std::set<uint64>& group : send_groups)
             {
                 index_t domid = *(group.begin());
-                const int tag = conduit::relay::mpi::safe_tag(TAG_SHARED_NODE_SYNC + domid * 100 + group_idx);
+                const int tag = conduit::relay::mpi::safe_tag(TAG_SHARED_NODE_SYNC + domid * 100 + group_idx, comm);
                 async_sends.push_back(MPI_Request{});
                 group_idx++;
                 std::vector<uint64>& sendbuf = groups_2_vids[group];

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
@@ -436,12 +436,12 @@ MatchQuery::execute()
     C.set_logging_root("mpi_matchquery");
     C.set_logging(true);
 #endif
-    int query_tag = 1;
+    const int query_tag = 770;
     for(size_t i = 0; i < allqueries.size(); i += ntuple_values)
     {
-        int owner = allqueries[i];
-        int domain = allqueries[i + 1];
-        int query_domain = allqueries[i + 2];
+        const int owner = allqueries[i];
+        const int domain = allqueries[i + 1];
+        const int query_domain = allqueries[i + 2];
 
         auto oppositeKey = std::make_pair(query_domain, domain);
 
@@ -668,7 +668,7 @@ compare_pointwise_impl(conduit::Node &mesh, const std::string &adjsetName,
 
     // Iterate over each of the possible adjset relationships. Not all of these
     // will have adjset groups.
-    const int tag = 1;
+    const int tag = 122;
     for(int d0 = 0; d0 < maxDomains; d0++)
     {
         for(int d1 = d0 + 1; d1 < maxDomains; d1++)

--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_utils.cpp
@@ -173,8 +173,8 @@ PointQuery::execute(const std::string &coordsetName)
     // the results. The results get stored in m_domResults.
     std::map<std::pair<int,int>, conduit::Node *> input_sends, result_sends,
                                                   input_recvs, result_recvs;
-    int inputs_tag = 55000000;
-    int results_tag = 66000000;
+    const int inputs_tag = 550;
+    const int results_tag = 660;
     for(int pass = 0; pass < 2; pass++)
     {
         conduit::relay::mpi::communicate_using_schema C(m_comm);
@@ -187,10 +187,10 @@ PointQuery::execute(const std::string &coordsetName)
 #endif
         for(size_t i = 0; i < allqueries.size(); i += 3)
         {
-            int asker  = allqueries[i];
-            int domain = allqueries[i+1];
-            int npts   = allqueries[i+2];
-            int owner = domain_to_rank[domain];
+            const int asker  = allqueries[i];
+            const int domain = allqueries[i+1];
+            const int npts   = allqueries[i+2];
+            const int owner = domain_to_rank[domain];
 
             if(asker == rank)
             {
@@ -278,6 +278,7 @@ PointQuery::execute(const std::string &coordsetName)
     for(auto it = result_recvs.begin(); it != result_recvs.end(); it++)
     {
         int domain = it->first.second;
+
         const conduit::Node &r = it->second->fetch_existing("results");
         auto acc = r.as_int_accessor();
         std::vector<int> &result = m_domResults[domain];
@@ -435,7 +436,7 @@ MatchQuery::execute()
     C.set_logging_root("mpi_matchquery");
     C.set_logging(true);
 #endif
-    int query_tag = 77000000;    
+    int query_tag = 1;
     for(size_t i = 0; i < allqueries.size(); i += ntuple_values)
     {
         int owner = allqueries[i];
@@ -667,7 +668,7 @@ compare_pointwise_impl(conduit::Node &mesh, const std::string &adjsetName,
 
     // Iterate over each of the possible adjset relationships. Not all of these
     // will have adjset groups.
-    const int tag = 12211221;
+    const int tag = 1;
     for(int d0 = 0; d0 < maxDomains; d0++)
     {
         for(int d1 = d0 + 1; d1 < maxDomains; d1++)

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -313,6 +313,7 @@ int safe_tag(int tag, MPI_Comm comm)
       // the range than to just clamp them.
       newtag = newtag % tag_ub;
     }
+std::cout << "**** safe_tag(" << tag << ")->" << newtag << std::endl;
     return newtag;
 }
 
@@ -1016,11 +1017,12 @@ isend(const Node &node,
                      "(" << std::numeric_limits<int>::max() << ")")
     }
 
+    const int newtag = safe_tag(tag, mpi_comm);
     int mpi_error =  MPI_Isend(const_cast<void*>(data_ptr), 
                                static_cast<int>(data_size),
                                MPI_BYTE, 
                                dest, 
-                               safe_tag(tag, mpi_comm),
+                               newtag,
                                mpi_comm,
                                &(request->m_request));
                                
@@ -1069,11 +1071,12 @@ irecv(Node &node,
                      "(" << std::numeric_limits<int>::max() << ")")
     }
 
+    const int newtag = safe_tag(tag, mpi_comm);
     int mpi_error =  MPI_Irecv(data_ptr,
                                static_cast<int>(data_size),
                                MPI_BYTE,
                                src,
-                               safe_tag(tag, mpi_comm),
+                               newtag,
                                mpi_comm,
                                &(request->m_request));
 

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -313,7 +313,7 @@ int safe_tag(int tag, MPI_Comm comm)
       // the range than to just clamp them.
       newtag = newtag % tag_ub;
     }
-std::cout << "**** safe_tag(" << tag << ")->" << newtag << std::endl;
+
     return newtag;
 }
 

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -312,8 +312,8 @@ private:
     }
 
     /// MPI calls this function to handle errors.
-    static void handler(MPI_Comm */*comm*/,
-                        int      */*errcode*/,
+    static void handler(MPI_Comm * /*comm*/,
+                        int      * /*errcode*/,
                         ...)
     {
 #if 0
@@ -374,7 +374,7 @@ public:
 
 private:
     /**
-     * @brief Query MPI for the maximum tag value, set m_upper_bound on success.
+     * @brief Query MPI for the maximum tag value.
      *
      * @param comm The MPI communicator.
      *
@@ -401,7 +401,7 @@ private:
     }
 
     /**
-     * @brief Probe MPI to determine the max tag value and set m_upper_bound.
+     * @brief Probe MPI to determine the max tag value.
      *
      * @param comm The MPI communicator.
      *

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 
 #include "conduit_relay_mpi.hpp"
+#include <algorithm>
 #include <iostream>
 #include <limits>
 

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -496,9 +496,9 @@ bool invalid_tag(int tag)
 
 //---------------------------------------------------------------------------//
 /**
- @brief MPI tags can be in the range [0,MPI_TAG_UB]. The values are
-        implementation-dependent. If the tag is not in that range, return
-        the value for MPI_TAG_UB so it is safe to use with MPI functions.
+ @brief Return a tag value that is safe to use with MPI functions. The tag is
+        determined dynamically the first time the function is called. If the
+        input tag is greater than the max tag then the value is clamped.
 
  @param tag The input tag.
  @param comm The MPI communicator.

--- a/src/libs/relay/conduit_relay_mpi.hpp
+++ b/src/libs/relay/conduit_relay_mpi.hpp
@@ -83,10 +83,11 @@ namespace mpi
              MPI_TAG_UB so it is safe to use with MPI functions.
 
       @param tag The input tag.
+      @param comm The MPI communicator.
 
       @return A tag value that is safe to use with MPI.
     */
-    int CONDUIT_RELAY_API safe_tag(int tag);
+    int CONDUIT_RELAY_API safe_tag(int tag, MPI_Comm comm);
 
     int CONDUIT_RELAY_API send(const Node &node,
                                 int dest,

--- a/src/libs/relay/conduit_relay_mpi.hpp
+++ b/src/libs/relay/conduit_relay_mpi.hpp
@@ -337,6 +337,13 @@ public:
 private:
     void clear();
 
+    /**
+     @brief Execute all the outstanding isend/irecv calls and reconstruct any
+            nodes after doing the data movement.
+     @return The return value from MPI_Waitall.
+     */
+    int  execute_internal();
+
     static const int OP_SEND;
     static const int OP_RECV;
     struct operation


### PR DESCRIPTION
On rzadams, the MPI does not like large tag values. The PointQuery algorithm (and others) were using large tag values. The mechanism put in place to query a communicator's upper tag limit was not quite right before. This PR updates some of that logic and lowers some tag values so they're more likely to work with that MPI.

Also, in relay::mpi::communicate_using_schema it was possible for a user-registered error function to prevent exceptions from being thrown when needed. The class now temporarily suspends user-registered warning/error functions so exceptions will get thrown if MPI errors or other errors occur. This should make errors easier to diagnose.