### PR TITLE
Let if() test the variable unevaluated

### DIFF
--- a/src/cmake/SetupTests.cmake
+++ b/src/cmake/SetupTests.cmake
@@ -28,7 +28,7 @@ if(CONDUIT_ENABLE_TESTS AND WIN32 AND BUILD_SHARED_LIBS)
     add_custom_target(tpl_dlls_dir ALL
                       COMMAND ${CMAKE_COMMAND} -E make_directory
                       ${CMAKE_BINARY_DIR}/bin/$<CONFIG>)
-    if(${tpl_all_dlls})
+    if(tpl_all_dlls)
         add_custom_target(tpl_dlls ALL
                           COMMAND ${CMAKE_COMMAND} -E copy
                           ${tpl_all_dlls}


### PR DESCRIPTION
Cmake if() takes the name of the variable to test.

This PR changed `if(${tpl_all_dlls})` to `if(tpl_all_dlls)` .  See https://cmake.org/cmake/help/v3.29/command/if.html#variable.  (I cite documentation for CMake 3.29 because that is the version shipped with VS2022.)