### PR TITLE
Avoid relinking python modules on every rebuild

### DIFF
--- a/src/libs/blueprint/python/CMakeLists.txt
+++ b/src/libs/blueprint/python/CMakeLists.txt
@@ -14,10 +14,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_python PRIVATE conduit conduit_blueprint conduit_python_build)
 
 #############################################################
 # blueprint.mcarray
@@ -32,10 +32,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_mcarray_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_mcarray_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mcarray_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_mcarray_python PRIVATE conduit conduit_blueprint conduit_python_build)
 
 # add mcarray examples submodule
 PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_examples_python
@@ -46,10 +46,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mcarray_examples_pyth
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_mcarray_examples_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_mcarray_examples_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mcarray_examples_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_mcarray_examples_python PRIVATE conduit conduit_blueprint conduit_python_build)
 
 #############################################################
 # blueprint.mesh
@@ -64,10 +64,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mesh_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_mesh_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_mesh_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mesh_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_mesh_python PRIVATE conduit conduit_blueprint conduit_python_build)
 
 
 # add mesh examples submodule
@@ -79,10 +79,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_mesh_examples_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_mesh_examples_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_mesh_examples_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_mesh_examples_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_mesh_examples_python PRIVATE conduit conduit_blueprint conduit_python_build)
 
 #############################################################
 # blueprint.table
@@ -97,10 +97,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_table_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_table_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_table_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_table_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_table_python PRIVATE conduit conduit_blueprint conduit_python_build)
 
 
 # add table examples submodule
@@ -112,7 +112,7 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_blueprint_table_examples_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_blueprint_table_examples_python conduit_python_py_setup)
+target_link_libraries(conduit_blueprint_table_examples_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_blueprint_table_examples_python conduit conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_blueprint_table_examples_python PRIVATE conduit conduit_blueprint conduit_python_build)

--- a/src/libs/conduit/python/CMakeLists.txt
+++ b/src/libs/conduit/python/CMakeLists.txt
@@ -44,7 +44,7 @@ PYTHON_ADD_HYBRID_MODULE(NAME          conduit_python
                          FOLDER        libs/python)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_python conduit conduit_python_build)
+target_link_libraries(conduit_python PRIVATE conduit conduit_python_build)
 
 
 #############################################################
@@ -60,10 +60,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_utils_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_utils_python conduit_python_py_setup)
+target_link_libraries(conduit_utils_python PRIVATE conduit_python_py_setup)
                            
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_utils_python conduit conduit_python_build)
+target_link_libraries(conduit_utils_python PRIVATE conduit conduit_python_build)
 
 # install the capi header so other python modules can use it
 # support alt install dir for python module via PYTHON_MODULE_INSTALL_PREFIX

--- a/src/libs/relay/python/CMakeLists.txt
+++ b/src/libs/relay/python/CMakeLists.txt
@@ -14,10 +14,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_relay_python conduit_python_py_setup)
+target_link_libraries(conduit_relay_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs
-target_link_libraries(conduit_relay_python conduit conduit_relay conduit_python_build)
+target_link_libraries(conduit_relay_python PRIVATE conduit conduit_relay conduit_python_build)
 
 # add relay io submodule
 PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_python
@@ -28,10 +28,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_relay_io_python conduit_python_py_setup)
+target_link_libraries(conduit_relay_io_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_relay_io_python conduit conduit_relay conduit_python_build)
+target_link_libraries(conduit_relay_io_python PRIVATE conduit conduit_relay conduit_python_build)
 
 # add relay io blueprint submodule
 PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_blueprint_python
@@ -42,10 +42,10 @@ PYTHON_ADD_COMPILED_MODULE(NAME          conduit_relay_io_blueprint_python
                            FOLDER        libs/python)
 
 # compiled modules depend on output dir structure created by main module setup
-add_dependencies( conduit_relay_io_blueprint_python conduit_python_py_setup)
+target_link_libraries(conduit_relay_io_blueprint_python PRIVATE conduit_python_py_setup)
 
 # link with the proper libs (beyond python)
-target_link_libraries(conduit_relay_io_blueprint_python conduit conduit_relay conduit_blueprint conduit_python_build)
+target_link_libraries(conduit_relay_io_blueprint_python PRIVATE conduit conduit_relay conduit_blueprint conduit_python_build)
 
 if(SILO_FOUND)
 
@@ -58,10 +58,10 @@ if(SILO_FOUND)
                                FOLDER        libs/python)
 
     # compiled modules depend on output dir structure created by main module setup
-    add_dependencies( conduit_relay_io_silo_python conduit_python_py_setup)
+    target_link_libraries(conduit_relay_io_silo_python PRIVATE conduit_python_py_setup)
 
     # link with the proper libs (beyond python)
-    target_link_libraries(conduit_relay_io_silo_python conduit conduit_relay conduit_blueprint conduit_python_build)
+    target_link_libraries(conduit_relay_io_silo_python PRIVATE conduit conduit_relay conduit_blueprint conduit_python_build)
 
 endif()
 
@@ -75,10 +75,10 @@ if(ENABLE_RELAY_WEBSERVER)
                                FOLDER        libs/python)
 
     # compiled modules depend on output dir structure created by main module setup
-    add_dependencies( conduit_relay_web_python conduit_python_py_setup)
+    target_link_libraries(conduit_relay_web_python PRIVATE conduit_python_py_setup)
 
     # link with the proper libs (beyond python)
-    target_link_libraries(conduit_relay_web_python conduit conduit_relay conduit_python_build)
+    target_link_libraries(conduit_relay_web_python PRIVATE conduit conduit_relay conduit_python_build)
 endif()
 
 ################################################################
@@ -96,10 +96,10 @@ if(MPI_FOUND)
                                FOLDER        libs/python)
 
     # compiled modules depend on output dir structure created by main module setup
-    add_dependencies( conduit_relay_mpi_python conduit_python_py_setup)
+    target_link_libraries(conduit_relay_mpi_python PRIVATE conduit_python_py_setup)
 
     # link with the proper libs (beyond python)
-    target_link_libraries(conduit_relay_mpi_python conduit conduit_relay_mpi conduit_python_build)
+    target_link_libraries(conduit_relay_mpi_python PRIVATE conduit conduit_relay_mpi conduit_python_build)
 
 endif()
 


### PR DESCRIPTION
Avoid rerunning `conduit_python_py_setup`'s `pip install` command on every invocation of `make` or `ninja` by recording its last execution time with an output time stamp file.  Whenever it does rerun, such as when an input file changes, relink dependent python modules since the `pip install` command wipes out its `--target` directory.  This can be achieved by making `conduit_python_py_setup` an INTERFACE library that propagates the time stamp file as a link dependency of dependent python modules through `INTERFACE_LINK_DEPENDS`.