### PR TITLE
Bugfix/capps2/operatorquote

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -2629,7 +2629,7 @@ braid_hexs(index_t npts_x,
 
 //---------------------------------------------------------------------------//
 void
-braid_bent_hexs(const Node& spec, Node& res)
+braid_bent_hexs(const Node &spec, Node &res)
 {
     res.reset();
 
@@ -2650,10 +2650,10 @@ braid_bent_hexs(const Node& spec, Node& res)
     braid_init_example_state(res);
     res["state/domain_id"] = domain_id;
     braid_init_explicit_lerp_coordset(npts_x,
-        npts_y,
-        npts_z,
-        res["coordsets/coords"],
-        x, y, z);
+                                      npts_y,
+                                      npts_z,
+                                      res["coordsets/coords"],
+                                      x, y, z);
 
     res["topologies/mesh/type"] = "structured";
     res["topologies/mesh/coordset"] = "coords";
@@ -2661,27 +2661,27 @@ braid_bent_hexs(const Node& spec, Node& res)
     res["topologies/mesh/elements/dims/j"] = (int32)nele_y;
     res["topologies/mesh/elements/dims/k"] = (int32)nele_z;
 
-    Node& fields = res["fields"];
+    Node &fields = res["fields"];
 
     braid_init_example_point_scalar_field(npts_x,
-        npts_y,
-        npts_z,
-        fields["braid"]);
+                                          npts_y,
+                                          npts_z,
+                                          fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_x,
-        nele_y,
-        nele_z,
-        fields["radial"]);
+                                            nele_y,
+                                            nele_z,
+                                            fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
-        npts_y,
-        npts_z,
-        fields["vel"]);
+                                          npts_y,
+                                          npts_z,
+                                          fields["vel"]);
 }
 
 //---------------------------------------------------------------------------//
 void
