### PR TITLE
specset::to_silo rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### Blueprint
 - Certain algorithms that use MPI tags had their tag values lowered since some MPI implementations do not support large values.
+- Changed the name of `conduit::blueprint::mesh::matset::to_sparse_by_element()` to `conduit::blueprint::mesh::matset::to_uni_buffer_by_element()` to be more consistent with similar function names.
 
 #### Relay
 - User-supplied warning and error handlers are suspended during `conduit::relay::communicate_using_schema::execute()` so exceptions will be thrown properly when there is an MPI error. The handlers are restored before the execute method returns.

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -6813,34 +6813,6 @@ mesh::specset::verify(const Node &specset,
     return res;
 }
 
-//-------------------------------------------------------------------------
-bool
-mesh::specset::is_multi_buffer(const Node &specset)
-{
-    return specset.child("matset_values").dtype().is_object();
-}
-
-//-------------------------------------------------------------------------
-bool
-mesh::specset::is_uni_buffer(const Node &specset)
-{
-    return specset.child("matset_values").dtype().is_number();
-}
-
-//-------------------------------------------------------------------------
-bool
-mesh::specset::is_element_dominant(const Node &specset)
-{
-    return false;
-}
-
-//-------------------------------------------------------------------------
-bool
-mesh::specset::is_material_dominant(const Node &specset)
-{
-    return false;
-}
-
 //-----------------------------------------------------------------------------
 // blueprint::mesh::specset::index::verify protocol interface
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -6813,6 +6813,34 @@ mesh::specset::verify(const Node &specset,
     return res;
 }
 
