### PR TITLE
Bugfix/capps2/operator-quote

### DIFF
--- a/src/thirdparty_builtin/fmt-7.1.0/conduit_fmt/format.h
+++ b/src/thirdparty_builtin/fmt-7.1.0/conduit_fmt/format.h
@@ -3940,11 +3940,11 @@ FMT_CONSTEXPR detail::udl_formatter<Char, CHARS...> operator""_format() {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_formatter<char> operator"" _format(const char* s,
+FMT_CONSTEXPR detail::udl_formatter<char> operator""_format(const char* s,
                                                              size_t n) {
   return {{s, n}};
 }
-FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
+FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator""_format(
     const wchar_t* s, size_t n) {
   return {{s, n}};
 }
@@ -3960,10 +3960,10 @@ FMT_CONSTEXPR detail::udl_formatter<wchar_t> operator"" _format(
     FMT_NAMESPACE::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-FMT_CONSTEXPR detail::udl_arg<char> operator"" _a(const char* s, size_t) {
+FMT_CONSTEXPR detail::udl_arg<char> operator""_a(const char* s, size_t) {
   return {s};
 }
-FMT_CONSTEXPR detail::udl_arg<wchar_t> operator"" _a(const wchar_t* s, size_t) {
+FMT_CONSTEXPR detail::udl_arg<wchar_t> operator""_a(const wchar_t* s, size_t) {
   return {s};
 }
 }  // namespace literals

--- a/src/thirdparty_builtin/fmt-7.1.0/conduit_readme.txt
+++ b/src/thirdparty_builtin/fmt-7.1.0/conduit_readme.txt
@@ -9,4 +9,6 @@ Added header (fmt/conduit_fmt.h) to simplify header only use
 
 Changed the default namespace from fmt to conduit_fmt to avoid potential symbol collisions
 
+Fixed deprecated syntax by removing a space after operator"", thereby avoiding compile warnings
+
 License: MIT


### PR DESCRIPTION
Remove space after operator""

With recent versions of clang, a space between operator"" and a user-defined suffix triggers a pesky warning. This PR removes that warning.