-nest_quads(const Node& spec, Node& parent, Node& res)
+nest_quads(const Node &spec, Node& parent, Node &res)
 {
     // spec must contain details about nesting, like this:
     //   nest_child_id: 13
@@ -2756,7 +2756,7 @@ nest_quads(const Node& spec, Node& parent, Node& res)
 
 //---------------------------------------------------------------------------//
 void
-nest_hexs(const Node& spec, Node& parent, Node& res)
+nest_hexs(const Node &spec, Node &parent, Node &res)
 {
     // spec must contain details about nesting, like this:
     //   nest_child_id: 13
@@ -2787,10 +2787,10 @@ nest_hexs(const Node& spec, Node& parent, Node& res)
         [nest_ratio](Node* n, std::string windowname,
             int domain_id, std::string domain_type,
             int dims_i, int dims_j, int dims_k) {
-                Node& nset = (*n)["nestsets/nestset"];
+                Node &nset = (*n)["nestsets/nestset"];
                 nset["association"] = "element";
                 nset["topology"] = "mesh"; // match what braid_bent_hexs does
-                Node& window = nset["windows"][windowname];
+                Node &window = nset["windows"][windowname];
                 window["domain_id"] = domain_id;
                 window["domain_type"] = domain_type;
                 window["origin/i"] = 0;
@@ -3836,7 +3836,7 @@ strided_structured(Node &desc, // shape of requested data arrays
 
 
 //---------------------------------------------------------------------------//
-void bent_multi_grid_defaults(conduit::Node& spec)
+void bent_multi_grid_defaults(conduit::Node &spec)
 {
     // Provide defaults for bent_multi_grid so a user can call that function
     // without having to remember what goes in spec
@@ -3845,7 +3845,7 @@ void bent_multi_grid_defaults(conduit::Node& spec)
         std::initializer_list<double> corner_xs,
         std::initializer_list<double> corner_ys)
         {
-            conduit::Node& dom = spec[label];
+            conduit::Node &dom = spec[label];
             dom["npts_x"] = npts_x;
             dom["npts_y"] = npts_y;
             dom["domain_id"] = domain_id;
@@ -3863,8 +3863,8 @@ void bent_multi_grid_defaults(conduit::Node& spec)
     fill_domain(2, 2, 5, "domain5", { 4, 5, 5, 4 }, { 2, 3, 3, 2 });
 }
 
-void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
-    conduit::Node& res)
+void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node &spec,
+                                           conduit::Node &res)
 {
     int last_dim = 0;
 
@@ -3990,8 +3990,8 @@ void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
     }
 }
 
-void CONDUIT_BLUEPRINT_API amr_bent_multi_grid(const conduit::Node& spec,
-                                                   conduit::Node& res)
+void CONDUIT_BLUEPRINT_API amr_bent_multi_grid(const conduit::Node &spec,
+                                               conduit::Node &res)
 {
     if (spec.dtype().is_empty())
     {

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -2681,7 +2681,7 @@ braid_bent_hexs(const Node &spec, Node &res)
 
 //---------------------------------------------------------------------------//
 void
-nest_quads(const Node &spec, Node& parent, Node &res)
+nest_quads(const Node &spec, Node &parent, Node &res)
 {
     // spec must contain details about nesting, like this:
     //   nest_child_id: 13

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -2716,7 +2716,7 @@ nest_quads(const Node& spec, Node& parent, Node& res)
         [nest_ratio](Node* n, std::string windowname,
             int domain_id, std::string domain_type,
             int dims_i, int dims_j) {
-                Node& nset = (*n)["nestsets/nestset/nest"];
+                Node& nset = (*n)["nestsets/nestset"];
                 nset["association"] = "element";
                 nset["topology"] = "mesh"; // match what braid_bent_hexs does
                 Node& window = nset["windows"][windowname];
@@ -3845,7 +3845,7 @@ void bent_multi_grid_defaults(conduit::Node& spec)
         std::initializer_list<double> corner_xs,
         std::initializer_list<double> corner_ys)
         {
-            conduit::Node dom = spec[label];
+            conduit::Node& dom = spec[label];
             dom["npts_x"] = npts_x;
             dom["npts_y"] = npts_y;
             dom["domain_id"] = domain_id;
@@ -3973,7 +3973,10 @@ void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
             if (dom_node.has_child("nest_child_id"))
             {
                 int child_id = dom_node["nest_child_id"].as_int();
-                std::string nest_name = "domain_" + child_id;
+                std::ostringstream oss;
+                // Match the naming style used by bent_braid(), which is domain0, domain1, etc.
+                oss << "domain" << child_id;
+                const std::string nest_name = oss.str();
                 if (last_dim == 2)
                 {
                     nest_quads(dom_node, res[doms_it.name()], res[nest_name]);

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -2629,7 +2629,7 @@ braid_hexs(index_t npts_x,
 
 //---------------------------------------------------------------------------//
 void
-braid_bent_hexs(const Node & spec, Node &res)
+braid_bent_hexs(const Node& spec, Node& res)
 {
     res.reset();
 
@@ -2650,10 +2650,10 @@ braid_bent_hexs(const Node & spec, Node &res)
     braid_init_example_state(res);
     res["state/domain_id"] = domain_id;
     braid_init_explicit_lerp_coordset(npts_x,
-                                      npts_y,
-                                      npts_z,
-                                      res["coordsets/coords"],
-                                      x, y, z);
+        npts_y,
+        npts_z,
+        res["coordsets/coords"],
+        x, y, z);
 
     res["topologies/mesh/type"] = "structured";
     res["topologies/mesh/coordset"] = "coords";
@@ -2661,22 +2661,171 @@ braid_bent_hexs(const Node & spec, Node &res)
     res["topologies/mesh/elements/dims/j"] = (int32)nele_y;
     res["topologies/mesh/elements/dims/k"] = (int32)nele_z;
 
-    Node &fields = res["fields"];
+    Node& fields = res["fields"];
 
     braid_init_example_point_scalar_field(npts_x,
-                                          npts_y,
-                                          npts_z,
-                                          fields["braid"]);
+        npts_y,
+        npts_z,
+        fields["braid"]);
 
     braid_init_example_element_scalar_field(nele_x,
-                                            nele_y,
-                                            nele_z,
-                                            fields["radial"]);
+        nele_y,
+        nele_z,
+        fields["radial"]);
 
     braid_init_example_point_vector_field(npts_x,
-                                          npts_y,
-                                          npts_z,
-                                          fields["vel"]);
+        npts_y,
+        npts_z,
+        fields["vel"]);
+}
+
+//---------------------------------------------------------------------------//
+void
+nest_quads(const Node& spec, Node& parent, Node& res)
+{
+    // spec must contain details about nesting, like this:
+    //   nest_child_id: 13
+    //   nest_ratio: 3
+    // res gets filled with a new domain refined from parent, including a nestset
+    // parent node gets a nestset tying it to res
+
+    // Basically, call braid_bent_quads, then do the nestset.
+    // spec must contain details about nesting, like this:
+    //   nest_child_id: 13
+    //   nest_ratio: 3
+    // res gets filled with a new domain refined from parent, including a nestset
+    // parent node gets a nestset tying it to res
+
+    // Basically, call braid_bent_hexs, then do the nestset.
+    const int32 nest_parent_id = parent["state/domain_id"].as_int32();
+    const int32 nest_child_id = spec["nest_child_id"].as_int32();
+    const int32 nest_ratio = spec["nest_ratio"].as_int32();
+    const int32 parent_npts_x = spec["npts_x"].as_int32();
+    const int32 parent_npts_y = spec["npts_y"].as_int32();
+    const int32 child_npts_x = nest_ratio * (parent_npts_x - 1) + 1;
+    const int32 child_npts_y = nest_ratio * (parent_npts_y - 1) + 1;
+
+    Node child_spec = spec; // we can now change child_spec without changing spec
+    child_spec["domain_id"] = nest_child_id;
+    child_spec["npts_x"] = child_npts_x;
+    child_spec["npts_y"] = child_npts_y;
+
+    braid_bent_quads(child_spec, res);
+
+    const auto setup_nestset =
+        [nest_ratio](Node* n, std::string windowname,
+            int domain_id, std::string domain_type,
+            int dims_i, int dims_j) {
+                Node& nset = (*n)["nestsets/nestset/nest"];
+                nset["association"] = "element";
+                nset["topology"] = "mesh"; // match what braid_bent_hexs does
+                Node& window = nset["windows"][windowname];
+                window["domain_id"] = domain_id;
+                window["domain_type"] = domain_type;
+                window["origin/i"] = 0;
+                window["origin/j"] = 0;
+                window["dims/i"] = dims_i;
+                window["dims/j"] = dims_j;
+                window["ratio/i"] = nest_ratio;
+                window["ratio/j"] = nest_ratio;
+        };
+
+    // Set up child nestset
+    std::ostringstream oss;
+    oss << "window_" << nest_child_id << "_" << nest_parent_id;
+    const std::string child_wname = oss.str();
+    setup_nestset(&res, child_wname, nest_parent_id, "parent",
+                  child_npts_x - 1, child_npts_y - 1);
+
+    // Set up parent nestset
+    std::ostringstream pss;
+    pss << "window_" << nest_parent_id << "_" << nest_child_id;
+    const std::string parent_wname = pss.str();
+    setup_nestset(&parent, parent_wname, nest_child_id, "child",
+                  parent_npts_x - 1, parent_npts_y - 1);
+
+    // Ensure nest level exists for parent, set for child.
+    if (!parent.has_path("state/level_id"))
+    {
+        int32 level_id = 0;
+        parent["state/level_id"] = level_id;
+    }
+    const int32 parent_level_id = parent["state/level_id"].as_int32();
+    res["state/level_id"] = parent_level_id + 1;
+}
+
+//---------------------------------------------------------------------------//
+void
+nest_hexs(const Node& spec, Node& parent, Node& res)
+{
+    // spec must contain details about nesting, like this:
+    //   nest_child_id: 13
+    //   nest_ratio: 3
+    // res gets filled with a new domain refined from parent, including a nestset
+    // parent node gets a nestset tying it to res
+
+    // Basically, call braid_bent_hexs, then do the nestset.
+    const int32 nest_parent_id = parent["state/domain_id"].as_int32();
+    const int32 nest_child_id = spec["nest_child_id"].as_int32();
+    const int32 nest_ratio = spec["nest_ratio"].as_int32();
+    const int32 parent_npts_x = spec["npts_x"].as_int32();
+    const int32 parent_npts_y = spec["npts_y"].as_int32();
+    const int32 parent_npts_z = spec["npts_z"].as_int32();
+    const int32 child_npts_x = nest_ratio * (parent_npts_x - 1) + 1;
+    const int32 child_npts_y = nest_ratio * (parent_npts_y - 1) + 1;
+    const int32 child_npts_z = nest_ratio * (parent_npts_z - 1) + 1;
+
+    Node child_spec = spec; // we can now change child_spec without changing spec
+    child_spec["domain_id"] = nest_child_id;
+    child_spec["npts_x"] = child_npts_x;
+    child_spec["npts_y"] = child_npts_y;
+    child_spec["npts_z"] = child_npts_z;
+
+    braid_bent_hexs(child_spec, res);
+
+    const auto setup_nestset =
+        [nest_ratio](Node* n, std::string windowname,
+            int domain_id, std::string domain_type,
+            int dims_i, int dims_j, int dims_k) {
+                Node& nset = (*n)["nestsets/nestset/nest"];
+                nset["association"] = "element";
+                nset["topology"] = "mesh"; // match what braid_bent_hexs does
+                Node& window = nset["windows"][windowname];
+                window["domain_id"] = domain_id;
+                window["domain_type"] = domain_type;
+                window["origin/i"] = 0;
+                window["origin/j"] = 0;
+                window["origin/k"] = 0;
+                window["dims/i"] = dims_i;
+                window["dims/j"] = dims_j;
+                window["dims/k"] = dims_k;
+                window["ratio/i"] = nest_ratio;
+                window["ratio/j"] = nest_ratio;
+                window["ratio/k"] = nest_ratio;
+        };
+
+    // Set up child nestset
+    std::ostringstream oss;
+    oss << "window_" << nest_child_id << "_" << nest_parent_id;
+    const std::string child_wname = oss.str();
+    setup_nestset(&res, child_wname, nest_parent_id, "parent",
+                  child_npts_x - 1, child_npts_y - 1, child_npts_z - 1);
+
+    // Set up parent nestset
+    std::ostringstream pss;
+    pss << "window_" << nest_parent_id << "_" << nest_child_id;
+    const std::string parent_wname = pss.str();
+    setup_nestset(&parent, parent_wname, nest_child_id, "child",
+                  parent_npts_x - 1, parent_npts_y - 1, parent_npts_z - 1);
+
+    // Ensure nest level exists for parent, set for child.
+    if (!parent.has_path("state/level_id"))
+    {
+        int32 level_id = 0;
+        parent["state/level_id"] = level_id;
+    }
+    const int32 parent_level_id = parent["state/level_id"].as_int32();
+    res["state/level_id"] = parent_level_id + 1;
 }
 
 //---------------------------------------------------------------------------//
@@ -3717,6 +3866,8 @@ void bent_multi_grid_defaults(conduit::Node& spec)
 void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
     conduit::Node& res)
 {
+    int last_dim = 0;
+
     if (spec.dtype().is_empty())
     {
         conduit::Node default_spec;
@@ -3742,12 +3893,18 @@ void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
             bool has_npts_z = ver_node.has_child("npts_z");
             bool has_domain_id = ver_node.has_child("domain_id");
 
+            // Check for nest set information.
+            bool has_nest_child_id = ver_node.has_child("nest_child_id");
+            bool has_nest_ratio = ver_node.has_child("nest_ratio");
+            // Need both nest_child_id and nest_ratio, or neither.
+            bool nest_ok = (has_nest_child_id == has_nest_ratio);
+
+            bool dims_ok = false;
             int dims = 0;
             if (has_corner_xs && has_corner_ys && has_npts_x && has_npts_y) { dims = 2; }
             if (dims == 2 && has_corner_zs && has_npts_z) { dims = 3; }
 
-            bool children_ok = (dims == 2 || dims == 3) && has_domain_id;
-            bool dims_ok = false;
+            bool children_ok = (dims == 2 || dims == 3) && has_domain_id && nest_ok;
 
             if (children_ok)
             {
@@ -3765,20 +3922,32 @@ void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
                     int npts_z = ver_node["npts_z"].as_int32();
                     dims_ok = dims_ok && npts_z >= 2;
                 }
+
+                // If the nesting specification child nodes are present,
+                // make sure they're integral.
+                if (has_nest_child_id && has_nest_ratio)
+                {
+                    nest_ok = ver_node["nest_child_id"].dtype().is_int() &&
+                        ver_node["nest_ratio"].dtype().is_int();
+                }
             }
 
-            if (!(children_ok && dims_ok))
+            if (!(children_ok && dims_ok && nest_ok))
             {
                 // error: some domain doesn't have the right children.
                 CONDUIT_ERROR("blueprint::mesh::examples::bent_multi_grid requires each domain in spec " << std::endl <<
                     "to have floating-point children corner_xs, corner_ys each with length > 3." << std::endl <<
                     "For a 3D mesh, each domain must have corner_xs, corner_ys, corner_zs each" << std::endl <<
                     "with length > 7.  Each domain must also have an integral domain_id and integral" << std::endl <<
-                    "npts_x, npts_y, and optionally npts_z.  Values provided : " << std::endl <<
+                    "npts_x, npts_y, and optionally npts_z." << std::endl <<
+                    "To specify a nesting domain, the parent domain must have integral children" << std::endl <<
+                    "nest_child_id and nest_ratio." << std::endl << "Values provided : " << std::endl <<
                     ver_node.to_yaml() << std::endl);
             }
 
+            last_dim = dims;
             dom_dimensions.push_back(dims);
+            // TODO: report error if all dimensions are not equal
         }
 
         // For each child node in spec,
@@ -3793,10 +3962,47 @@ void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
             bent_braid(dom_node, res[doms_it.name()]);
         }
 
+        // Tie adjacent domains together with adjsets.
         braid_init_example_adjset(res);
+
+        // Now refine selected domains.
+        doms_it.to_front();
+        while (doms_it.has_next())
+        {
+            const Node& dom_node = doms_it.next();
+            if (dom_node.has_child("nest_child_id"))
+            {
+                int child_id = dom_node["nest_child_id"].as_int();
+                std::string nest_name = "domain_" + child_id;
+                if (last_dim == 2)
+                {
+                    nest_quads(dom_node, res[doms_it.name()], res[nest_name]);
+                }
+                else
+                {
+                    nest_hexs(dom_node, res[doms_it.name()], res[nest_name]);
+                }
+            }
+        }
     }
 }
 
