### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/.gitlab/toolchains_templates.yml
+++ b/.gitlab/toolchains_templates.yml
@@ -15,14 +15,14 @@
 .with_gcc_static:
   variables:
     TOOLCHAIN: "gcc_static"
-    PKG_SPEC: "%gcc~shared"
+    PKG_SPEC: "~shared %gcc"
 
 .with_clang:
   variables:
     TOOLCHAIN: "clang"
-    PKG_SPEC: "%clang@coral~python~fortran"
+    PKG_SPEC: "~python~fortran %clang@coral"
 
 .with_xl:
   variables:
     TOOLCHAIN: "xl"
-    PKG_SPEC: "%xl@coral~shared~python~fortran"
+    PKG_SPEC: "~shared~python~fortran %xl@coral"


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