+//-------------------------------------------------------------------------
+bool
+mesh::specset::is_multi_buffer(const Node &specset)
+{
+    return specset.child("matset_values").dtype().is_object();
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::specset::is_uni_buffer(const Node &specset)
+{
+    return specset.child("matset_values").dtype().is_number();
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::specset::is_element_dominant(const Node &specset)
+{
+    return false;
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::specset::is_material_dominant(const Node &specset)
+{
+    return false;
+}
+
 //-----------------------------------------------------------------------------
 // blueprint::mesh::specset::index::verify protocol interface
 //-----------------------------------------------------------------------------

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -748,9 +748,9 @@ namespace matset
 
     //-------------------------------------------------------------------------
     // creates a unibuffer case with 1st index into elements
-    void CONDUIT_BLUEPRINT_API to_sparse_by_element(const conduit::Node &src_matset,
-                                                    conduit::Node &dest_matset,
-                                                    const float64 epsilon = CONDUIT_EPSILON);
+    void CONDUIT_BLUEPRINT_API to_uni_buffer_by_element(const conduit::Node &src_matset,
+                                                        conduit::Node &dest_matset,
+                                                        const float64 epsilon = CONDUIT_EPSILON);
 
     //-------------------------------------------------------------------------
     // covers both the sparse and non sparse case
@@ -817,11 +817,11 @@ namespace field
 
     //-------------------------------------------------------------------------
     // creates a unibuffer case with 1st index into elements
-    void CONDUIT_BLUEPRINT_API to_sparse_by_element(const conduit::Node &src_matset,
-                                                    const conduit::Node &src_field,
-                                                    const std::string &dest_matset_name,
-                                                    conduit::Node &dest_field,
-                                                    const float64 epsilon = CONDUIT_EPSILON);
+    void CONDUIT_BLUEPRINT_API to_uni_buffer_by_element(const conduit::Node &src_matset,
+                                                        const conduit::Node &src_field,
+                                                        const std::string &dest_matset_name,
+                                                        conduit::Node &dest_field,
+                                                        const float64 epsilon = CONDUIT_EPSILON);
 
     //-------------------------------------------------------------------------
     // covers both the sparse and non sparse case

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1583,6 +1583,10 @@ to_silo(const conduit::Node &specset,
     }
 
     // TODO change this once we write specset converters
+    // I think the right path will be to rewrite this function using the 
+    // sparse by element (uni_buffer element_dominant) specset flavor.
+    // So we will convert all specsets to that form and then convert to silo.
+    // Should be simpler and get rid of a lot of the indexing madness.
     if (silo_matset["buffer_style"].as_string() != "multi")
     {
         CONDUIT_ERROR("TODO cannot handle uni buffer specsets");

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1790,6 +1790,12 @@ to_silo(const conduit::Node &specset,
             }
             else
             {
+                // Either there are multiple species for this material or there 
+                // are none. If there are none, then the value computed here
+                // will ultimately not be used by Silo readers. There must be 
+                // a value here though even when there are no species for the
+                // material because we must have entries in the different silo
+                // species arrays for each material.
                 speclist[zone_id] = calculate_species_index(zone_id, mat_index);
             }
         }
@@ -1825,6 +1831,12 @@ to_silo(const conduit::Node &specset,
                 }
                 else
                 {
+                    // Either there are multiple species for this material or there 
+                    // are none. If there are none, then the value computed here
+                    // will ultimately not be used by Silo readers. There must be 
+                    // a value here though even when there are no species for the
+                    // material because we must have entries in the different silo
+                    // species arrays for each material.
                     mix_spec.push_back(calculate_species_index(zone_id, mat_index));
                 }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1709,8 +1709,6 @@ to_silo(const conduit::Node &specset,
         }
     }
 
-    // TODO justin I left off here. plus the matmap_map stuff needs to be redone too
-
     const int nspecies_mf = static_cast<int>(species_mf.size());
 
     // get pointers to the silo material representation data
@@ -1774,9 +1772,9 @@ to_silo(const conduit::Node &specset,
     std::vector<int> mix_spec;
 
     // now we create the speclist and mix_spec arrays, traversing through the zones
-    for (int zoneId = 0; zoneId < num_zones; zoneId ++)
+    for (int zone_id = 0; zone_id < num_zones; zone_id ++)
     {
-        const int matlist_entry = silo_matlist[zoneId];
+        const int matlist_entry = silo_matlist[zone_id];
         // is this zone clean?
         if (matlist_entry >= 0) // this relies on matset_ptr->allowmat0 == 0
         {
@@ -1785,7 +1783,7 @@ to_silo(const conduit::Node &specset,
             // I can use the material number to determine which part of the speclist to index into
             const int &matno = matlist_entry;
             const int mat_index = mat_id_to_array_index[matno];
-            speclist[zoneId] = calculate_species_index(zoneId, mat_index);
+            speclist[zone_id] = calculate_species_index(zone_id, mat_index);
         }
         else
         {
@@ -1794,7 +1792,7 @@ to_silo(const conduit::Node &specset,
             // TODO isn't this value the same as the one in the silo_matlist?
             // can't we just copy it over? TODO
             // we save the negated 1-index into the mix_spec array
-            speclist[zoneId] = mix_start_index;
+            speclist[zone_id] = mix_start_index;
 
             // for mixed zones, the numbers in the matlist are negated 1-indices into
             // the silo mixed data arrays. To turn them into zero-indices, we must add
@@ -1810,7 +1808,7 @@ to_silo(const conduit::Node &specset,
                 // I can use the material number to determine which part of the speclist to index into
                 const int matno = silo_mix_mat[mix_id];
                 const int mat_index = mat_id_to_array_index[matno];
-                mix_spec.push_back(calculate_species_index(zoneId, mat_index));
+                mix_spec.push_back(calculate_species_index(zone_id, mat_index));
 
                 // since mix_id is a 1-index, we must subtract one
                 // this makes sure that mix_id = 0 is the last case,

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1455,14 +1455,14 @@ to_multi_buffer_full(const conduit::Node &src_matset,
 
 //-----------------------------------------------------------------------------
 void
-to_sparse_by_element(const conduit::Node &src_matset,
-                     conduit::Node &dest_matset,
-                     const float64 epsilon)
+to_uni_buffer_by_element(const conduit::Node &src_matset,
+                         conduit::Node &dest_matset,
+                         const float64 epsilon)
 {
     // extra seat belt here
     if (! src_matset.dtype().is_object())
     {
-        CONDUIT_ERROR("blueprint::mesh::matset::to_sparse_by_element"
+        CONDUIT_ERROR("blueprint::mesh::matset::to_uni_buffer_by_element"
                       " passed matset node must be a valid matset tree.");
     }
 
@@ -1928,22 +1928,22 @@ to_multi_buffer_full(const conduit::Node &src_matset,
 
 //-----------------------------------------------------------------------------
 void
-to_sparse_by_element(const conduit::Node &src_matset,
-                     const conduit::Node &src_field,
-                     const std::string &dest_matset_name,
-                     conduit::Node &dest_field,
-                     const float64 epsilon)
+to_uni_buffer_by_element(const conduit::Node &src_matset,
+                         const conduit::Node &src_field,
+                         const std::string &dest_matset_name,
+                         conduit::Node &dest_field,
+                         const float64 epsilon)
 {
     // extra seat belt here
     if (! src_matset.dtype().is_object())
     {
-        CONDUIT_ERROR("blueprint::mesh::field::to_sparse_by_element"
+        CONDUIT_ERROR("blueprint::mesh::field::to_uni_buffer_by_element"
                       " passed matset node must be a valid matset tree.");
     }
 
     if (! src_field.dtype().is_object())
     {
-        CONDUIT_ERROR("blueprint::mesh::field::to_sparse_by_element"
+        CONDUIT_ERROR("blueprint::mesh::field::to_uni_buffer_by_element"
                       " passed field node must be a valid field tree.");
     }
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1748,6 +1748,28 @@ to_silo(const conduit::Node &specset,
             return sum;
         }();
 
+        // WARNING: this can produce indices that are out of bounds in specific cases:
+        // example:
+        //   nmatspec: [0, 2, 2, 0]
+        //   specnames: 
+        //     - "a_spec1"
+        //     - "a_spec2"
+        //     - "b_spec1"
+        //     - "b_spec2"
+        //   speclist: [1, 5, 9, -1]
+        //   nmat: 4
+        //   nspecies_mf: 16
+        //   species_mf: [0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+        //   mix_spec: [13, 15, 17]
+        //   mixlen: 3
+
+        // mix_spec has 17 at the end of the list. 17 is out of bounds for species_mf. But 17 is 
+        // the correct index given our method of calculation. The third entry in the mix_spec
+        // array corresponds to a material circle_c which is present in the zone but has no
+        // species. If circle_c had species, then 17 would be the right index for it.
+        // I don't think downstream silo data consumers will read
+
+
         // we save the final index for this zone
         return outer_index + local_index;
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1709,6 +1709,8 @@ to_silo(const conduit::Node &specset,
         }
     }
 
+    // TODO justin I left off here. plus the matmap_map stuff needs to be redone too
+
     const int nspecies_mf = static_cast<int>(species_mf.size());
 
     // get pointers to the silo material representation data
@@ -1789,6 +1791,8 @@ to_silo(const conduit::Node &specset,
         {
             // mixed
 
+            // TODO isn't this value the same as the one in the silo_matlist?
+            // can't we just copy it over? TODO
             // we save the negated 1-index into the mix_spec array
             speclist[zoneId] = mix_start_index;
 

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -602,3 +602,55 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
     std::cout << silo_rep2.to_yaml() << std::endl;
     EXPECT_FALSE(silo_rep2.diff(baseline, info, CONDUIT_EPSILON, true));
 }
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mats)
+{
+    Node mesh;
+    blueprint::mesh::examples::venn_specsets("sparse_by_material", 4, 4, 0.25, mesh);
+
+    mesh["specsets"]["specset"]["matset_values"].remove_child("background");
+
+    const Node &matset = mesh["matsets/matset"];
+    const Node &specset = mesh["specsets/specset"];
+
+    Node silo_rep;
+
+    // first test transforming specset to silo rep with a regular matset
+    blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
+    std::cout << silo_rep.to_yaml() << std::endl;
+
+    // mesh.print();
+
+    // TODO JUSTIN the above error is triggered because we have this case here:
+    // topology: "MMESH"
+    // material_map: 
+    //   1: 1
+    //   2: 2
+    //   3: 3
+    //   4: 4
+    //   5: 5
+    //   6: 6
+    // matlist: [2, 2, 2, ..., 2, 2]
+    // mix_next: []
+    // mix_mat: []
+    // mix_vf: []
+
+
+    // matset: "MMATERIAL"
+    // matset_values: 
+    //   2: 
+    //     species0: [0.00221, -0.0712111111111111, -0.144632222222222, ..., 0.663, 0.589578888888889]
+    //     species1: [0.00222, -0.0715333333333333, -0.145286666666667, ..., 0.666, 0.592246666666667]
+    //     species2: [0.00223, -0.0718555555555556, -0.145941111111111, ..., 0.669, 0.594914444444445]
+    //     species3: [0.00224, -0.0721777777777778, -0.146595555555556, ..., 0.672, 0.597582222222222]
+    //   3: 
+    //     species4: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+    //     species5: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+    //   4: 
+    //     species6: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+
+    // not all materials show up in the specset
+    // this really screws things up. I need to be very careful when making silo arrays like nmatspec
+    // I also need a test for this
+}

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -583,44 +583,44 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_style_transforms)
     }
 }
 
-// //-----------------------------------------------------------------------------
-// TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
-// {
-//     Node mesh;
-//     blueprint::mesh::examples::misc("specsets", 4, 4, 1, mesh);
-//     const Node &matset = mesh["matsets/mesh"];
-//     const Node &specset = mesh["specsets/mesh"];
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
+{
+    Node mesh;
+    blueprint::mesh::examples::misc("specsets", 4, 4, 1, mesh);
+    const Node &matset = mesh["matsets/mesh"];
+    const Node &specset = mesh["specsets/mesh"];
 
-//     Node silo_rep1, silo_rep2, silo_rep_matset, info;
+    Node silo_rep1, silo_rep2, silo_rep_matset, info;
 
-//     const std::string yaml_text = 
-//         "specnames: \n"
-//         "  - \"spec1\"\n"
-//         "  - \"spec2\"\n"
-//         "  - \"spec1\"\n"
-//         "  - \"spec2\"\n"
-//         "nmat: 2\n"
-//         "nmatspec: [2, 2]\n"
-//         "speclist: [3, -1, 9, 15, -3, 21, 27, -5, 33]\n"
-//         "nspecies_mf: 36\n"
-//         "species_mf: [0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0]\n"
-//         "mix_spec: [5, 7, 17, 19, 29, 31]\n"
-//         "mixlen: 6";
-//     Node baseline;
-//     baseline.parse(yaml_text, "yaml");
+    const std::string yaml_text = 
+        "specnames: \n"
+        "  - \"spec1\"\n"
+        "  - \"spec2\"\n"
+        "  - \"spec1\"\n"
+        "  - \"spec2\"\n"
+        "nmat: 2\n"
+        "nmatspec: [2, 2]\n"
+        "speclist: [3, -1, 9, 15, -3, 21, 27, -5, 33]\n"
+        "nspecies_mf: 36\n"
+        "species_mf: [0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0]\n"
+        "mix_spec: [5, 7, 17, 19, 29, 31]\n"
+        "mixlen: 6";
+    Node baseline;
+    baseline.parse(yaml_text, "yaml");
 
 
-//     // first test transforming specset to silo rep with a regular matset
-//     blueprint::mesh::specset::to_silo(specset, matset, silo_rep1);
-//     std::cout << silo_rep1.to_yaml() << std::endl;
-//     EXPECT_FALSE(silo_rep1.diff(baseline, info, CONDUIT_EPSILON, true));
+    // first test transforming specset to silo rep with a regular matset
+    blueprint::mesh::specset::to_silo(specset, matset, silo_rep1);
+    std::cout << silo_rep1.to_yaml() << std::endl;
+    EXPECT_FALSE(silo_rep1.diff(baseline, info, CONDUIT_EPSILON, true));
 
-//     // next we test transforming specset to silo rep with a silo rep matset
-//     blueprint::mesh::matset::to_silo(matset, silo_rep_matset);
-//     blueprint::mesh::specset::to_silo(specset, silo_rep_matset, silo_rep2);
-//     std::cout << silo_rep2.to_yaml() << std::endl;
-//     EXPECT_FALSE(silo_rep2.diff(baseline, info, CONDUIT_EPSILON, true));
-// }
+    // next we test transforming specset to silo rep with a silo rep matset
+    blueprint::mesh::matset::to_silo(matset, silo_rep_matset);
+    blueprint::mesh::specset::to_silo(specset, silo_rep_matset, silo_rep2);
+    std::cout << silo_rep2.to_yaml() << std::endl;
+    EXPECT_FALSE(silo_rep2.diff(baseline, info, CONDUIT_EPSILON, true));
+}
 
 // //-----------------------------------------------------------------------------
 // TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mats)

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -607,9 +607,23 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
 TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mats)
 {
     Node mesh;
-    blueprint::mesh::examples::venn_specsets("sparse_by_material", 4, 4, 0.25, mesh);
+    blueprint::mesh::examples::venn_specsets("sparse_by_material", 2, 2, 0.25, mesh);
 
+    // remove some of the materials from the specset
     mesh["specsets"]["specset"]["matset_values"].remove_child("background");
+    mesh["specsets"]["specset"]["matset_values"].remove_child("circle_b");
+    // create a new specset that has the materials in reverse order
+    mesh["specsets"]["specset2"]["matset"] = "matset";
+    mesh["specsets"]["specset2"]["matset_values"]["circle_c"].set(
+        mesh["specsets"]["specset"]["matset_values"]["circle_c"]);
+    mesh["specsets"]["specset2"]["matset_values"]["circle_a"].set(
+        mesh["specsets"]["specset"]["matset_values"]["circle_a"]);
+    // remove the original specset and replace it with the new one
+    mesh["specsets"].remove_child("specset");
+    mesh["specsets"].rename_child("specset2", "specset");
+
+    mesh.print();
+
 
     const Node &matset = mesh["matsets/matset"];
     const Node &specset = mesh["specsets/specset"];

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -623,7 +623,7 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mats)
+TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_edge_cases)
 {
     CONDUIT_INFO("Case 1: Missing materials and material order is reversed in the specset.");
     {

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -646,9 +646,8 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mat
         const Node &matset = mesh["matsets/matset"];
         const Node &specset = mesh["specsets/specset"];
 
-        Node silo_rep, silo_rep_matset;
+        Node silo_rep;
 
-        // first test transforming specset to silo rep with a regular matset
         blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
 
         std::cout << specset.to_yaml() << std::endl;
@@ -696,9 +695,8 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mat
         const Node &matset = mesh["matsets/matset"];
         const Node &specset = mesh["specsets/specset"];
 
-        Node silo_rep, silo_rep_matset;
+        Node silo_rep;
 
-        // first test transforming specset to silo rep with a regular matset
         blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
 
         std::cout << specset.to_yaml() << std::endl;
@@ -715,7 +713,7 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mat
             "  - \"c_spec1\"\n"
             "  - \"c_spec2\"\n"
             "  - \"c_spec3\"\n"
-            "speclist: [1, 9, 17, -1]\n"
+            "speclist: [0, 0, 0, -1]\n"
             "nmat: 4\n"
             "nspecies_mf: 32\n"
             "species_mf: [1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.5, 0.5, 0.0, 1.0, 0.75, 0.1875, 0.0625, 1.0, 0.0, 1.0, 0.5, 0.5, 0.75, 0.1875, 0.0625, 1.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.375, 0.125]\n"
@@ -749,9 +747,8 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mat
         const Node &matset = mesh["matsets/matset"];
         const Node &specset = mesh["specsets/specset"];
 
-        Node silo_rep, silo_rep_matset;
+        Node silo_rep;
 
-        // first test transforming specset to silo rep with a regular matset
         blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
 
         std::cout << specset.to_yaml() << std::endl;
@@ -768,7 +765,7 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mat
             "  - \"b_spec2\"\n"
             "  - \"a_spec1\"\n"
             "  - \"a_spec2\"\n"
-            "speclist: [4, 12, 20, -1]\n"
+            "speclist: [0, 0, 0, -1]\n"
             "nmat: 4\n"
             "nspecies_mf: 32\n"
             "species_mf: [1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.75, 0.1875, 0.0625, 1.0, 0.0, 1.0, 0.5, 0.5, 0.75, 0.1875, 0.0625, 1.0, 0.5, 0.5, 0.0, 1.0, 0.5, 0.375, 0.125, 1.0, 0.5, 0.5, 0.5, 0.5]\n"
@@ -801,31 +798,29 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mat
         const Node &matset = mesh["matsets/matset"];
         const Node &specset = mesh["specsets/specset"];
 
-        Node silo_rep, silo_rep_matset;
+        Node silo_rep;
 
-        // first test transforming specset to silo rep with a regular matset
         blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
 
         std::cout << specset.to_yaml() << std::endl;
         std::cout << silo_rep.to_yaml() << std::endl;
 
-        // const std::string yaml_text = 
-        //     "nmatspec: [0, 2, 0, 3]\n"
-        //     "specnames: \n"
-        //       "- \"a_spec1\"\n"
-        //       "- \"a_spec2\"\n"
-        //       "- \"c_spec1\"\n"
-        //       "- \"c_spec2\"\n"
-        //       "- \"c_spec3\"\n"
-        //     "speclist: [1, 6, 11, -1]\n"
-        //     "nmat: 4\n"
-        //     "nspecies_mf: 20\n"
-        //     "species_mf: [0.0, 1.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.75, 0.1875, 0.0625, 0.0, 1.0, 0.75, 0.1875, 0.0625, 0.5, 0.5, 0.5, 0.375, 0.125]\n"
-        //     "mix_spec: [16, 18, 18]\n"
-        //     "mixlen: 3\n";
-        // Node baseline;
-        // baseline.parse(yaml_text, "yaml");
+        const std::string yaml_text = 
+            "nmatspec: [0, 2, 2, 0]\n"
+            "specnames: \n"
+            "  - \"a_spec1\"\n"
+            "  - \"a_spec2\"\n"
+            "  - \"b_spec1\"\n"
+            "  - \"b_spec2\"\n"
+            "speclist: [1, 5, 9, -1]\n"
+            "nmat: 4\n"
+            "nspecies_mf: 16\n"
+            "species_mf: [0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]\n"
+            "mix_spec: [13, 15, 17]\n"
+            "mixlen: 3\n";
+        Node baseline;
+        baseline.parse(yaml_text, "yaml");
 
-        // EXPECT_FALSE(silo_rep.diff(baseline, info, CONDUIT_EPSILON, true));
+        EXPECT_FALSE(silo_rep.diff(baseline, info, CONDUIT_EPSILON, true));
     }
 }

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -179,6 +179,7 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo)
     Node mset_silo_baseline;
     
     // all of these cases should create the same silo output
+    // (aside from "buffer_style" and "dominance" leaves)
     // we diff the 2 and 3 cases with the 1 to test this
 
     CONDUIT_INFO("venn full to silo");
@@ -208,6 +209,9 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo)
         blueprint::mesh::matset::to_silo(mset, mset_silo);
         std::cout << mset_silo.to_yaml() << std::endl;
 
+        mset_silo_baseline["buffer_style"] = "multi";
+        mset_silo_baseline["dominance"] = "material";
+
         EXPECT_FALSE(mset_silo.diff(mset_silo_baseline,info));
     }
 
@@ -222,6 +226,9 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo)
         Node mset_silo;
         blueprint::mesh::matset::to_silo(mset, mset_silo);
         std::cout << mset_silo.to_yaml() << std::endl;
+
+        mset_silo_baseline["buffer_style"] = "uni";
+        mset_silo_baseline["dominance"] = "element";
 
         EXPECT_FALSE(mset_silo.diff(mset_silo_baseline,info));
     }
@@ -239,8 +246,10 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo)
         blueprint::mesh::matset::to_silo(mset, mset_silo);
         std::cout << mset_silo.to_yaml() << std::endl;
 
+        mset_silo_baseline["buffer_style"] = "uni";
+        mset_silo_baseline["dominance"] = "material";
+
         EXPECT_FALSE(mset_silo.diff(mset_silo_baseline,info));
-        info.print();
     }
 
 }
@@ -255,6 +264,7 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo_matset_values)
     Node mset_silo_baseline;
     
     // all of these cases should create the same silo output