+void CONDUIT_BLUEPRINT_API amr_bent_multi_grid(const conduit::Node& spec,
+                                                   conduit::Node& res)
+{
+    if (spec.dtype().is_empty())
+    {
+        conduit::Node default_spec;
+        bent_multi_grid_defaults(default_spec);
+        default_spec["domain0/nest_child_id"] = 6;
+        default_spec["domain0/nest_ratio"] = 3;
+        bent_multi_grid(default_spec, res);
+    }
+    else
+    {
+        bent_multi_grid(spec, res);
+    }
+}
 
 //---------------------------------------------------------------------------//
 void

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.cpp
@@ -2787,7 +2787,7 @@ nest_hexs(const Node& spec, Node& parent, Node& res)
         [nest_ratio](Node* n, std::string windowname,
             int domain_id, std::string domain_type,
             int dims_i, int dims_j, int dims_k) {
-                Node& nset = (*n)["nestsets/nestset/nest"];
+                Node& nset = (*n)["nestsets/nestset"];
                 nset["association"] = "element";
                 nset["topology"] = "mesh"; // match what braid_bent_hexs does
                 Node& window = nset["windows"][windowname];

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples.hpp
@@ -276,11 +276,22 @@ namespace examples
     ///  - integral children npts_x, npts_y, optionally npts_z
     ///  - integral child domain_id
     ///  - numerical array children corner_xs, corner_ys, optionally corner_zs
+    ///  - optionally, integral children nest_child_id and nest_ratio
     ///
     /// Taken together, the corner_xs, corner_ys, and optionally corner_zs
     /// represent the points at the corners of that domain.
+    ///
+    /// If nest_child_id and nest_ratio are present in a domain spec,
+    /// bent_multi_grid makes a refined domain nested within the domain.
     void CONDUIT_BLUEPRINT_API bent_multi_grid(const conduit::Node& spec,
-                                        conduit::Node& res);
+                                               conduit::Node& res);
+
+    /// Generates a multidomain grid of examples.  If spec is an empty node,
+    /// makes a default spec that includes enhanced and reduced connectivity
+    /// as well as a nested domain, then calls bent_multi_grid.  If spec
+    /// is not empty, directly calls bent_multi_grid.
+    void CONDUIT_BLUEPRINT_API amr_bent_multi_grid(const conduit::Node& spec,
+                                                   conduit::Node& res);
 
     /// Generates a braid-like example mesh that covers elements defined in a
     /// rectilinear grid.  Currently hexs are supported for 3D meshes and quads

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_generate.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_generate.cpp
@@ -596,6 +596,14 @@ generate_default_options(const std::string &example_name,
         opts["ny"]          = 100;
         opts["radius"]      = 0.25;
     }
