### PR TITLE
DRAFT: Changes/fixes for adjset generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 ### Added
 - Added support for unstructured topologies with `mixed` shape type in the `conduit::blueprint::mesh::partition()` and `conduit::blueprint::mesh::utils::topology::iterate_elements()` functions. They work with mixed shape types, including polyhedra.
 - Enhanced the `conduit::blueprint::mesh::examples::tiled()` function so it can accept mesh tiles containing `mixed` shape types for generating 2D tiled output.
+- Added `conduit::blueprint::mesh::utils::topology::compute_mesh_info()` function to compute basic information about a mesh such as extents and edge lengths.
+- Added `conduit::blueprint::mesh::utils::topology::Quantizer` class to compute a quantized index for a point.
 
 ### Changed
 - The `conduit::blueprint::mesh::topology::dims()` function was changed so it will return the maximum topological dimension of the shape types from the `shape_map` for a `mixed` shape.
+- Adjacency set construction was altered so points are sorted spatially using the `Quantizer` class.
 
 ## [0.9.4] - Released 2025-04-03
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -7038,13 +7038,11 @@ mesh::adjset::is_maxshare(const Node &adjset)
     while(group_itr.has_next() && res)
     {
         const Node &group = group_itr.next();
-        const Node &group_values = group["values"];
+        const auto values = group["values"].as_index_t_accessor();
 
-        for(index_t ni = 0; ni < group_values.dtype().number_of_elements(); ni++)
+        for(index_t vi = 0; vi < values.number_of_elements(); vi++)
         {
-            Node temp(DataType(group_values.dtype().id(), 1),
-                (void*)group_values.element_ptr(ni), true);
-            const index_t next_id = temp.to_index_t();
+            const index_t next_id = values[vi];
 
             res &= ids.find(next_id) == ids.end();
             ids.insert(next_id);
@@ -7078,23 +7076,22 @@ mesh::adjset::to_pairwise(const Node &adjset,
 
         std::vector<index_t> group_neighbors;
         {
-            const Node &group_nvals = group_node["neighbors"];
-            for(index_t ni = 0; ni < group_nvals.dtype().number_of_elements(); ++ni)
+            const auto neighbors = group_node["neighbors"].as_index_t_accessor();
+            group_neighbors.reserve(neighbors.number_of_elements());
+            for(index_t ni = 0; ni < neighbors.number_of_elements(); ++ni)
             {
-                Node temp(DataType(group_nvals.dtype().id(), 1),
-                    (void*)group_nvals.element_ptr(ni), true);
-                group_neighbors.push_back(temp.to_index_t());
+                group_neighbors.push_back(neighbors[ni]);
             }
         }
 
         std::vector<index_t> group_values;
         {
-            const Node &group_vals = group_node["values"];
-            for(index_t vi = 0; vi < group_vals.dtype().number_of_elements(); ++vi)
+            const auto values = group_node["values"].as_index_t_accessor();
+            const index_t numValues = values.number_of_elements();
+            group_values.reserve(numValues);
+            for(index_t vi = 0; vi < numValues; ++vi)
             {
-                Node temp(DataType(group_vals.dtype().id(), 1),
-                    (void*)group_vals.element_ptr(vi), true);
-                group_values.push_back(temp.to_index_t());
+                group_values.push_back(values[vi]);
             }
         }
 
@@ -7158,23 +7155,20 @@ mesh::adjset::to_maxshare(const Node &adjset,
 
         std::vector<index_t> group_neighbors;
         {
-            const Node &group_nvals = group_node["neighbors"];
-            for(index_t ni = 0; ni < group_nvals.dtype().number_of_elements(); ++ni)
+            const auto neighbors = group_node["neighbors"].as_index_t_accessor();
+            group_neighbors.reserve(neighbors.number_of_elements());
+            for(index_t ni = 0; ni < neighbors.number_of_elements(); ++ni)
             {
-                Node temp(DataType(group_nvals.dtype().id(), 1),
-                    (void*)group_nvals.element_ptr(ni), true);
-                group_neighbors.push_back(temp.to_index_t());
+                group_neighbors.push_back(neighbors[ni]);
             }
         }
 
         std::vector<index_t> group_values;
         {
-            const Node &group_vals = group_node["values"];
-            for(index_t vi = 0; vi < group_vals.dtype().number_of_elements(); ++vi)
+            const auto values = group_node["values"].as_index_t_accessor();
+            for(index_t vi = 0; vi < values.number_of_elements(); ++vi)
             {
-                Node temp(DataType(group_vals.dtype().id(), 1),
-                    (void*)group_vals.element_ptr(vi), true);
-                group_values.push_back(temp.to_index_t());
+                group_values.push_back(values[vi]);
             }
         }
 
@@ -7219,12 +7213,10 @@ mesh::adjset::to_maxshare(const Node &adjset,
     for(const std::string &group_name : adjset_group_names)
     {
         const Node &group_node = adjset["groups"][group_name];
-        const Node &group_vals = group_node["values"];
-        for(index_t vi = 0; vi < group_vals.dtype().number_of_elements(); ++vi)
+        const auto values = group_node["values"].as_index_t_accessor();
+        for(index_t vi = 0; vi < values.number_of_elements(); ++vi)
         {
-            Node temp(DataType(group_vals.dtype().id(), 1),
-                (void*)group_vals.element_ptr(vi), true);
-            const index_t group_entity = temp.to_index_t();
+            const index_t group_entity = values[vi];
 
             auto &groupset_pair = groupset_values_map[entity_groupset_map[group_entity]];
             std::vector<index_t> &groupset_valuelist = groupset_pair.first;

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3070,7 +3070,6 @@ generate_derived_entities(conduit::Node &mesh,
             // Make entity
             Entity entity;
             auto &entity_points = std::get<0>(entity);
-            auto &entity_id = std::get<1>(entity);
             for(const index_t &entity_pidx : entity_pidxs)
             {
                 // Get the points for entity_pidx. NOTE: src_cset is same as new dst_topo's coordset.
@@ -3083,7 +3082,7 @@ generate_derived_entities(conduit::Node &mesh,
                     (point_coords.size() > 1) ? point_coords[1] : 0.0,
                     (point_coords.size() > 2) ? point_coords[2] : 0.0);
             }
-            entity_id = ei;
+            std::get<1>(entity) = ei;
 
             // NOTE(JRC): Inserting with this method allows this algorithm to sort new
             // elements as they're generated, rather than as a separate process at the
@@ -3128,25 +3127,18 @@ generate_derived_entities(conduit::Node &mesh,
 
             dst_neighbors.set(DataType(src_neighbors_dtype.id(), group_nidxs.size()));
             index_t ni = 0;
+            auto neighbors = dst_neighbors.as_index_t_accessor();
             for(auto nitr = group_nidxs.begin(); nitr != group_nidxs.end(); ++nitr)
             {
-                // TODO: USE ACCESSORS
-                src_data.set_external(DataType::index_t(1),
-                    (void*)&(*nitr));
-                dst_data.set_external(DataType(src_neighbors_dtype.id(), 1),
-                    (void*)dst_neighbors.element_ptr(ni++));
-                src_data.to_data_type(dst_data.dtype().id(), dst_data);
+                neighbors.set(ni++, *nitr);
             }
 
             dst_values.set(DataType(src_values_dtype.id(), group_entities.size()));
+            auto values = dst_values.as_index_t_accessor();
             for(index_t ei = 0; ei < (index_t)group_entities.size(); ei++)
             {
-                // TODO: USE ACCESSORS
-                src_data.set_external(DataType::index_t(1),
-                    (void*)&std::get<1>(group_entities[ei]));
-                dst_data.set_external(DataType(src_values_dtype.id(), 1),
-                    (void*)dst_values.element_ptr(ei));
-                src_data.to_data_type(dst_data.dtype().id(), dst_data);
+                const index_t nodeid = std::get<1>(group_entities[ei]);
+                values.set(ei, nodeid);
             }
         }
     }
@@ -3425,10 +3417,8 @@ generate_decomposed_entities(conduit::Node &mesh,
 
             // Make entity
             Entity entity;
-            auto &entity_points = std::get<0>(entity);
-            auto &entity_id = std::get<1>(entity);
 #ifdef CONDUIT_SINGLE_POINT
-            entity_points = PointTuple{point_coords[0],
+            std::get<0>(entity) = PointTuple{point_coords[0],
                 (point_coords.size() > 1) ? point_coords[1] : 0.0,
                 (point_coords.size() > 2) ? point_coords[2] : 0.0};
 #else
@@ -3438,7 +3428,7 @@ generate_decomposed_entities(conduit::Node &mesh,
                 (point_coords.size() > 1) ? point_coords[1] : 0.0,
                 (point_coords.size() > 2) ? point_coords[2] : 0.0);
 #endif
-            entity_id = entity_cidx;
+            std::get<1>(entity) = entity_cidx;
 
             // NOTE(JRC): Inserting with this method allows this algorithm to sort new
             // elements as they're generated, rather than as a separate process at the
@@ -3486,33 +3476,15 @@ generate_decomposed_entities(conduit::Node &mesh,
             auto neighbors = dst_neighbors.as_index_t_accessor();
             for(auto nitr = group_nidxs.begin(); nitr != group_nidxs.end(); ++nitr)
             {
-#if 1
                 neighbors.set(ni++, *nitr);
-#else
-                // TODO: USE ACCESSORS
-                src_data.set_external(DataType::index_t(1),
-                    (void*)&(*nitr));
-                dst_data.set_external(DataType(src_neighbors_dtype.id(), 1),
-                    (void*)dst_neighbors.element_ptr(ni++));
-                src_data.to_data_type(dst_data.dtype().id(), dst_data);
-#endif
             }
 
             dst_values.set(DataType(src_values_dtype.id(), group_entities.size()));
             auto values = dst_values.as_index_t_accessor();
             for(index_t ei = 0; ei < (index_t)group_entities.size(); ei++)
             {
-#if 1
                 const index_t nodeid = std::get<1>(group_entities[ei]);
                 values.set(ei, nodeid);
-#else
-                // TODO: USE ACCESSORS
-                src_data.set_external(DataType::index_t(1),
-                    (void*)&std::get<1>(group_entities[ei]));
-                dst_data.set_external(DataType(src_values_dtype.id(), 1),
-                    (void*)dst_values.element_ptr(ei));
-                src_data.to_data_type(dst_data.dtype().id(), dst_data);
-#endif
             }
         }
     }

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -3193,7 +3193,12 @@ generate_decomposed_entities(conduit::Node &mesh,
                              const std::vector<index_t> &decomposed_centroid_dims,
                              conduit::blueprint::mesh::utils::query::PointQueryBase &query)
 {
+#define CONDUIT_SINGLE_POINT
+#ifdef CONDUIT_SINGLE_POINT
+    using Entity = std::tuple<PointTuple, index_t>;
+#else
     using Entity = std::tuple<std::set<PointTuple>, index_t>;
+#endif
     using EntityVector = std::vector<Entity>;
 
     CONDUIT_ANNOTATE_MARK_FUNCTION;
@@ -3422,13 +3427,17 @@ generate_decomposed_entities(conduit::Node &mesh,
             Entity entity;
             auto &entity_points = std::get<0>(entity);
             auto &entity_id = std::get<1>(entity);
-
+#ifdef CONDUIT_SINGLE_POINT
+            entity_points = PointTuple{point_coords[0],
+                (point_coords.size() > 1) ? point_coords[1] : 0.0,
+                (point_coords.size() > 2) ? point_coords[2] : 0.0};
+#else
             // 1 point is being added to the entity.
             entity_points.emplace(
                 point_coords[0],
                 (point_coords.size() > 1) ? point_coords[1] : 0.0,
                 (point_coords.size() > 2) ? point_coords[2] : 0.0);
-
+#endif
             entity_id = entity_cidx;
 
             // NOTE(JRC): Inserting with this method allows this algorithm to sort new
@@ -3474,25 +3483,36 @@ generate_decomposed_entities(conduit::Node &mesh,
 
             dst_neighbors.set(DataType(src_neighbors_dtype.id(), group_nidxs.size()));
             index_t ni = 0;
+            auto neighbors = dst_neighbors.as_index_t_accessor();
             for(auto nitr = group_nidxs.begin(); nitr != group_nidxs.end(); ++nitr)
             {
+#if 1
+                neighbors.set(ni++, *nitr);
+#else
                 // TODO: USE ACCESSORS
                 src_data.set_external(DataType::index_t(1),
                     (void*)&(*nitr));
                 dst_data.set_external(DataType(src_neighbors_dtype.id(), 1),
                     (void*)dst_neighbors.element_ptr(ni++));
                 src_data.to_data_type(dst_data.dtype().id(), dst_data);
+#endif
             }
 
             dst_values.set(DataType(src_values_dtype.id(), group_entities.size()));
+            auto values = dst_values.as_index_t_accessor();
             for(index_t ei = 0; ei < (index_t)group_entities.size(); ei++)
             {
+#if 1
+                const index_t nodeid = std::get<1>(group_entities[ei]);
+                values.set(ei, nodeid);
+#else
                 // TODO: USE ACCESSORS
                 src_data.set_external(DataType::index_t(1),
                     (void*)&std::get<1>(group_entities[ei]));
                 dst_data.set_external(DataType(src_values_dtype.id(), 1),
                     (void*)dst_values.element_ptr(ei));
                 src_data.to_data_type(dst_data.dtype().id(), dst_data);
+#endif
             }
         }
     }

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -57,9 +57,21 @@ typedef bputils::TopologyMetadata TopologyMetadata;
 //-----------------------------------------------------------------------------
 // -- begin internal helpers --
 //-----------------------------------------------------------------------------
-// TODO(JRC): Consider moving an improved version of this type to a more accessible location.
+
+/*
+ * @brief This struct represents a float64 with a custom less than operator that
+ *        considers a tolerance to determine whether values are the same. If
+ *        the difference in values is greater than the epsilon then the values
+ *        are different and we can compare with float64::operator<
+ *
+ * @note TODO(JRC): Consider moving an improved version of this type to a more accessible location.
+ */
 struct ffloat64
 {
+    // NOTE: Define an epsilon here that is smaller than CONDUIT_EPSILON so
+    //       values have to be closer together to be considered equal.
+    static constexpr conduit::float64 FFLOAT_EPSILON = CONDUIT_EPSILON / 10.;
+
     conduit::float64 data;
 
     ffloat64(conduit::float64 input = 0.0)
@@ -74,7 +86,8 @@ struct ffloat64
 
     bool operator<(const ffloat64 &other) const
     {
-        return this->data < other.data && std::abs(this->data - other.data) > CONDUIT_EPSILON;
+        //     less than               and  values are different
+        return this->data < other.data && std::abs(this->data - other.data) > FFLOAT_EPSILON;
     }
 };
 
@@ -85,7 +98,14 @@ namespace o2mrelation = conduit::blueprint::o2mrelation;
 
 // typedefs for verbose but commonly used types
 typedef std::tuple<conduit::Node*, conduit::Node*, conduit::Node*> DomMapsTuple;
+
+/*
+ * @brief Represent a point using ffloat64 so the point will use ffloat64's less
+ *        than operator on each component to determine less than for the point.
+ *        This helps Conduit sort points spatially.
+ */
 typedef std::tuple<ffloat64, ffloat64, ffloat64> PointTuple;
+
 // typedefs to enable passing around function pointers
 typedef void (*GenDerivedFun)(const conduit::Node&, conduit::Node&, conduit::Node&, conduit::Node&);
 typedef void (*GenDecomposedFun)(const conduit::Node&, conduit::Node&, conduit::Node&, conduit::Node&, conduit::Node&);
@@ -2874,6 +2894,9 @@ generate_derived_entities(conduit::Node &mesh,
                           GenDerivedFun generate_derived,
                           conduit::blueprint::mesh::utils::query::MatchQuery &Q)
 {
+    using Entity = std::tuple<std::set<PointTuple>, index_t>;
+    using EntityVector = std::vector<Entity>;
+
     CONDUIT_ANNOTATE_MARK_FUNCTION;
 
     // loop over all domains and call generate_derived on each domain
@@ -3026,56 +3049,62 @@ generate_derived_entities(conduit::Node &mesh,
         const Node &src_topo = *src_topo_ptr;
         const Node *src_cset_ptr = bputils::find_reference_node(src_topo, "coordset");
         const Node &src_cset = *src_cset_ptr;
+        const conduit::Node &src_adjset_groups = domain["adjsets"][src_adjset_name]["groups"];
 
         const Node &dst_topo = domain["topologies"][dst_topo_name];
 
-        const conduit::Node &src_adjset_groups = domain["adjsets"][src_adjset_name]["groups"];
         conduit::Node &dst_adjset_groups = domain["adjsets"][dst_adjset_name]["groups"];
 
         // Use Entity Interfaces to Construct Group Entity Lists //
 
-        std::map<std::set<index_t>, std::vector<std::tuple<std::set<PointTuple>, index_t>>> group_entity_map;
+        std::map<std::set<index_t>, EntityVector> group_entity_map;
         const auto &entity_neighbor_map = dom_entity_neighbor_map[domain_id];
         for(const auto &entity_neighbor_pair : entity_neighbor_map)
         {
             const index_t &ei = entity_neighbor_pair.first;
             const std::set<index_t> &entity_neighbors = entity_neighbor_pair.second;
-            std::tuple<std::set<PointTuple>, index_t> entity;
 
-            std::vector<index_t> entity_pidxs = bputils::topology::unstructured::points(dst_topo, ei);
-            std::set<PointTuple> &entity_points = std::get<0>(entity);
+            // Get point ids used in entity ei in dst_topo
+            const std::vector<index_t> entity_pidxs = bputils::topology::unstructured::points(dst_topo, ei);
+
+            // Make entity
+            Entity entity;
+            auto &entity_points = std::get<0>(entity);
+            auto &entity_id = std::get<1>(entity);
             for(const index_t &entity_pidx : entity_pidxs)
             {
+                // Get the points for entity_pidx. NOTE: src_cset is same as new dst_topo's coordset.
                 const std::vector<float64> point_coords = bputils::coordset::_explicit::coords(
                     src_cset, entity_pidx);
+
+                // Emplace the point into entity_points as a PointTuple.
                 entity_points.emplace(
                     point_coords[0],
                     (point_coords.size() > 1) ? point_coords[1] : 0.0,
                     (point_coords.size() > 2) ? point_coords[2] : 0.0);
             }
-
-            index_t &entity_id = std::get<1>(entity);
             entity_id = ei;
 
             // NOTE(JRC): Inserting with this method allows this algorithm to sort new
             // elements as they're generated, rather than as a separate process at the
-            // end (slight optimization overall).
-            std::vector<std::tuple<std::set<PointTuple>, index_t>> &group_entities =
-                group_entity_map[entity_neighbors];
+            // end (slight optimization overall). PointTuple and ffloat64's less than
+            // operator determines the insertion location.
+            auto &group_entities = group_entity_map[entity_neighbors];
             auto entity_itr = std::upper_bound(group_entities.begin(), group_entities.end(), entity);
             group_entities.insert(entity_itr, entity);
         }
 
         for(const auto &group_pair : group_entity_map)
         {
+            const std::set<index_t> &group_nidxs = group_pair.first;
+            const EntityVector &group_entities = group_pair.second;
+
             // NOTE(JRC): It's possible for the 'src_adjset_groups' node to be empty,
             // so we only want to query child data types if we know there is at least
             // 1 non-empty group.
             const conduit::DataType src_neighbors_dtype = src_adjset_groups.child(0)["neighbors"].dtype();
             const conduit::DataType src_values_dtype = src_adjset_groups.child(0)["values"].dtype();
 
-            const std::set<index_t> &group_nidxs = group_pair.first;
-            const std::vector<std::tuple<std::set<PointTuple>, index_t>> &group_entities = group_pair.second;
             std::string group_name;
             {
                 // NOTE(JRC): The current domain is included in the domain name so that
@@ -3164,6 +3193,9 @@ generate_decomposed_entities(conduit::Node &mesh,
                              const std::vector<index_t> &decomposed_centroid_dims,
                              conduit::blueprint::mesh::utils::query::PointQueryBase &query)
 {
+    using Entity = std::tuple<std::set<PointTuple>, index_t>;
+    using EntityVector = std::vector<Entity>;
+
     CONDUIT_ANNOTATE_MARK_FUNCTION;
 
     // Iterate over the domains and produce a "decomposed" mesh for each domain.
@@ -3373,16 +3405,11 @@ generate_decomposed_entities(conduit::Node &mesh,
         //
         // This assumption must be made to avoid a costly coordinate->id lookup.
 
-        std::map<std::set<index_t>, std::vector<std::tuple<std::set<PointTuple>, index_t>>> group_entity_map;
+        std::map<std::set<index_t>, EntityVector> group_entity_map;
         for(const auto &entity_neighbor_pair : entity_neighbor_map)
         {
             const index_t &entity_cidx = entity_neighbor_pair.first;
             const std::set<index_t> &entity_neighbors = entity_neighbor_pair.second;
-
-            // Make an entity tuple and get references to its members.
-            std::tuple<std::set<PointTuple>, index_t> entity;
-            std::set<PointTuple> &entity_points = std::get<0>(entity);
-            index_t &entity_id = std::get<1>(entity);
 
             // NOTE(JRC): Diff: Substitute entity for centroid point at the end here.
 
@@ -3391,6 +3418,12 @@ generate_decomposed_entities(conduit::Node &mesh,
             const std::vector<float64> point_coords = bputils::coordset::_explicit::coords(
                 dst_cset, entity_cidx);
 
+            // Make entity
+            Entity entity;
+            auto &entity_points = std::get<0>(entity);
+            auto &entity_id = std::get<1>(entity);
+
+            // 1 point is being added to the entity.
             entity_points.emplace(
                 point_coords[0],
                 (point_coords.size() > 1) ? point_coords[1] : 0.0,
@@ -3400,7 +3433,8 @@ generate_decomposed_entities(conduit::Node &mesh,
 
             // NOTE(JRC): Inserting with this method allows this algorithm to sort new
             // elements as they're generated, rather than as a separate process at the
-            // end (slight optimization overall).
+            // end (slight optimization overall). PointTuple and ffloat64's less than
+            // operator determines the insertion location.
             auto &group_entities = group_entity_map[entity_neighbors];
             auto entity_itr = std::upper_bound(group_entities.begin(), group_entities.end(), entity);
             group_entities.insert(entity_itr, entity);

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -58,39 +58,6 @@ typedef bputils::TopologyMetadata TopologyMetadata;
 // -- begin internal helpers --
 //-----------------------------------------------------------------------------
 
-/*
- * @brief This struct represents a float64 with a custom less than operator that
- *        considers a tolerance to determine whether values are the same. If
- *        the difference in values is greater than the epsilon then the values
- *        are different and we can compare with float64::operator<
- *
- * @note TODO(JRC): Consider moving an improved version of this type to a more accessible location.
- */
-struct ffloat64
-{
-    // NOTE: Define an epsilon here that is smaller than CONDUIT_EPSILON so
-    //       values have to be closer together to be considered equal.
-    static constexpr conduit::float64 FFLOAT_EPSILON = CONDUIT_EPSILON / 10.;
-
-    conduit::float64 data;
-
-    ffloat64(conduit::float64 input = 0.0)
-    {
-        data = input;
-    }
-
-    operator conduit::float64() const
-    {
-        return this->data;
-    }
-
-    bool operator<(const ffloat64 &other) const
-    {
-        //     less than               and  values are different
-        return this->data < other.data && std::abs(this->data - other.data) > FFLOAT_EPSILON;
-    }
-};
-
 // access conduit blueprint mesh utilities
 namespace bputils = conduit::blueprint::mesh::utils;
 // access one-to-many index types
@@ -98,13 +65,6 @@ namespace o2mrelation = conduit::blueprint::o2mrelation;
 
 // typedefs for verbose but commonly used types
 typedef std::tuple<conduit::Node*, conduit::Node*, conduit::Node*> DomMapsTuple;
-
-/*
- * @brief Represent a point using ffloat64 so the point will use ffloat64's less
- *        than operator on each component to determine less than for the point.
- *        This helps Conduit sort points spatially.
- */
-typedef std::tuple<ffloat64, ffloat64, ffloat64> PointTuple;
 
 // typedefs to enable passing around function pointers
 typedef void (*GenDerivedFun)(const conduit::Node&, conduit::Node&, conduit::Node&, conduit::Node&);
@@ -2894,7 +2854,8 @@ generate_derived_entities(conduit::Node &mesh,
                           GenDerivedFun generate_derived,
                           conduit::blueprint::mesh::utils::query::MatchQuery &Q)
 {
-    using Entity = std::tuple<std::set<PointTuple>, index_t>;
+    namespace topoutils = conduit::blueprint::mesh::utils::topology;
+    using Entity = std::tuple<std::set<topoutils::Quantizer::QuantizedIndex>, index_t>;
     using EntityVector = std::vector<Entity>;
 
     CONDUIT_ANNOTATE_MARK_FUNCTION;
@@ -3053,6 +3014,11 @@ generate_derived_entities(conduit::Node &mesh,
 
         const Node &dst_topo = domain["topologies"][dst_topo_name];
 
+        // Compute information about the dst_topo and make a Quantizer with it.
+        topoutils::MeshInfo dst_info;
+        topoutils::compute_mesh_info(dst_topo, dst_info);
+        topoutils::Quantizer quantizer(dst_info);
+
         conduit::Node &dst_adjset_groups = domain["adjsets"][dst_adjset_name]["groups"];
 
         // Use Entity Interfaces to Construct Group Entity Lists //
@@ -3076,11 +3042,8 @@ generate_derived_entities(conduit::Node &mesh,
                 const std::vector<float64> point_coords = bputils::coordset::_explicit::coords(
                     src_cset, entity_pidx);
 
-                // Emplace the point into entity_points as a PointTuple.
-                entity_points.emplace(
-                    point_coords[0],
-                    (point_coords.size() > 1) ? point_coords[1] : 0.0,
-                    (point_coords.size() > 2) ? point_coords[2] : 0.0);
+                // Add a quantized point id to the entity points
+                entity_points.emplace(quantizer.quantize(point_coords));
             }
             std::get<1>(entity) = ei;
 
@@ -3185,12 +3148,8 @@ generate_decomposed_entities(conduit::Node &mesh,
                              const std::vector<index_t> &decomposed_centroid_dims,
                              conduit::blueprint::mesh::utils::query::PointQueryBase &query)
 {
-#define CONDUIT_SINGLE_POINT
-#ifdef CONDUIT_SINGLE_POINT
-    using Entity = std::tuple<PointTuple, index_t>;
-#else
-    using Entity = std::tuple<std::set<PointTuple>, index_t>;
-#endif
+    namespace topoutils = conduit::blueprint::mesh::utils::topology;
+    using Entity = std::tuple<topoutils::Quantizer::QuantizedIndex, index_t>;
     using EntityVector = std::vector<Entity>;
 
     CONDUIT_ANNOTATE_MARK_FUNCTION;
@@ -3391,6 +3350,13 @@ generate_decomposed_entities(conduit::Node &mesh,
         const Node &src_adjset_groups = domain["adjsets"][src_adjset_name]["groups"];
         Node &dst_adjset_groups = domain["adjsets"][dst_adjset_name]["groups"];
 
+        const Node &dst_topo = domain["topologies"][dst_topo_name];
+
+        // Compute information about the dst_topo and make a Quantizer with it.
+        topoutils::MeshInfo dst_info;
+        topoutils::compute_mesh_info(dst_topo, dst_info);
+        topoutils::Quantizer quantizer(dst_info);
+
         // Use Entity Interfaces to Construct Group Entity Lists //
 
         // Iterate over the entity_neighbor_map and build up group_entity_map.
@@ -3417,17 +3383,7 @@ generate_decomposed_entities(conduit::Node &mesh,
 
             // Make entity
             Entity entity;
-#ifdef CONDUIT_SINGLE_POINT
-            std::get<0>(entity) = PointTuple{point_coords[0],
-                (point_coords.size() > 1) ? point_coords[1] : 0.0,
-                (point_coords.size() > 2) ? point_coords[2] : 0.0};
-#else
-            // 1 point is being added to the entity.
-            entity_points.emplace(
-                point_coords[0],
-                (point_coords.size() > 1) ? point_coords[1] : 0.0,
-                (point_coords.size() > 2) ? point_coords[2] : 0.0);
-#endif
+            std::get<0>(entity) = quantizer.quantize(point_coords);
             std::get<1>(entity) = entity_cidx;
 
             // NOTE(JRC): Inserting with this method allows this algorithm to sort new

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -28,8 +28,10 @@
 #include "conduit_blueprint_o2mrelation.hpp"
 #include "conduit_blueprint_o2mrelation_iterator.hpp"
 #include "conduit_blueprint_mesh_utils.hpp"
+#include "conduit_blueprint_mesh_utils_iterate_elements.hpp"
 #include "conduit_execution.hpp"
 #include "conduit_annotations.hpp"
+#include "conduit_utils.hpp"
 #include "conduit_blueprint_mesh_kdtree.hpp"
 
 // access one-to-many index types
@@ -2316,6 +2318,161 @@ topology::search(const conduit::Node &topo1, const conduit::Node &topo2)
 
 //-----------------------------------------------------------------------------
 void
+topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &info)
+{
+    CONDUIT_ANNOTATE_MARK_FUNCTION;
+
+    // Get the coordset
+    const Node *n_coordset_ptr = find_reference_node(n_topo, "coordset");
+    if(n_coordset_ptr == nullptr)
+    {
+       CONDUIT_ERROR("Unable to get coordset for topology.");
+    }
+    const Node &n_coordset = *n_coordset_ptr;
+    if(n_coordset.fetch_existing("type").as_string() != "explicit")
+    {
+       CONDUIT_ERROR("Requires explicit coordset");
+    }
+
+    // Make coordset accessors for the components.
+    std::vector<double_accessor> coords;
+    for(const auto &axisName : conduit::blueprint::mesh::utils::coordset::axes(n_coordset))
+    {
+       coords.push_back(n_coordset.fetch_existing("values/" + axisName).as_double_accessor());
+    }
+
+    // Initialize the mesh information.
+    for(size_t i = 0; i < 3; i++)
+    {
+      info.minExtents[i] = (i < coords.size()) ? std::numeric_limits<double>::max() : 0.;
+      info.maxExtents[i] = (i < coords.size()) ? std::numeric_limits<double>::lowest() : 0.;
+    }
+    info.minEdgeLength = std::numeric_limits<double>::max();
+    info.maxEdgeLength = std::numeric_limits<double>::lowest();
+
+    // This lambda computes edge information for the edge between p0, p1.
+    auto computeEdgeInfo = [&](index_t p0, index_t p1)
+    {
+        double lenSquared = 0.;
+        for(size_t comp = 0; comp < coords.size(); comp++)
+        {
+            const auto &acc = coords[comp];
+            const auto v0 = acc[p0];
+            const auto v1 = acc[p1];
+            const auto dValue = v0 - v1;
+            lenSquared += dValue * dValue;
+
+            info.minExtents[comp] = std::min(info.minExtents[comp], v0);
+            info.maxExtents[comp] = std::max(info.maxExtents[comp], v0);
+        }
+
+        if(lenSquared > 0.)
+        {
+            info.minEdgeLength = std::min(info.minEdgeLength, lenSquared);
+            info.maxEdgeLength = std::max(info.maxEdgeLength, lenSquared);
+        }
+    };
+
+    // Iterate over all of the elements in the topology and compute the edge info
+    // for each element.
+    iterate_elements(n_topo, [&](const entity &e)
+    {
+        if(e.shape.is_polyhedral())
+        {
+            for(size_t f = 0; f < e.subelement_ids.size(); f++)
+            {
+                const auto &faceIds = e.subelement_ids[f];
+                index_t nIds = faceIds.size();
+                for(index_t i = 0; i < nIds; i++)
+                {
+                    computeEdgeInfo(faceIds[i], faceIds[(i + 1) % nIds]);
+                }
+            }
+        }
+        else if(e.shape.dim == 3)
+        {
+            for(index_t f = 0; f < e.shape.num_faces(); f++)
+            {
+                index_t nIds;
+                const auto *faceIds = e.shape.get_face(f, nIds);
+                for(index_t i = 0; i < nIds; i++)
+                {
+                    computeEdgeInfo(e.element_ids[faceIds[i]],
+                                    e.element_ids[faceIds[(i + 1) % nIds]]);
+                }
+            }
+        }
+        else if(e.shape.dim == 2)
+        {
+            const index_t nIds = static_cast<index_t>(e.element_ids.size());
+            for(index_t i = 0; i < nIds; i++)
+            {
+              computeEdgeInfo(e.element_ids[i],
+                              e.element_ids[(i + 1) % nIds]);
+            }
+        }
+    });
+
+    // If we had edges then the min,max edge lengths will be greater than zero.
+    // Turn them from len squared to len by taking the square root.
+    info.minEdgeLength = (info.minEdgeLength > 0.) ? sqrt(info.minEdgeLength) : 1.;
+    info.maxEdgeLength = (info.maxEdgeLength > 0.) ? sqrt(info.maxEdgeLength) : 1.;
+}
+
+//-----------------------------------------------------------------------------
+namespace topology
+{
+std::ostream &operator << (std::ostream &os, const MeshInfo &obj)
+{
+    os << "{minExtents={" << obj.minExtents[0] << ", " << obj.minExtents[1] << ", " << obj.minExtents[2] << "}, "
+       << "maxExtents={" << obj.maxExtents[0] << ", " << obj.maxExtents[1] << ", " << obj.maxExtents[2] << "}, "
+       << "minEdgeLength=" << obj.minEdgeLength << ", "
+       << "maxEdgeLength=" << obj.maxEdgeLength << "}";
+    return os;
+}
+} // end topology namespace
+
+//-----------------------------------------------------------------------------
+topology::Quantizer::Quantizer(const topology::MeshInfo &info) : meshInfo(info)
+{
+    // Set some values derived from the MeshInfo.
+    QX = std::max(uint64_t{1}, static_cast<uint64_t>(ceil((meshInfo.maxExtents[0] - meshInfo.minExtents[0]) / meshInfo.minEdgeLength)));
+    QY = std::max(uint64_t{1}, static_cast<uint64_t>(ceil((meshInfo.maxExtents[1] - meshInfo.minExtents[1]) / meshInfo.minEdgeLength)));
+    QXQY = QX * QY;
+}
+
+topology::Quantizer::QuantizedIndex
+topology::Quantizer::quantize(float64 value, index_t component) const
+{
+    CONDUIT_ASSERT(component >= 0 && component < 3, "Valid components are 0,1,2");
+    return static_cast<QuantizedIndex>((value - meshInfo.minExtents[component]) / meshInfo.minEdgeLength);
+}
+
+topology::Quantizer::QuantizedIndex
+topology::Quantizer::quantize(const std::vector<float64> &node) const
+{
+    CONDUIT_ASSERT(node.size() <= 3, "Node has invalid number of components");
+    QuantizedIndex qIndex = 0;
+    switch(node.size())
+    {
+    default:
+        CONDUIT_ERROR("Unsupported number of components.");
+        break;
+    case 3:
+        qIndex += QXQY * quantize(node[2], 2);
+        // Falls through
+    case 2:
+        qIndex += QX * quantize(node[1], 1);
+        // Falls through
+    case 1:
+        qIndex += quantize(node[0], 0);
+        break;
+    }
+    return qIndex;
+}
+
+//-----------------------------------------------------------------------------
+void
 topology::unstructured::generate_offsets_inline(Node &topo)
 {
     // check for polyhedral case
@@ -3140,8 +3297,16 @@ adjset::validate(const conduit::Node &doms,
                 ss << "Domain " << domain_id << " adjset " << adjsetName
                    << " group " << groupName
                    << ": vertex " << ptid
-                   << " (" << coord[0] << ", " << coord[1]
-                   << ", " << coord[2] << ") at index " << ptid
+                   << " (" << coord[0];
+                if(coord.size() > 1)
+                {
+                    ss << ", " << coord[1];
+                }
+                if(coord.size() > 2)
+                {
+                    ss << ", " << coord[2];
+                }
+                ss << ") at index " << ptid
                    << " could not be located in neighbor domain "
                    << nbr << ".";
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -582,7 +582,7 @@ namespace topology
      *
      * @return The output stream reference.
      */
-    std::ostream & CONDUIT_BLUEPRINT_API operator << (std::ostream &os, const MeshInfo &obj);
+    std::ostream &operator << (std::ostream &os, const MeshInfo &obj);
 
     //-------------------------------------------------------------------------
     /**

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.hpp
@@ -553,6 +553,77 @@ namespace topology
                                                   const conduit::Node &topo2);
 
     //-------------------------------------------------------------------------
+    /**
+     * @brief Compute information about a mesh; its coordinate extents and edge
+     *        lengths. It is implemented as a struct in case other quantities are
+     *        added in the future.
+     */
+    struct CONDUIT_BLUEPRINT_API MeshInfo
+    {
+        float64 minExtents[3];
+        float64 maxExtents[3];
+        float64 minEdgeLength;
+        float64 maxEdgeLength;
+    };
+
+    /**
+     * @brief Compute the mesh information.
+     *
+     * @param n_topo A topology to use for computing the mesh information.
+     * @param[out] info A struct that contains the mesh information.
+     */
+    void CONDUIT_BLUEPRINT_API compute_mesh_info(const conduit::Node &n_topo, MeshInfo &info);
+
+    /**
+     * @brief Output stream operator for MeshInfo
+     *
+     * @param os The output stream to use.
+     * @param obj The MeshInfo object to write.
+     *
+     * @return The output stream reference.
+     */
+    std::ostream & CONDUIT_BLUEPRINT_API operator << (std::ostream &os, const MeshInfo &obj);
+
+    //-------------------------------------------------------------------------
+    /**
+     * @brief Quantize a mesh node into an index by binning the points in a regular
+     *        grid determined using MeshInfo.
+     */
+    struct CONDUIT_BLUEPRINT_API Quantizer
+    {
+        using QuantizedIndex = uint64_t;
+
+        /// Constructor.
+        Quantizer(const MeshInfo &info);
+
+        /**
+         * @brief Quantize a single value using the binned spatial mesh, implied
+         *        by the MeshInfo.
+         *
+         * @param value The value to be quantized.
+         * @param dim The mesh dimension index (0,1,2) to be used for quantization.
+         *
+         * @return A quantized index along the dimension.
+         */
+        QuantizedIndex quantize(float64 value, index_t dim) const;
+
+        /**
+         * @brief Convert the input node into a quantized index in the binned
+         *        spatial mesh, implied by the MeshInfo.
+         *
+         * @param node A vector containing a point with 1-3 components.
+         *
+         * @return A quantized node index that can identify the node.
+         */
+        QuantizedIndex quantize(const std::vector<float64> &node) const;
+
+        MeshInfo meshInfo;
+        QuantizedIndex QX;
+        QuantizedIndex QY;
+        QuantizedIndex QXQY;
+    };
+
+    //-------------------------------------------------------------------------
     // -- begin conduit::blueprint::mesh::utils::topology::unstructured --
     //-------------------------------------------------------------------------
     namespace unstructured

--- a/src/tests/blueprint/t_blueprint_mesh_utils.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_utils.cpp
@@ -1198,3 +1198,125 @@ TEST(conduit_blueprint_mesh_utils, lerp_3d_cube)
         verify_lerp_result(expcube, cube);
     }
 }
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_utils, mesh_info)
+{
+    namespace topoutils = conduit::blueprint::mesh::utils::topology;
+    conduit::Node root;
+    const char *yaml = R"(
+coordsets:
+  coords:
+    type: explicit
+    values:
+      x: [0.,0.1, 0.3, 0.6, 1.,  0.,0.1, 0.3, 0.6, 1.,  0., 0.1, 0.3, 0.6, 1.]
+      y: [0., 0., 0., 0., 0.,  1., 1., 1., 1., 1.,  2.5, 2.5, 2.5, 2.5, 2.5]
+topologies:
+  main:
+    type: unstructured
+    coordset: coords
+    elements:
+      shape: quad
+      connectivity: [0,1,6,5, 1,2,7,6, 2,3,8,7, 3,4,9,8, 5,6,11,10, 6,7,12,11, 7,8,13,12, 8,9,14,13]
+      sizes: [4,4,4,4,4,4]
+      offsets: [0,4,8,12,16,20]
+)";
+    root.parse(yaml);
+
+    topoutils::MeshInfo info;
+    topoutils::compute_mesh_info(root.fetch_existing("topologies/main"), info);
+
+    const double eps = 1.e-12;
+    EXPECT_NEAR(info.minExtents[0], 0., eps);
+    EXPECT_NEAR(info.minExtents[1], 0., eps);
+    EXPECT_NEAR(info.minExtents[2], 0., eps);
+    EXPECT_NEAR(info.maxExtents[0], 1., eps);
+    EXPECT_NEAR(info.maxExtents[1], 2.5, eps);
+    EXPECT_NEAR(info.maxExtents[2], 0., eps);
+    EXPECT_NEAR(info.minEdgeLength, 0.1, eps);
+    EXPECT_NEAR(info.maxEdgeLength, 1.5, eps);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_utils, mesh_info_3d)
+{
+    namespace topoutils = conduit::blueprint::mesh::utils::topology;
+    conduit::Node root;
+    const char *yaml = R"(
+coordsets:
+  coords:
+    type: explicit
+    values:
+      x: [0.,0.1, 0.3, 0.,0.1, 0.3, 0.,0.1, 0.3,  0.,0.1, 0.3, 0.,0.1, 0.3, 0.,0.1, 0.3]
+      y: [1., 1., 1.,  2., 2., 2., 4., 4., 4.,  1., 1., 1.,  2., 2., 2., 4., 4., 4.]
+      z: [2., 2., 2.,  2., 2., 2., 2., 2., 2.,  6., 6., 6.,  6., 6., 6., 6., 6., 6.]
+topologies:
+  main:
+    type: unstructured
+    coordset: coords
+    elements:
+      shape: hex
+      connectivity: [0,1,4,3,9,10,13,12, 1,2,5,4,10,11,14,13, 3,4,7,6,12,13,16,15, 4,5,8,7,13,14,17,16]
+      sizes: [4,4,4,4]
+      offsets: [0,6,12,18]
+)";
+    root.parse(yaml);
+
+    topoutils::MeshInfo info;
+    topoutils::compute_mesh_info(root.fetch_existing("topologies/main"), info);
+
+    const double eps = 1.e-12;
+    EXPECT_NEAR(info.minExtents[0], 0., eps);
+    EXPECT_NEAR(info.minExtents[1], 1., eps);
+    EXPECT_NEAR(info.minExtents[2], 2., eps);
+    EXPECT_NEAR(info.maxExtents[0], 0.3, eps);
+    EXPECT_NEAR(info.maxExtents[1], 4., eps);
+    EXPECT_NEAR(info.maxExtents[2], 6., eps);
+    EXPECT_NEAR(info.minEdgeLength, 0.1, eps);
+    EXPECT_NEAR(info.maxEdgeLength, 4., eps);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_utils, mesh_info_ph)
+{
+    namespace topoutils = conduit::blueprint::mesh::utils::topology;
+    conduit::Node root;
+    const char *yaml = R"(
+coordsets:
+  coords:
+    type: explicit
+    values:
+      x: [0.,0.1, 0.3, 0.,0.1, 0.3, 0.,0.1, 0.3,  0.,0.1, 0.3, 0.,0.1, 0.3, 0.,0.1, 0.3]
+      y: [1., 1., 1.,  2., 2., 2., 4., 4., 4.,  1., 1., 1.,  2., 2., 2., 4., 4., 4.]
+      z: [2., 2., 2.,  2., 2., 2., 2., 2., 2.,  6., 6., 6.,  6., 6., 6., 6., 6., 6.]
+topologies:
+  main:
+    type: unstructured
+    coordset: coords
+    elements:
+      shape: polyhedral
+      connectivity: [0,1,2,3,4,5, 1,6,7,8,9,10, 11,12,3,13,14,15, 12,16,8,17,18,19]
+      sizes: [6,6,6,6]
+      offsets: [0,6,12,18]
+    subelements:
+      shape: polygonal
+      #              0         1          2         3          4        5           6          7          8          9        10           11         12         13         14       15           16         17         18       19
+      connectivity: [0,9,12,3, 1,4,13,10, 0,1,10,9, 3,12,13,4, 0,3,4,1, 9,10,13,12, 2,5,14,11, 1,2,11,10, 5,4,13,14, 1,4,5,2, 10,11,14,13, 3,12,15,6, 4,7,16,13, 6,15,16,7, 3,6,7,4, 12,13,16,15, 5,8,17,14, 7,16,17,8, 4,7,8,5, 13,14,17,16]
+      sizes: [4,4,4,4,4, 4,4,4,4,4, 4,4,4,4,4, 4,4,4,4,4]
+      offsets: [0,4,8,12,16, 20,24,28,32,36, 40,44,48,52,56, 60,64,68,72,76]
+)";
+    root.parse(yaml);
+
+    topoutils::MeshInfo info;
+    topoutils::compute_mesh_info(root.fetch_existing("topologies/main"), info);
+
+    const double eps = 1.e-12;
+    EXPECT_NEAR(info.minExtents[0], 0., eps);
+    EXPECT_NEAR(info.minExtents[1], 1., eps);
+    EXPECT_NEAR(info.minExtents[2], 2., eps);
+    EXPECT_NEAR(info.maxExtents[0], 0.3, eps);
+    EXPECT_NEAR(info.maxExtents[1], 4., eps);
+    EXPECT_NEAR(info.maxExtents[2], 6., eps);
+    EXPECT_NEAR(info.minEdgeLength, 0.1, eps);
+    EXPECT_NEAR(info.maxEdgeLength, 4., eps);
+}

--- a/src/tests/blueprint/t_blueprint_mpi_mesh_tiled.cpp
+++ b/src/tests/blueprint/t_blueprint_mpi_mesh_tiled.cpp
@@ -26,7 +26,10 @@
 #include <algorithm>
 #include <vector>
 #include <string>
+#include <sstream>
+
 #include <mpi.h>
+
 #include "gtest/gtest.h"
 
 using namespace conduit;
@@ -35,6 +38,9 @@ using namespace generate;
 
 // Uncomment if we want to write the data files.
 //#define CONDUIT_WRITE_TEST_DATA
+
+// Uncomment for more verbose test output during debugging.
+//#define CONDUIT_DEBUG_TEST
 
 //---------------------------------------------------------------------------
 #ifdef CONDUIT_WRITE_TEST_DATA
@@ -87,6 +93,9 @@ make_tiled(conduit::Node &mesh, const int dims[3], const int domains[3],
         offset += domains_per_rank[i];
 
     // Make domains.
+#ifdef CONDUIT_DEBUG_TEST
+    std::stringstream ss;
+#endif
     const double extents[] = {0., 1., 0., 1., 0., 1.};
     int domainIndex = 0;
     for(int k = 0; k < domains[2]; k++)
@@ -118,17 +127,17 @@ make_tiled(conduit::Node &mesh, const int dims[3], const int domains[3],
             opts["domains"].set(domains, 3);
             opts["reorder"] = reorder;
 
+#ifdef CONDUIT_DEBUG_TEST
+            ss << "Rank " << par_rank << " makes domain " << domainId
+               << ", ijk={" << domain[0] << ", " << domain[1] << ", " << domain[2] << "}"
+               << ", extents={" << domainExt[0] << ", " << domainExt[1]
+               << ", " << domainExt[2] << ", " << domainExt[3]
+               << ", " << domainExt[4] << ", " << domainExt[5] << "}"
+               << ", reorder=\"" << reorder << "\"\n";
+#endif
             if(ndoms > 1)
             {
-                std::string domainName;
-                if(!domainNumbering.empty())
-                {
-                    domainName = conduit_fmt::format("domain_{:07}",domainNumbering[domainIndex]);
-                }
-                else
-                {
-                    domainName = conduit_fmt::format("domain_{:07}",domainIndex);
-                }
+                std::string domainName = conduit_fmt::format("domain_{:07}",domainId);
                 conduit::Node &dom = mesh[domainName];
                 conduit::blueprint::mesh::examples::tiled(dims[0], dims[1], dims[2], dom, opts);
             }
@@ -138,6 +147,19 @@ make_tiled(conduit::Node &mesh, const int dims[3], const int domains[3],
             }
         }
     }
+
+#ifdef CONDUIT_DEBUG_TEST
+    // Print some build messages.
+    for(int rank = 0; rank < par_size; rank++)
+    {
+        MPI_Barrier(MPI_COMM_WORLD);
+        if(rank == par_rank)
+        {
+           std::cout << ss.str();
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+#endif
 }
 
 //-----------------------------------------------------------------------------
@@ -224,7 +246,7 @@ test_tiled_adjsets(const int dims[3], const std::string &testName)
             in_rank_order(MPI_COMM_WORLD, [&](int rank) {
                 if(!same)
                 {
-                    if(info.number_of_children() > 0)
+                    if(info.number_of_children() > 0 && info["valid"].as_string() == "false")
                     {
                         std::cout << "Rank " << rank << ": mesh_adjset was different."
                                   << " domainNumbering=" << domainNumbering
@@ -241,7 +263,7 @@ test_tiled_adjsets(const int dims[3], const std::string &testName)
             in_rank_order(MPI_COMM_WORLD, [&](int rank) {
                 if(!same)
                 {
-                    if(info.number_of_children() > 0)
+                    if(info.number_of_children() > 0 && info["valid"].as_string() == "false")
                     {
                         std::cout << "Rank " << rank << ": corner_pairwise_adjset was different."
                                   << " domainNumbering=" << domainNumbering


### PR DESCRIPTION
I've been running into a problem with adjset generation where points on either side of a domain will have scrambled point index orderings in the adjsets. If one uses the adjsets to index into the coordsets, it is possible to get points that do not match on either side of a domain interface. I figured out this happens because of the distance and tolerance comparison in [ffloat::operator<](https://github.com/LLNL/conduit/blob/b8f4ad0858980e430661b2d381645bd1de5c0e4b/src/libs/blueprint/conduit_blueprint_mesh.cpp#L77). Apparently, we get points that are closer than CONDUIT_EPSILON (1.e-12) and the less than comparison fails. This affects ``PointTuple::operator<`` and ultimately the index at which new entities are inserted into the entity vector used to build the adjset. 

If the epsilon is decreased then the adjset is fixed for the dataset that causes the problem. This does not seem like a robust enough fix so I'm still thinking about solutions. We should discuss.

Other changes:
 * Add some ``using`` statements for type readability
 * Use accessors to populate the adjset data