+    // (aside from "buffer_style" and "dominance" leaves)
     // we diff the 2 and 3 cases with the 1 to test this
 
     CONDUIT_INFO("venn full to silo");
@@ -295,6 +305,9 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo_matset_values)
 
         std::cout << mset_silo.to_yaml() << std::endl;
 
+        mset_silo_baseline["buffer_style"] = "multi";
+        mset_silo_baseline["dominance"] = "material";
+
         EXPECT_FALSE(mset_silo.diff(mset_silo_baseline,info));
     }
 
@@ -315,6 +328,9 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo_matset_values)
                                         mset_silo);
 
         std::cout << mset_silo.to_yaml() << std::endl;
+
+        mset_silo_baseline["buffer_style"] = "uni";
+        mset_silo_baseline["dominance"] = "element";
 
         EXPECT_FALSE(mset_silo.diff(mset_silo_baseline,info));
     }
@@ -337,13 +353,16 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_venn_to_silo_matset_values)
 
         std::cout << mset_silo.to_yaml() << std::endl;
 
+        mset_silo_baseline["buffer_style"] = "uni";
+        mset_silo_baseline["dominance"] = "material";
+
         EXPECT_FALSE(mset_silo.diff(mset_silo_baseline,info));
     }
 
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_element)
+TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_style_transforms)
 {
     const int nx = 4, ny = 4;
     const double radius = 0.25;
@@ -398,8 +417,8 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
 
         Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
-        blueprint::mesh::matset::to_sparse_by_element(mset, converted_mset);
-        blueprint::mesh::field::to_sparse_by_element(mset, 
+        blueprint::mesh::matset::to_uni_buffer_by_element(mset, converted_mset);
+        blueprint::mesh::field::to_uni_buffer_by_element(mset, 
                                                      field, 
                                                      converted_matset_name, 
                                                      converted_field);
@@ -548,8 +567,8 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
 
         Node converted_mset, converted_field;
         std::string converted_matset_name = "matset2";
-        blueprint::mesh::matset::to_sparse_by_element(mset, converted_mset);
-        blueprint::mesh::field::to_sparse_by_element(mset, 
+        blueprint::mesh::matset::to_uni_buffer_by_element(mset, converted_mset);
+        blueprint::mesh::field::to_uni_buffer_by_element(mset, 
                                                      field, 
                                                      converted_matset_name, 
                                                      converted_field);
@@ -564,107 +583,107 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_matset_full_to_sparse_by_el
     }
 }
 
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
-{
-    Node mesh;
-    blueprint::mesh::examples::misc("specsets", 4, 4, 1, mesh);
-    const Node &matset = mesh["matsets/mesh"];
-    const Node &specset = mesh["specsets/mesh"];
+// //-----------------------------------------------------------------------------
+// TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_misc)
+// {
+//     Node mesh;
+//     blueprint::mesh::examples::misc("specsets", 4, 4, 1, mesh);
+//     const Node &matset = mesh["matsets/mesh"];
+//     const Node &specset = mesh["specsets/mesh"];
 
-    Node silo_rep1, silo_rep2, silo_rep_matset, info;
+//     Node silo_rep1, silo_rep2, silo_rep_matset, info;
 
-    const std::string yaml_text = 
-        "specnames: \n"
-        "  - \"spec1\"\n"
-        "  - \"spec2\"\n"
-        "  - \"spec1\"\n"
-        "  - \"spec2\"\n"
-        "nmat: 2\n"
-        "nmatspec: [2, 2]\n"
-        "speclist: [3, -1, 9, 15, -3, 21, 27, -5, 33]\n"
-        "nspecies_mf: 36\n"
-        "species_mf: [0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0]\n"
-        "mix_spec: [5, 7, 17, 19, 29, 31]\n"
-        "mixlen: 6";
-    Node baseline;
-    baseline.parse(yaml_text, "yaml");
-
-
-    // first test transforming specset to silo rep with a regular matset
-    blueprint::mesh::specset::to_silo(specset, matset, silo_rep1);
-    std::cout << silo_rep1.to_yaml() << std::endl;
-    EXPECT_FALSE(silo_rep1.diff(baseline, info, CONDUIT_EPSILON, true));
-
-    // next we test transforming specset to silo rep with a silo rep matset
-    blueprint::mesh::matset::to_silo(matset, silo_rep_matset);
-    blueprint::mesh::specset::to_silo(specset, silo_rep_matset, silo_rep2);
-    std::cout << silo_rep2.to_yaml() << std::endl;
-    EXPECT_FALSE(silo_rep2.diff(baseline, info, CONDUIT_EPSILON, true));
-}
-
-//-----------------------------------------------------------------------------
-TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mats)
-{
-    Node mesh;
-    blueprint::mesh::examples::venn_specsets("sparse_by_material", 2, 2, 0.25, mesh);
-
-    // remove some of the materials from the specset
-    mesh["specsets"]["specset"]["matset_values"].remove_child("background");
-    mesh["specsets"]["specset"]["matset_values"].remove_child("circle_b");
-    // create a new specset that has the materials in reverse order
-    mesh["specsets"]["specset2"]["matset"] = "matset";
-    mesh["specsets"]["specset2"]["matset_values"]["circle_c"].set(
-        mesh["specsets"]["specset"]["matset_values"]["circle_c"]);
-    mesh["specsets"]["specset2"]["matset_values"]["circle_a"].set(
-        mesh["specsets"]["specset"]["matset_values"]["circle_a"]);
-    // remove the original specset and replace it with the new one
-    mesh["specsets"].remove_child("specset");
-    mesh["specsets"].rename_child("specset2", "specset");
-
-    mesh.print();
+//     const std::string yaml_text = 
+//         "specnames: \n"
+//         "  - \"spec1\"\n"
+//         "  - \"spec2\"\n"
+//         "  - \"spec1\"\n"
+//         "  - \"spec2\"\n"
+//         "nmat: 2\n"
+//         "nmatspec: [2, 2]\n"
+//         "speclist: [3, -1, 9, 15, -3, 21, 27, -5, 33]\n"
+//         "nspecies_mf: 36\n"
+//         "species_mf: [0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 1.0, 0.0]\n"
+//         "mix_spec: [5, 7, 17, 19, 29, 31]\n"
+//         "mixlen: 6";
+//     Node baseline;
+//     baseline.parse(yaml_text, "yaml");
 
 
-    const Node &matset = mesh["matsets/matset"];
-    const Node &specset = mesh["specsets/specset"];
+//     // first test transforming specset to silo rep with a regular matset
+//     blueprint::mesh::specset::to_silo(specset, matset, silo_rep1);
+//     std::cout << silo_rep1.to_yaml() << std::endl;
+//     EXPECT_FALSE(silo_rep1.diff(baseline, info, CONDUIT_EPSILON, true));
 
-    Node silo_rep;
+//     // next we test transforming specset to silo rep with a silo rep matset
+//     blueprint::mesh::matset::to_silo(matset, silo_rep_matset);
+//     blueprint::mesh::specset::to_silo(specset, silo_rep_matset, silo_rep2);
+//     std::cout << silo_rep2.to_yaml() << std::endl;
+//     EXPECT_FALSE(silo_rep2.diff(baseline, info, CONDUIT_EPSILON, true));
+// }
 
-    // first test transforming specset to silo rep with a regular matset
-    blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
-    std::cout << silo_rep.to_yaml() << std::endl;
+// //-----------------------------------------------------------------------------
+// TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_to_silo_specset_missing_mats)
+// {
+//     Node mesh;
+//     blueprint::mesh::examples::venn_specsets("sparse_by_material", 2, 2, 0.25, mesh);
 
-    // mesh.print();
+//     // remove some of the materials from the specset
+//     mesh["specsets"]["specset"]["matset_values"].remove_child("background");
+//     mesh["specsets"]["specset"]["matset_values"].remove_child("circle_b");
+//     // create a new specset that has the materials in reverse order
+//     mesh["specsets"]["specset2"]["matset"] = "matset";
+//     mesh["specsets"]["specset2"]["matset_values"]["circle_c"].set(
+//         mesh["specsets"]["specset"]["matset_values"]["circle_c"]);
+//     mesh["specsets"]["specset2"]["matset_values"]["circle_a"].set(
+//         mesh["specsets"]["specset"]["matset_values"]["circle_a"]);
+//     // remove the original specset and replace it with the new one
+//     mesh["specsets"].remove_child("specset");
+//     mesh["specsets"].rename_child("specset2", "specset");
 
-    // TODO JUSTIN the above error is triggered because we have this case here:
-    // topology: "MMESH"
-    // material_map: 
-    //   1: 1
-    //   2: 2
-    //   3: 3
-    //   4: 4
-    //   5: 5
-    //   6: 6
-    // matlist: [2, 2, 2, ..., 2, 2]
-    // mix_next: []
-    // mix_mat: []
-    // mix_vf: []
+//     mesh.print();
 
 
-    // matset: "MMATERIAL"
-    // matset_values: 
-    //   2: 
-    //     species0: [0.00221, -0.0712111111111111, -0.144632222222222, ..., 0.663, 0.589578888888889]
-    //     species1: [0.00222, -0.0715333333333333, -0.145286666666667, ..., 0.666, 0.592246666666667]
-    //     species2: [0.00223, -0.0718555555555556, -0.145941111111111, ..., 0.669, 0.594914444444445]
-    //     species3: [0.00224, -0.0721777777777778, -0.146595555555556, ..., 0.672, 0.597582222222222]
-    //   3: 
-    //     species4: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
-    //     species5: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
-    //   4: 
-    //     species6: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+//     const Node &matset = mesh["matsets/matset"];
+//     const Node &specset = mesh["specsets/specset"];
 
-    // not all materials show up in the specset
-    // this really screws things up. I need to be very careful when making silo arrays like nmatspec
-    // I also need a test for this
-}
+//     Node silo_rep;
+
+//     // first test transforming specset to silo rep with a regular matset
+//     blueprint::mesh::specset::to_silo(specset, matset, silo_rep);
+//     std::cout << silo_rep.to_yaml() << std::endl;
+
+//     // mesh.print();
+
+//     // TODO JUSTIN the above error is triggered because we have this case here:
+//     // topology: "MMESH"
+//     // material_map: 
+//     //   1: 1
+//     //   2: 2
+//     //   3: 3
+//     //   4: 4
+//     //   5: 5
+//     //   6: 6
+//     // matlist: [2, 2, 2, ..., 2, 2]
+//     // mix_next: []
+//     // mix_mat: []
+//     // mix_vf: []
+
+
+//     // matset: "MMATERIAL"
+//     // matset_values: 
+//     //   2: 
+//     //     species0: [0.00221, -0.0712111111111111, -0.144632222222222, ..., 0.663, 0.589578888888889]
+//     //     species1: [0.00222, -0.0715333333333333, -0.145286666666667, ..., 0.666, 0.592246666666667]
+//     //     species2: [0.00223, -0.0718555555555556, -0.145941111111111, ..., 0.669, 0.594914444444445]
+//     //     species3: [0.00224, -0.0721777777777778, -0.146595555555556, ..., 0.672, 0.597582222222222]
+//     //   3: 
+//     //     species4: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+//     //     species5: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+//     //   4: 
+//     //     species6: [0.0, 0.0, 0.0, ..., 0.0, 0.0]
+
+//     // not all materials show up in the specset
+//     // this really screws things up. I need to be very careful when making silo arrays like nmatspec
+//     // I also need a test for this
+// }

--- a/src/tests/blueprint/t_blueprint_mesh_partition.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_partition.cpp
@@ -2077,6 +2077,11 @@ diff_to_silo(const conduit::Node &baseline, const conduit::Node &matset,
     conduit::Node test_silo;
     conduit::blueprint::mesh::matset::to_silo(matset["matsets/matset"], test_silo);
 
+    base_silo.remove_child("buffer_style");
+    base_silo.remove_child("dominance");
+    test_silo.remove_child("buffer_style");
+    test_silo.remove_child("dominance");
+
     info.reset();
     return base_silo.diff(test_silo, info, CONDUIT_EPSILON, true);
 }


### PR DESCRIPTION
handle the case where not all materials have species, use some silo optimizations, tests for many strange cases.