### PR TITLE
Silo/Overlink I/O Careful Handling of Names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Testing/
 .vscode/launch.json
 scripts/azemu/AZEMU-LAUNCH*.sh
 scripts/azemu/AZEMU-SCRIPT*.sh
+.gitignore_backup
+src/libs/conduit/python/build/
+src/libs/conduit/python/conduit.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ Testing/
 .vscode/launch.json
 scripts/azemu/AZEMU-LAUNCH*.sh
 scripts/azemu/AZEMU-SCRIPT*.sh
-.gitignore_backup
-src/libs/conduit/python/build/
-src/libs/conduit/python/conduit.egg-info/

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -316,7 +316,7 @@ public:
 // silo likes alphanumeric names
 bool check_alphanumeric(const std::string &str)
 {
-    for (char ch : str)
+    for (const char &ch : str)
     {
         if (!std::isalnum(ch) && ch != '_')
         {

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -4938,8 +4938,6 @@ void silo_write_matset(DBfile *dbfile,
 
     Node bookkeeping_info;
     bookkeeping_info["comp_info"]["comp"] = "matsets";
-    // TODO I may want to save overlink names here instead as things will get crazy
-    // when we start doing this for specsets - think about this
     bookkeeping_info["comp_info"]["comp_name"] = matset_name;
     bookkeeping_info["domain_info"]["local_num_domains"] = local_num_domains;
     bookkeeping_info["domain_info"]["local_domain_index"] = local_domain_index;

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -149,10 +149,10 @@ TEST(conduit_relay_io_silo, round_trip_basic)
     };
     for (int i = 0; i < mesh_types.size(); ++i)
     {
-        std::string dim = mesh_types[i].second;
-        index_t nx = 3;
-        index_t ny = 4;
-        index_t nz = (dim == "2" ? 0 : 2);
+        const std::string dim = mesh_types[i].second;
+        const index_t nx = 3;
+        const index_t ny = 4;
+        const index_t nz = (dim == "2" ? 0 : 2);
 
         const std::string mesh_type = mesh_types[i].first;
 
@@ -180,6 +180,44 @@ TEST(conduit_relay_io_silo, round_trip_basic)
         EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
         EXPECT_FALSE(load_mesh[0].diff(save_mesh, info, CONDUIT_EPSILON, true));
     }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_relay_io_silo, round_trip_avoid_name_collisions)
+{
+    Node save_mesh, load_mesh, info;
+    blueprint::mesh::examples::misc("specsets", 4, 4, 1, save_mesh);
+    save_mesh["fields"]["mesh"].set(save_mesh["fields"]["braid"]);
+    save_mesh["matsets"]["matset"].set(save_mesh["matsets"]["mesh"]);
+    save_mesh["specsets"]["specset"].set(save_mesh["specsets"]["mesh"]);
+    save_mesh["specsets"]["specset"]["matset"].set("matset");
+
+    const std::string basename = "silo_round_trip_avoid_name_collisions";
+    const std::string filename = basename + ".cycle_000100.root";;
+
+    Node read_opts;
+    read_opts["matset_style"] = "multi_buffer_full";
+
+    remove_path_if_exists(filename);
+    io::silo::save_mesh(save_mesh, basename);
+    io::silo::load_mesh(filename, read_opts, load_mesh);
+    EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+    save_mesh["fields"].remove_child("mesh");
+    save_mesh["matsets"].remove_child("mesh");
+    save_mesh["specsets"].remove_child("mesh");
+
+    // TODO remove this once we add specsets
+    save_mesh.remove_child("specsets");
+
+    // make changes to save mesh so the diff will pass
+    silo_name_changer("mesh", save_mesh);
+
+    // the loaded mesh will be in the multidomain format
+    // but the saved mesh is in the single domain format
+    EXPECT_EQ(load_mesh.number_of_children(), 1);
+    EXPECT_EQ(load_mesh[0].number_of_children(), save_mesh.number_of_children());
+    EXPECT_FALSE(load_mesh[0].diff(save_mesh, info, CONDUIT_EPSILON, true));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- fail when names are not alphanumeric instead of renaming things
- prevent name collisions
- new test to check that name collisions are avoided
- refactor generate_silo_names
- misc fixes