### PR TITLE
Expand species sets representations

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -6723,7 +6723,6 @@ mesh::specset::verify(const Node &specset,
             {
                 const Node &mat = mat_it.next();
                 const std::string &mat_name = mat_it.name();
-                Node &mat_info = mfs_info[mat_name];
 
                 if (!mat.dtype().is_object())
                 {
@@ -6733,6 +6732,7 @@ mesh::specset::verify(const Node &specset,
                 }
                 else
                 {
+                    Node &mat_info = mfs_info[mat_name];
                     NodeConstIterator spec_it = mat.children();
                     while (spec_it.has_next())
                     {
@@ -6748,6 +6748,9 @@ mesh::specset::verify(const Node &specset,
                             mvs_res &= verify_number_field(protocol, mat, mat_info, spec_name);
                         }
                     }
+
+                    res &= mvs_res;
+                    log::validation(mat_info, mvs_res);
                 }
             }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -6819,8 +6819,6 @@ bool
 mesh::specset::index::verify(const Node &specset_idx,
                              Node &info)
 {
-    specset_idx.print();
-
     const std::string protocol = "mesh::specset::index";
     bool res = true;
     info.reset();

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -2365,20 +2365,34 @@ mesh::generate_index_for_single_domain(const Node &mesh,
 
             idx_specset["matset"] = specset["matset"].as_string();
 
-            NodeConstIterator matset_vals_itr = specset["matset_values"].children();
-            while(matset_vals_itr.has_next())
+            if (specset.has_child("species_names"))
             {
-                const Node &matset_val = matset_vals_itr.next();
-                const std::string matname = matset_vals_itr.name();
-
-                NodeConstIterator specs_itr = matset_val.children();
-                while(specs_itr.has_next())
+                idx_specset["species"] = specset["species_names"];
+            }
+            else if (specset.has_child("matset_values"))
+            {
+                NodeConstIterator matset_vals_itr = specset["matset_values"].children();
+                while(matset_vals_itr.has_next())
                 {
-                    specs_itr.next();
-                    const std::string specname = specs_itr.name();
-                    idx_specset["species"][matname][specname];
+                    const Node &matset_val = matset_vals_itr.next();
+                    const std::string matname = matset_vals_itr.name();
+
+                    NodeConstIterator specs_itr = matset_val.children();
+                    while(specs_itr.has_next())
+                    {
+                        specs_itr.next();
+                        const std::string specname = specs_itr.name();
+                        idx_specset["species"][matname][specname];
+                    }
                 }
             }
+            else // surprise!
+            {
+                CONDUIT_ERROR("blueprint::mesh::generate_index: "
+                              "Invalid specset flavor."
+                              "Input node does not conform to mesh blueprint.");
+            }
+
             std::string ms_ref_path = join_path(ref_path, "specsets");
             ms_ref_path = join_path(ms_ref_path, specset_name);
             idx_specset["path"] = ms_ref_path;
@@ -6629,54 +6643,166 @@ mesh::field::index::verify(const Node &field_idx,
 //-----------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------
+// helper to verify a specset species_names
+//-----------------------------------------------------------------------------
+bool verify_specset_species_names(const std::string &protocol,
+                                  const conduit::Node &specset,
+                                  conduit::Node &info)
+{
+    bool res = verify_object_field(protocol, specset, info, "species_names");
+
+    if (res)
+    {
+        // we already know we have an object, children should be
+        // objects
+        NodeConstIterator itr = specset["species_names"].children();
+        while (itr.has_next())
+        {
+            const Node &curr_child = itr.next();
+            if (!curr_child.dtype().is_object())
+            {
+                log::error(info,
+                           protocol,
+                           log::quote("species_names") +
+                           "child " +
+                           log::quote(itr.name()) +
+                           " is not an object.");
+                res = false;
+            }
+        }
+    }
+
+    log::validation(info, res);
+
+    return res;
+}
+
+//-----------------------------------------------------------------------------
 bool
 mesh::specset::verify(const Node &specset,
                       Node &info)
 {
     const std::string protocol = "mesh::specset";
-    bool res = true;
+    bool res = true, mvs_res = true;
+    bool specnames_are_optional = true;
     info.reset();
 
     res &= verify_string_field(protocol, specset, info, "matset");
-    if(!verify_object_field(protocol, specset, info, "matset_values"))
+    res &= mvs_res &= verify_field_exists(protocol, specset, info, "matset_values");
+
+    if (mvs_res)
     {
+        if (!specset["matset_values"].dtype().is_number() &&
+            !specset["matset_values"].dtype().is_object())
+        {
+            log::error(info, protocol, "'matset_values' isn't the correct type");
+            res &= mvs_res &= false;
+        }
+        else if (specset["matset_values"].dtype().is_number() &&
+                 verify_number_field(protocol, specset, info, "matset_values"))
+        {
+            log::info(info, protocol, "detected uni-buffer specset");
+            // species_names is not optional in this case, signal
+            // for opt check down the line
+            specnames_are_optional = false;
+
+            mvs_res &= blueprint::o2mrelation::verify(specset, info);
+
+            res &= mvs_res;
+        }
+        else if (specset["matset_values"].dtype().is_object() &&
+                 verify_object_field(protocol, specset, info, "matset_values"))
+        {
+            log::info(info, protocol, "detected multi-buffer specset");
+
+            const Node &mfs = specset["matset_values"];
+            Node &mfs_info = info["matset_values"];
+
+            NodeConstIterator mat_it = mfs.children();
+            while (mat_it.has_next())
+            {
+                const Node &mat = mat_it.next();
+                const std::string &mat_name = mat_it.name();
+                Node &mat_info = mfs_info[mat_name];
+
+                if (!mat.dtype().is_object())
+                {
+                    log::error(info, protocol,
+                               "each material name must be the parent of species names (required for multi-buffer specsets) ");
+                    res &= mvs_res &= false;
+                }
+                else
+                {
+                    NodeConstIterator spec_it = mat.children();
+                    while (spec_it.has_next())
+                    {
+                        const Node &spec = spec_it.next();
+                        const std::string &spec_name = spec_it.name();
+
+                        if (spec.dtype().is_object())
+                        {
+                            mvs_res &= verify_o2mrelation_field(protocol, mat, mat_info, spec_name);
+                        }
+                        else
+                        {
+                            mvs_res &= verify_number_field(protocol, mat, mat_info, spec_name);
+                        }
+                    }
+                }
+            }
+
+            res &= mvs_res;
+            log::validation(mfs_info, mvs_res);
+        }
+    }
+
+    if (!specnames_are_optional && !specset.has_child("species_names"))
+    {
+        log::error(info, protocol,
+            "'species_names' is missing (required for uni-buffer specsets) ");
         res &= false;
     }
-    else
-    {
-        bool specmats_res = true;
-        index_t specmats_len = 0;
 
-        const Node &specmats = specset["matset_values"];
-        Node &specmats_info = info["matset_values"];
-        NodeConstIterator specmats_it = specmats.children();
-        while(specmats_it.has_next())
+    if (specset.has_child("species_names"))
+    {
+        if (specnames_are_optional)
         {
-            const Node &specmat = specmats_it.next();
-            const std::string specmat_name = specmat.name();
-            if(!verify_mcarray_field(protocol, specmats, specmats_info, specmat_name))
+            log::optional(info, protocol, "includes species_names");
+        }
+
+        res &= verify_specset_species_names(protocol,specset,info);
+
+        // for cases where matset_values are an object, we expect the species_names child
+        // names to be a subset of the matset_values child names
+        if (specset.has_child("matset_values") &&
+            specset["matset_values"].dtype().is_object())
+        {
+            NodeConstIterator specnames_mat_itr = specset["species_names"].children();
+            while (specnames_mat_itr.has_next())
             {
-                specmats_res &= false;
-            }
-            else
-            {
-                const index_t specmat_len = specmat.child(0).dtype().number_of_elements();
-                if(specmats_len == 0)
+                const Node &specnames_mat = specnames_mat_itr.next();
+                const std::string mat_name = specnames_mat_itr.name();
+
+                NodeConstIterator specnames_mat_specnames_itr = specnames_mat.children();
+                while (specnames_mat_specnames_itr.has_next())
                 {
-                    specmats_len = specmat_len;
-                }
-                else if(specmats_len != specmat_len)
-                {
-                    log::error(specmats_info, protocol,
-                        log::quote(specmat_name) + " has mismatched length " +
-                        "relative to other material mcarrays in this specset");
-                    specmats_res &= false;
+                    specnames_mat_specnames_itr.next();
+                    const std::string spec_name = specnames_mat_specnames_itr.name();
+
+                    if (! specset["matset_values"].has_path(mat_name + "/" + spec_name))
+                    {
+                        std::ostringstream oss;
+                        oss << "'species_names' hierarchy must be a subset of "
+                               "'matset_values'. "
+                               " 'matset_values' is missing child '"
+                               << mat_name << "/" << spec_name
+                               <<"' which exists in 'species_names`" ;
+                        log::error(info, protocol,oss.str());
+                        res &= false;
+                    }
                 }
             }
         }
-
-        log::validation(specmats_info, specmats_res);
-        res &= specmats_res;
     }
 
     log::validation(info, res);
@@ -6693,6 +6819,8 @@ bool
 mesh::specset::index::verify(const Node &specset_idx,
                              Node &info)
 {
+    specset_idx.print();
+
     const std::string protocol = "mesh::specset::index";
     bool res = true;
     info.reset();

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -837,7 +837,6 @@ void venn_full_specset(Node &res, index_t nx, index_t ny)
         for (index_t x = 0; x < nx; x ++)
         {
             const index_t elem_id = x + nx * y;
-            std::cout << elem_id << std::endl;
             const float64 xf = static_cast<float64>(x);
 
             // circle_a species vary horizontally

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -837,23 +837,24 @@ void venn_full_specset(Node &res, index_t nx, index_t ny)
         for (index_t x = 0; x < nx; x ++)
         {
             const index_t elem_id = x + nx * y;
+            std::cout << elem_id << std::endl;
             const float64 xf = static_cast<float64>(x);
 
             // circle_a species vary horizontally
-            float64 specvalue = xf / (nxf - 1.0);
+            float64 specvalue = xf / nxf;
             ca_spec1[elem_id] = specvalue;
             ca_spec2[elem_id] = 1.0 - specvalue;
 
             // circle_b species vary vertically
-            specvalue = yf / (nyf - 1.0);
+            specvalue = yf / nyf;
             cb_spec1[elem_id] = specvalue;
             cb_spec2[elem_id] = 1.0 - specvalue;
 
             // circle_c species vary diagonally
-            specvalue = (yf / (nyf - 1.0) + xf / (nxf - 1.0)) / 2.0;
-            cc_spec1[elem_id] = specvalue;
-            cc_spec2[elem_id] = (1.0 - specvalue) / 2.0;
-            cc_spec2[elem_id] = (1.0 - specvalue) / 2.0;
+            specvalue = (yf / nyf + xf / nxf) / 2.0;
+            cc_spec1[elem_id] = 1.0 - specvalue;
+            cc_spec2[elem_id] = 0.75 * specvalue;
+            cc_spec3[elem_id] = 0.25 * specvalue;
 
             // background species do not vary
             bg_spec1[elem_id] = 1.0;
@@ -893,7 +894,7 @@ void venn_sparse_by_material_specset(Node &res, index_t nx, index_t ny)
             if (contains(element_ids["circle_a"], elem_id))
             {
                 // circle_a species vary horizontally
-                const float64 specvalue = xf / (nxf - 1.0);
+                const float64 specvalue = xf / nxf;
                 ca_spec1.push_back(specvalue);
                 ca_spec2.push_back(1.0 - specvalue);
             }
@@ -901,7 +902,7 @@ void venn_sparse_by_material_specset(Node &res, index_t nx, index_t ny)
             if (contains(element_ids["circle_b"], elem_id))
             {
                 // circle_b species vary vertically
-                const float64 specvalue = yf / (nyf - 1.0);
+                const float64 specvalue = yf / nyf;
                 cb_spec1.push_back(specvalue);
                 cb_spec2.push_back(1.0 - specvalue);
             }
@@ -909,10 +910,10 @@ void venn_sparse_by_material_specset(Node &res, index_t nx, index_t ny)
             if (contains(element_ids["circle_c"], elem_id))
             {
                 // circle_c species vary diagonally
-                const float64 specvalue = (yf / (nyf - 1.0) + xf / (nxf - 1.0)) / 2.0;
-                cc_spec1.push_back(specvalue);
-                cc_spec2.push_back((1.0 - specvalue) / 2.0);
-                cc_spec2.push_back((1.0 - specvalue) / 2.0);
+                const float64 specvalue = (yf / nyf + xf / nxf) / 2.0;
+                cc_spec1.push_back(1.0 - specvalue);
+                cc_spec2.push_back(0.75 * specvalue);
+                cc_spec3.push_back(0.25 * specvalue);
             }
 
             if (contains(element_ids["background"], elem_id))
@@ -990,7 +991,7 @@ void venn_sparse_by_element_specset(Node &res, index_t nx, index_t ny)
                 if ("circle_a" == matname)
                 {
                     // circle_a species vary horizontally
-                    const float64 specvalue = xf / (nxf - 1.0);
+                    const float64 specvalue = xf / nxf;
                     matset_values.push_back(specvalue);
                     matset_values.push_back(1.0 - specvalue);
                     num_specs_in_zone += 2;
@@ -998,7 +999,7 @@ void venn_sparse_by_element_specset(Node &res, index_t nx, index_t ny)
                 else if ("circle_b" == matname)
                 {
                     // circle_b species vary vertically
-                    const float64 specvalue = yf / (nyf - 1.0);
+                    const float64 specvalue = yf / nyf;
                     matset_values.push_back(specvalue);
                     matset_values.push_back(1.0 - specvalue);
                     num_specs_in_zone += 2;
@@ -1006,10 +1007,10 @@ void venn_sparse_by_element_specset(Node &res, index_t nx, index_t ny)
                 else if ("circle_c" == matname)
                 {
                     // circle_c species vary diagonally
-                    const float64 specvalue = (yf / (nyf - 1.0) + xf / (nxf - 1.0)) / 2.0;
-                    matset_values.push_back(specvalue);
-                    matset_values.push_back((1.0 - specvalue) / 2.0);
-                    matset_values.push_back((1.0 - specvalue) / 2.0);
+                    const float64 specvalue = (yf / nyf + xf / nxf) / 2.0;
+                    matset_values.push_back(1.0 - specvalue);
+                    matset_values.push_back(0.75 * specvalue);
+                    matset_values.push_back(0.25 * specvalue);
                     num_specs_in_zone += 3;
                 }
                 else // ("background" == matname)

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.cpp
@@ -802,6 +802,266 @@ void venn(const std::string &matset_type,
     res.remove("meta");
 }
 
+//---------------------------------------------------------------------------//
+void venn_full_specset(Node &res, index_t nx, index_t ny)
+{
+    // create the species sets
+
+    index_t elements = nx * ny;
+
+    res["specsets/specset/matset"] = "matset";
+    res["specsets/specset/matset_values/background/bg_spec1"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_a/a_spec1"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_a/a_spec2"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_b/b_spec1"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_b/b_spec2"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_c/c_spec1"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_c/c_spec2"] = DataType::float64(elements);
+    res["specsets/specset/matset_values/circle_c/c_spec3"] = DataType::float64(elements);
+
+    float64_array bg_spec1 = res["specsets/specset/matset_values/background/bg_spec1"].value();
+    float64_array ca_spec1 = res["specsets/specset/matset_values/circle_a/a_spec1"].value();
+    float64_array ca_spec2 = res["specsets/specset/matset_values/circle_a/a_spec2"].value();
+    float64_array cb_spec1 = res["specsets/specset/matset_values/circle_b/b_spec1"].value();
+    float64_array cb_spec2 = res["specsets/specset/matset_values/circle_b/b_spec2"].value();
+    float64_array cc_spec1 = res["specsets/specset/matset_values/circle_c/c_spec1"].value();
+    float64_array cc_spec2 = res["specsets/specset/matset_values/circle_c/c_spec2"].value();
+    float64_array cc_spec3 = res["specsets/specset/matset_values/circle_c/c_spec3"].value();
+
+    const float64 nxf = static_cast<float64>(nx);
+    const float64 nyf = static_cast<float64>(ny);
+
+    for (index_t y = 0; y < ny; y ++)
+    {
+        const float64 yf = static_cast<float64>(y);
+        for (index_t x = 0; x < nx; x ++)
+        {
+            const index_t elem_id = x + nx * y;
+            const float64 xf = static_cast<float64>(x);
+
+            // circle_a species vary horizontally
+            float64 specvalue = xf / (nxf - 1.0);
+            ca_spec1[elem_id] = specvalue;
+            ca_spec2[elem_id] = 1.0 - specvalue;
+
+            // circle_b species vary vertically
+            specvalue = yf / (nyf - 1.0);
+            cb_spec1[elem_id] = specvalue;
+            cb_spec2[elem_id] = 1.0 - specvalue;
+
+            // circle_c species vary diagonally
+            specvalue = (yf / (nyf - 1.0) + xf / (nxf - 1.0)) / 2.0;
+            cc_spec1[elem_id] = specvalue;
+            cc_spec2[elem_id] = (1.0 - specvalue) / 2.0;
+            cc_spec2[elem_id] = (1.0 - specvalue) / 2.0;
+
+            // background species do not vary
+            bg_spec1[elem_id] = 1.0;
+        }
+    }
+}
+
+void venn_sparse_by_material_specset(Node &res, index_t nx, index_t ny)
+{
+    auto contains = [](const Node &leaf_array, index_t value) -> bool
+    {
+        const index_t_accessor leaf_arr_acc = leaf_array.value();
+        return leaf_arr_acc.count(value) > 0;
+    };
+
+    const Node &element_ids = res["matsets/matset/element_ids"];
+
+    std::vector<float64> bg_spec1;
+    std::vector<float64> ca_spec1;
+    std::vector<float64> ca_spec2;
+    std::vector<float64> cb_spec1;
+    std::vector<float64> cb_spec2;
+    std::vector<float64> cc_spec1;
+    std::vector<float64> cc_spec2;
+    std::vector<float64> cc_spec3;
+
+    const float64 nxf = static_cast<float64>(nx);
+    const float64 nyf = static_cast<float64>(ny);
+    for (index_t y = 0; y < ny; y ++)
+    {
+        const float64 yf = static_cast<float64>(y);
+        for (index_t x = 0; x < nx; x ++)
+        {
+            const index_t elem_id = x + nx * y;
+            const float64 xf = static_cast<float64>(x);
+
+            if (contains(element_ids["circle_a"], elem_id))
+            {
+                // circle_a species vary horizontally
+                const float64 specvalue = xf / (nxf - 1.0);
+                ca_spec1.push_back(specvalue);
+                ca_spec2.push_back(1.0 - specvalue);
+            }
+
+            if (contains(element_ids["circle_b"], elem_id))
+            {
+                // circle_b species vary vertically
+                const float64 specvalue = yf / (nyf - 1.0);
+                cb_spec1.push_back(specvalue);
+                cb_spec2.push_back(1.0 - specvalue);
+            }
+
+            if (contains(element_ids["circle_c"], elem_id))
+            {
+                // circle_c species vary diagonally
+                const float64 specvalue = (yf / (nyf - 1.0) + xf / (nxf - 1.0)) / 2.0;
+                cc_spec1.push_back(specvalue);
+                cc_spec2.push_back((1.0 - specvalue) / 2.0);
+                cc_spec2.push_back((1.0 - specvalue) / 2.0);
+            }
+
+            if (contains(element_ids["background"], elem_id))
+            {
+                // background species do not vary
+                bg_spec1.push_back(1.0);
+            }
+        }
+    }
+
+    res["specsets/specset/matset"] = "matset";
+    res["specsets/specset/matset_values/background/bg_spec1"].set(bg_spec1);
+    res["specsets/specset/matset_values/circle_a/a_spec1"].set(ca_spec1);
+    res["specsets/specset/matset_values/circle_a/a_spec2"].set(ca_spec2);
+    res["specsets/specset/matset_values/circle_b/b_spec1"].set(cb_spec1);
+    res["specsets/specset/matset_values/circle_b/b_spec2"].set(cb_spec2);
+    res["specsets/specset/matset_values/circle_c/c_spec1"].set(cc_spec1);
+    res["specsets/specset/matset_values/circle_c/c_spec2"].set(cc_spec2);
+    res["specsets/specset/matset_values/circle_c/c_spec3"].set(cc_spec3);
+}
+
+void venn_sparse_by_element_specset(Node &res, index_t nx, index_t ny)
+{
+    // get references to the matset
+    const Node &matset = res["matsets/matset"];
+    const index_t_accessor m_sizes = matset["sizes"].value();
+    const index_t_accessor m_offsets = matset["offsets"].value();
+    const index_t_accessor m_material_ids = matset["material_ids"].value();
+
+    // create reverse material map
+    std::map<int, std::string> reverse_matmap;
+    auto matmap_itr = matset["material_map"].children();
+    while (matmap_itr.has_next())
+    {
+        const Node &matmap_entry = matmap_itr.next();
+        const std::string matname = matmap_itr.name();
+
+        reverse_matmap[matmap_entry.to_int()] = matname;
+    }
+
+    // create species_names
+    res["specsets/specset/matset"] = "matset";
+    res["specsets/specset/species_names/background/bg_spec1"];
+    res["specsets/specset/species_names/circle_a/a_spec1"];
+    res["specsets/specset/species_names/circle_a/a_spec2"];
+    res["specsets/specset/species_names/circle_b/b_spec1"];
+    res["specsets/specset/species_names/circle_b/b_spec2"];
+    res["specsets/specset/species_names/circle_c/c_spec1"];
+    res["specsets/specset/species_names/circle_c/c_spec2"];
+    res["specsets/specset/species_names/circle_c/c_spec3"];
+
+    std::vector<float64> matset_values;
+    std::vector<index_t> sizes;
+    std::vector<index_t> offsets;
+
+    const float64 nxf = static_cast<float64>(nx);
+    const float64 nyf = static_cast<float64>(ny);
+    for (index_t y = 0; y < ny; y ++)
+    {
+        const float64 yf = static_cast<float64>(y);
+        for (index_t x = 0; x < nx; x ++)
+        {
+            const index_t elem_id = x + nx * y;
+            const float64 xf = static_cast<float64>(x);
+
+            const index_t zone_size = m_sizes[elem_id];
+            const index_t zone_offset = m_offsets[elem_id];
+
+            index_t num_specs_in_zone = 0;
+            for (index_t local_offset = 0; local_offset < zone_size; local_offset ++)
+            {
+                const index_t mat_id = m_material_ids[zone_offset + local_offset];
+                const std::string matname = reverse_matmap.at(mat_id);
+
+                if ("circle_a" == matname)
+                {
+                    // circle_a species vary horizontally
+                    const float64 specvalue = xf / (nxf - 1.0);
+                    matset_values.push_back(specvalue);
+                    matset_values.push_back(1.0 - specvalue);
+                    num_specs_in_zone += 2;
+                }
+                else if ("circle_b" == matname)
+                {
+                    // circle_b species vary vertically
+                    const float64 specvalue = yf / (nyf - 1.0);
+                    matset_values.push_back(specvalue);
+                    matset_values.push_back(1.0 - specvalue);
+                    num_specs_in_zone += 2;
+                }
+                else if ("circle_c" == matname)
+                {
+                    // circle_c species vary diagonally
+                    const float64 specvalue = (yf / (nyf - 1.0) + xf / (nxf - 1.0)) / 2.0;
+                    matset_values.push_back(specvalue);
+                    matset_values.push_back((1.0 - specvalue) / 2.0);
+                    matset_values.push_back((1.0 - specvalue) / 2.0);
+                    num_specs_in_zone += 3;
+                }
+                else // ("background" == matname)
+                {
+                    // background species do not vary
+                    matset_values.push_back(1.0);
+                    num_specs_in_zone += 1;
+                }
+            }
+
+            sizes.push_back(num_specs_in_zone);
+        }
+    }
+
+    offsets.push_back(0);
+    for (index_t elem_id = 1; elem_id < nx * ny; elem_id ++)
+    {
+        offsets.push_back(offsets[elem_id - 1] + sizes[elem_id - 1]);
+    }
+
+    res["specsets/specset/matset_values"].set(matset_values);
+    res["specsets/specset/sizes"].set(sizes);
+    res["specsets/specset/offsets"].set(offsets);
+}
+
+//-----------------------------------------------------------------------------
+void venn_specsets(const std::string &matset_type,
+                   index_t nx,
+                   index_t ny,
+                   float64 radius, 
+                   Node &res)
+{
+    venn(matset_type, nx, ny, radius, res);
+
+    if (matset_type == "full")
+    {
+        venn_full_specset(res, nx, ny);
+    }
+    else if (matset_type == "sparse_by_material")
+    {
+        venn_sparse_by_material_specset(res, nx, ny);
+    }
+    else if (matset_type == "sparse_by_element")
+    {
+        venn_sparse_by_element_specset(res, nx, ny);
+    }
+    else
+    {
+        CONDUIT_ERROR("unknown matset_type = " << matset_type);
+    }
+}
+
 }
 //-----------------------------------------------------------------------------
 // -- end conduit::blueprint::mesh::examples --

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_venn.hpp
@@ -57,6 +57,21 @@ namespace examples
                                     float64 radius,
                                     Node &res);
 
+    /// Generates a rectilinear grid with fields that
+    /// are computed from 3 overlapping circles.
+    ///
+    /// matset_type options:
+    ///   full -> non sparse volume fractions and matset values
+    ///   sparse_by_material ->  sparse (material dominant) volume fractions
+    ///                          and matset values
+    ///   sparse_by_element  ->  sparse (element dominant)
+    ///                          volume fractions and matset values
+    void CONDUIT_BLUEPRINT_API venn_specsets(const std::string &matset_type,
+                                             index_t nx,
+                                             index_t ny,
+                                             float64 radius,
+                                             Node &res);
+
 }
 //-----------------------------------------------------------------------------
 // -- end conduit::blueprint::mesh::examples --

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -1148,7 +1148,7 @@ TEST(conduit_blueprint_mesh_examples, check_gen_index_state_prop)
 void venn_test_small_yaml(const std::string &venn_type, const bool specsets)
 {
     // provide small example save to yaml for folks to look at
-    const int nx = 4, ny = 4;
+    const int nx = 2, ny = 2;
     const double radius = 0.25;
 
     Node res, info, n_idx;
@@ -1164,7 +1164,6 @@ void venn_test_small_yaml(const std::string &venn_type, const bool specsets)
     EXPECT_TRUE(blueprint::mesh::verify(res, info));
     info.print();
     blueprint::mesh::generate_index(res,"",1,n_idx);
-    n_idx.print();
     EXPECT_TRUE(blueprint::verify("mesh/index",n_idx,info));
 
     std::string ofbase = "venn_" + std::string(specsets ? "specsets_" : "") + "small_example_" + venn_type;

--- a/src/tests/blueprint/t_blueprint_mesh_examples.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples.cpp
@@ -1145,21 +1145,29 @@ TEST(conduit_blueprint_mesh_examples, check_gen_index_state_prop)
 
 
 //-----------------------------------------------------------------------------
-void venn_test_small_yaml(const std::string &venn_type)
+void venn_test_small_yaml(const std::string &venn_type, const bool specsets)
 {
     // provide small example save to yaml for folks to look at
     const int nx = 4, ny = 4;
     const double radius = 0.25;
 
     Node res, info, n_idx;
-    blueprint::mesh::examples::venn(venn_type, nx, ny, radius, res);
+    if (specsets)
+    {
+        blueprint::mesh::examples::venn_specsets(venn_type, nx, ny, radius, res);
+    }
+    else
+    {
+        blueprint::mesh::examples::venn(venn_type, nx, ny, radius, res);
+    }
 
     EXPECT_TRUE(blueprint::mesh::verify(res, info));
     info.print();
     blueprint::mesh::generate_index(res,"",1,n_idx);
+    n_idx.print();
     EXPECT_TRUE(blueprint::verify("mesh/index",n_idx,info));
 
-    std::string ofbase= "venn_small_example_" + venn_type;
+    std::string ofbase = "venn_" + std::string(specsets ? "specsets_" : "") + "small_example_" + venn_type;
 
     // save yaml and hdf5 versions
     relay::io::blueprint::save_mesh(res,
@@ -1180,23 +1188,28 @@ void venn_test_small_yaml(const std::string &venn_type)
 }
 
 //-----------------------------------------------------------------------------
-void venn_test(const std::string &venn_type)
+void venn_test(const std::string &venn_type, const bool specsets)
 {
     const int nx = 100, ny = 100;
     const double radius = 0.25;
 
     Node res, info;
-    blueprint::mesh::examples::venn(venn_type, nx, ny, radius, res);
+    if (specsets)
+    {
+        blueprint::mesh::examples::venn_specsets(venn_type, nx, ny, radius, res);
+    }
+    else
+    {
+        blueprint::mesh::examples::venn(venn_type, nx, ny, radius, res);
+    }
 
     EXPECT_TRUE(blueprint::mesh::verify(res, info));
     utils::log::remove_valid(info);
     CONDUIT_INFO(info.to_yaml());
     CONDUIT_INFO(res.schema().to_json());
 
-    std::string ofbase = "venn_example_" + venn_type;
+    std::string ofbase = "venn_" + std::string(specsets ? "specsets_" : "") + "example_" + venn_type;
     std::cout << "[Saving " << ofbase << "]" << std::endl;
-
-    std::string ofile_root= "venn_small_example_" + venn_type;
 
     // save yaml and hdf5 versions
     relay::io::blueprint::save_mesh(res,
@@ -1234,22 +1247,28 @@ void venn_test(const std::string &venn_type)
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_examples, venn_full)
 {
-    venn_test("full");
-    venn_test_small_yaml("full");
+    venn_test("full", false);
+    venn_test("full", true);
+    venn_test_small_yaml("full", false);
+    venn_test_small_yaml("full", true);
 }
 
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_examples, venn_sparse_by_material)
 {
-    venn_test("sparse_by_material");
-    venn_test_small_yaml("sparse_by_material");
+    venn_test("sparse_by_material", false);
+    venn_test("sparse_by_material", true);
+    venn_test_small_yaml("sparse_by_material", false);
+    venn_test_small_yaml("sparse_by_material", true);
 }
 
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_examples, venn_sparse_by_element)
 {
-    venn_test("sparse_by_element");
-    venn_test_small_yaml("sparse_by_element");
+    venn_test("sparse_by_element", false);
+    venn_test("sparse_by_element", true);
+    venn_test_small_yaml("sparse_by_element", false);
+    venn_test_small_yaml("sparse_by_element", true);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -1355,9 +1355,9 @@ TEST(conduit_blueprint_mesh_verify, specset_general)
             n["matset_values"].reset();
             n["matset_values"]["m1"].append().set(DataType::float64(5));
             n["matset_values"]["m1"].append().set(DataType::float64(5));
-            CHECK_MESH(verify_specset,n,info,true);
+            CHECK_MESH(verify_specset,n,info,false);
             n["matset_values"]["m2"].append().set(DataType::float64(5));
-            CHECK_MESH(verify_specset,n,info,true);
+            CHECK_MESH(verify_specset,n,info,false);
 
             n["matset_values"].reset();
             n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
@@ -1374,14 +1374,14 @@ TEST(conduit_blueprint_mesh_verify, specset_general)
             n["matset_values"].reset();
             n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
             n["matset_values"]["m1"]["s2"].set(DataType::float64(6));
-            CHECK_MESH(verify_specset,n,info,false);
+            CHECK_MESH(verify_specset,n,info,true);
 
             n["matset_values"].reset();
             n["matset_values"]["m1"]["s1"].set(DataType::float64(5));
             n["matset_values"]["m1"]["s2"].set(DataType::float64(5));
             CHECK_MESH(verify_specset,n,info,true);
             n["matset_values"]["m2"]["s3"].set(DataType::float64(6));
-            CHECK_MESH(verify_specset,n,info,false);
+            CHECK_MESH(verify_specset,n,info,true);
 
             n["matset_values"].reset();
             n["matset_values"].set(mfs);
@@ -1390,7 +1390,7 @@ TEST(conduit_blueprint_mesh_verify, specset_general)
     }
 }
 
-/// Mesh Field Tests ///
+// / Mesh Field Tests ///
 
 //-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_verify, field_general)


### PR DESCRIPTION
I have expanded the way species sets are represented in Blueprint.

I have added a new example, `venn_specsets`, that covers the breadth of new specset representations.

Here are examples of matsets, specsets, and material-dependent fields in the various forms.
```
full (element_dominant and multi_buffer)


matset: 
  topology: "topo"
  volume_fractions: 
    background: [1.0, 1.0, 1.0, 0.0]
    circle_a: [0.0, 0.0, 0.0, 0.333333333333333]
    circle_b: [0.0, 0.0, 0.0, 0.333333333333333]
    circle_c: [0.0, 0.0, 0.0, 0.333333333333333]

specset: 
  matset: "matset"
  matset_values: 
    background: 
      bg_spec1: [1.0, 1.0, 1.0, 1.0]
    circle_a: 
      a_spec1: [0.0, 0.5, 0.0, 0.5]
      a_spec2: [1.0, 0.5, 1.0, 0.5]
    circle_b: 
      b_spec1: [0.0, 0.0, 0.5, 0.5]
      b_spec2: [1.0, 1.0, 0.5, 0.5]
    circle_c: 
      c_spec1: [1.0, 0.75, 0.75, 0.5]
      c_spec2: [0.0, 0.1875, 0.1875, 0.375]
      c_spec3: [0.0, 0.0625, 0.0625, 0.125]

association: "element"
topology: "topo"
matset: "matset"
values: [0.0, 0.5, 0.5, 0.300000009437402]
matset_values: 
  background: [0.0, 0.5, 0.5, 0.0]
  circle_a: [0.0, 0.0, 0.0, 0.100000001490116]
  circle_b: [0.0, 0.0, 0.0, 0.200000002980232]
  circle_c: [0.0, 0.0, 0.0, 0.600000023841858]


sparse_by_material (material_dominant and multi_buffer)


matset: 
  volume_fractions: 
    background: [1.0, 1.0, 1.0]
    circle_a: 0.333333333333333
    circle_b: 0.333333333333333
    circle_c: 0.333333333333333
  element_ids: 
    background: [0, 1, 2]
    circle_a: 3
    circle_b: 3
    circle_c: 3
  topology: "topo"

specset: 
matset: "matset"
matset_values: 
  background: 
    bg_spec1: [1.0, 1.0, 1.0]
  circle_a: 
    a_spec1: 0.5
    a_spec2: 0.5
  circle_b: 
    b_spec1: 0.5
    b_spec2: 0.5
  circle_c: 
    c_spec1: 0.5
    c_spec2: 0.375
    c_spec3: 0.125

association: "element"
topology: "topo"
matset: "matset"
values: [0.0, 0.5, 0.5, 0.300000009437402]
matset_values: 
  circle_a: 0.100000001490116
  circle_b: 0.200000002980232
  circle_c: 0.600000023841858
  background: [0.0, 0.5, 0.5]


sparse_by_element (uni_buffer and element_dominant)


matset: 
  topology: "topo"
  material_map: 
    circle_a: 1
    circle_b: 2
    circle_c: 3
    background: 0
  volume_fractions: [1.0, 1.0, 1.0, 0.333333333333333, 0.333333333333333, 0.333333333333333]
  material_ids: [0, 0, 0, 1, 2, 3]
  sizes: [1, 1, 1, 3]
  offsets: [0, 1, 2, 3]

specset: 
  matset: "matset"
  species_names: 
    background: 
      bg_spec1: 
    circle_a: 
      a_spec1: 
      a_spec2: 
    circle_b: 
      b_spec1: 
      b_spec2: 
    circle_c: 
      c_spec1: 
      c_spec2: 
      c_spec3: 
  matset_values: [1.0, 1.0, 1.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.375, 0.125]
  sizes: [1, 1, 1, 7]
  offsets: [0, 1, 2, 3]

association: "element"
topology: "topo"
matset: "matset"
values: [0.0, 0.5, 0.5, 0.300000009437402]
matset_values: [0.0, 0.5, 0.5, 0.100000001490116, 0.200000002980232, 0.600000023841858]
```