### PR TITLE
conduit_node.cpp: Correct typo in error message

### DIFF
--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -366,7 +366,7 @@ Node::load(const std::string &ibase,
         {
             CONDUIT_ERROR("<Node::load> (using protocol = "
                           << proto << ") "
-                          << "failed to open: \"`" << ibase << "\"");
+                          << "failed to open: \"" << ibase << "\"");
         }
         std::string data((std::istreambuf_iterator<char>(ifile)),
                           std::istreambuf_iterator<char>());


### PR DESCRIPTION
Remove superfluous backquote in error message.