+    else if (example_name == "bent_multi_grid")
+    {
+        // bent_multi_grid provides its own default args
+    }
+    else if (example_name == "amr_bent_multi_grid")
+    {
+        // amr_bent_multi_grid provides its own default args
+    }
     else
     {
         // ERROR UNSUPPORTED!

--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_generate.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_generate.cpp
@@ -453,6 +453,12 @@ generate(const std::string &example_name,
         // sensible defaults if passed an empty Node for the first argument.
         bent_multi_grid(opts, res);
     }
+    else if (example_name == "amr_bent_multi_grid")
+    {
+        // amr_bent_multi_grid has its own defaults generator, which gives
+        // sensible defaults if passed an empty Node for the first argument.
+        amr_bent_multi_grid(opts, res);
+    }
     else
     {
         // ERROR UNSUPPORTED!

--- a/src/tests/blueprint/t_blueprint_mesh_examples_generate.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_examples_generate.cpp
@@ -76,7 +76,9 @@ TEST(conduit_blueprint_mesh_examples_generate, gen_driver_all_examples)
                                               "related_boundary",
                                               "rz_cylinder",
                                               "tiled",
-                                              "venn"};
+                                              "venn",
+                                              "bent_multi_grid",
+                                              "amr_bent_multi_grid" };
 
     for(const std::string &example_name : example_names)
     {

--- a/src/thirdparty_builtin/fmt-7.1.0/conduit_fmt/format.h
+++ b/src/thirdparty_builtin/fmt-7.1.0/conduit_fmt/format.h
@@ -3940,11 +3940,11 @@ FMT_CONSTEXPR detail::udl_formatter<Char, CHARS...> operator""_format() {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_formatter<char> operator"" _format(const char* s,
+FMT_CONSTEXPR detail::udl_formatter<char> operator""_format(const char* s,
                                                              size_t n) {
   return {{s, n}};
 }
-FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
+FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator""_format(
     const wchar_t* s, size_t n) {
   return {{s, n}};
 }
@@ -3960,10 +3960,10 @@ FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
     FMT_NAMESPACE::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_arg<char> operator"" _a(const char* s, size_t) {
+FMT_CONSTEXPR detail::udl_arg<char> operator""_a(const char* s, size_t) {
   return {s};
 }
-FMT_CONSTEXPR detail::udl_arg<wchar_t> operator"" _a(const wchar_t* s, size_t) {
+FMT_CONSTEXPR detail::udl_arg<wchar_t> operator""_a(const wchar_t* s, size_t) {
   return {s};
 }
 }  // namespace literals

--- a/src/thirdparty_builtin/fmt-7.1.0/conduit_readme.txt
+++ b/src/thirdparty_builtin/fmt-7.1.0/conduit_readme.txt
@@ -9,4 +9,6 @@ Added header (fmt/conduit_fmt.h) to simplify header only use
 
 Changed the default namespace from fmt to conduit_fmt to avoid potential symbol collisions
 
+Fixed deprecated syntax by removing a space after operator"", thereby avoiding compile warnings
+
 License: MIT


### PR DESCRIPTION
Remove space after operator""

With recent versions of clang, a space between operator"" and a user-defined suffix triggers a pesky warning.  This PR removes that warning.