### PR TITLE
config/cmake: find MPI if the MPI component is requested

### DIFF
--- a/src/config/ConduitConfig.cmake.in
+++ b/src/config/ConduitConfig.cmake.in
@@ -16,83 +16,78 @@ cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 @PACKAGE_INIT@
 
-if(NOT CONDUIT_FOUND)
-
-    # Compute the installation prefix relative to this file.
-    get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
-    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-    if(_IMPORT_PREFIX STREQUAL "/")
-      set(_IMPORT_PREFIX "")
-    endif()
-
-    set(CONDUIT_VERSION "@PROJECT_VERSION@")
-    # keep CONDUIT_USE_CXX11 to support old install logic
-    set(CONDUIT_USE_CXX11   "@CONDUIT_USE_CXX11@")
-    set(CONDUIT_USE_CXX14   "@CONDUIT_USE_CXX14@")
-    set(CONDUIT_USE_FMT     "@CONDUIT_USE_FMT@")
-    set(CONDUIT_USE_CALIPER "@CONDUIT_USE_CALIPER@")
-    set(CONDUIT_USE_MPI     "@ENABLE_MPI@")
-    set(CONDUIT_USE_OPENMP  "@ENABLE_OPENMP@")
-    set(CONDUIT_INSTALL_PREFIX "@CONDUIT_INSTALL_PREFIX@")
-    set(CONDUIT_ZLIB_DIR  "@ZLIB_DIR@")
-    set(CONDUIT_HDF5_DIR  "@HDF5_DIR@")
-    set(CONDUIT_ADIOS_DIR "@ADIOS_DIR@")
-    set(CONDUIT_SILO_DIR "@SILO_DIR@")
-    set(CONDUIT_METIS_DIR "@METIS_DIR@")
-    set(CONDUIT_PARMETIS_DIR "@PARMETIS_DIR@")
-    set(CONDUIT_ADIAK_DIR "@ADIAK_DIR@")
-    set(CONDUIT_CALIPER_DIR "@CALIPER_DIR@")
-    set(CONDUIT_PYTHON_ENABLED "@PYTHON_FOUND@")
-    set(CONDUIT_PYTHON_EXECUTABLE "@PYTHON_EXECUTABLE@")
-    set(CONDUIT_PYTHON_MODULE_DIR "@CONDUIT_INSTALL_PYTHON_MODULE_DIR@")
-    set(CONDUIT_PYTHON_MODULE_CUSTOM_PREFIX "@CONDUIT_INSTALL_PYTHON_MODULE_CUSTOM_PREFIX@")
-    set(CONDUIT_USE_CMAKE_MPI_TARGETS   "@CONDUIT_USE_CMAKE_MPI_TARGETS@")
-
-    get_filename_component(CONDUIT_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
-    # setup dependent pkgs
-    include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit_setup_deps.cmake)
-
-    # include targets exported by cmake
-    include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit.cmake)
-
-    # finally setup our final imported targets
-    include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit_setup_targets.cmake)
-
-    set(Conduit_FOUND TRUE)
-
-    set(_conduit_known_components
-      MPI)
-    foreach(_conduit_component IN LISTS Conduit_FIND_COMPONENTS)
-      if (NOT _conduit_component IN_LIST _conduit_known_components)
-        set("Conduit_${_conduit_component}_FOUND" 0)
-        set("Conduit_${_conduit_component}_NOT_FOUND_MESSAGE"
-          "Unknown component ${_conduit_component}")
-
-        if(Conduit_FIND_REQUIRED_${_conduit_component})
-          set(Conduit_FOUND 0)
-          list(APPEND Conduit_NOT_FOUND_MESSAGE
-            "Unknown component ${_conduit_component}")
-        endif()
-      else()
-        if(NOT DEFINED Conduit_${_conduit_component}_FOUND)
-          set("Conduit_${_conduit_component}_FOUND" 0)
-          set("Conduit_${_conduit_component}_NOT_FOUND_MESSAGE"
-            "Component ${_conduit_component} was not found (unimplemented?)")
-        endif()
-        if(NOT Conduit_${_conduit_component}_FOUND AND
-           Conduit_FIND_REQUIRED_${_conduit_component})
-          set(Conduit_FOUND 0)
-          list(APPEND Conduit_NOT_FOUND_MESSAGE
-            "Component ${_conduit_component} was not found: ${Conduit_${_conduit_component}_NOT_FOUND_MESSAGE}")
-        endif()
-      endif()
-    endforeach()
-    unset(_conduit_known_components)
-    unset(_conduit_component)
-
-    set(CONDUIT_FOUND "${Conduit_FOUND}")
-
+# Compute the installation prefix relative to this file.
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+if(_IMPORT_PREFIX STREQUAL "/")
+  set(_IMPORT_PREFIX "")
 endif()
 
+set(CONDUIT_VERSION "@PROJECT_VERSION@")
+# keep CONDUIT_USE_CXX11 to support old install logic
+set(CONDUIT_USE_CXX11   "@CONDUIT_USE_CXX11@")
+set(CONDUIT_USE_CXX14   "@CONDUIT_USE_CXX14@")
+set(CONDUIT_USE_FMT     "@CONDUIT_USE_FMT@")
+set(CONDUIT_USE_CALIPER "@CONDUIT_USE_CALIPER@")
+set(CONDUIT_USE_MPI     "@ENABLE_MPI@")
+set(CONDUIT_USE_OPENMP  "@ENABLE_OPENMP@")
+set(CONDUIT_INSTALL_PREFIX "@CONDUIT_INSTALL_PREFIX@")
+set(CONDUIT_ZLIB_DIR  "@ZLIB_DIR@")
+set(CONDUIT_HDF5_DIR  "@HDF5_DIR@")
+set(CONDUIT_ADIOS_DIR "@ADIOS_DIR@")
+set(CONDUIT_SILO_DIR "@SILO_DIR@")
+set(CONDUIT_METIS_DIR "@METIS_DIR@")
+set(CONDUIT_PARMETIS_DIR "@PARMETIS_DIR@")
+set(CONDUIT_ADIAK_DIR "@ADIAK_DIR@")
+set(CONDUIT_CALIPER_DIR "@CALIPER_DIR@")
+set(CONDUIT_PYTHON_ENABLED "@PYTHON_FOUND@")
+set(CONDUIT_PYTHON_EXECUTABLE "@PYTHON_EXECUTABLE@")
+set(CONDUIT_PYTHON_MODULE_DIR "@CONDUIT_INSTALL_PYTHON_MODULE_DIR@")
+set(CONDUIT_PYTHON_MODULE_CUSTOM_PREFIX "@CONDUIT_INSTALL_PYTHON_MODULE_CUSTOM_PREFIX@")
+set(CONDUIT_USE_CMAKE_MPI_TARGETS   "@CONDUIT_USE_CMAKE_MPI_TARGETS@")
+
+get_filename_component(CONDUIT_CMAKE_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# setup dependent pkgs
+include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit_setup_deps.cmake)
+
+# include targets exported by cmake
+include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit.cmake)
+
+# finally setup our final imported targets
+include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit_setup_targets.cmake)
+
+set(Conduit_FOUND TRUE)
+
+set(_conduit_known_components
+  MPI)
+foreach(_conduit_component IN LISTS Conduit_FIND_COMPONENTS)
+  if (NOT _conduit_component IN_LIST _conduit_known_components)
+    set("Conduit_${_conduit_component}_FOUND" 0)
+    set("Conduit_${_conduit_component}_NOT_FOUND_MESSAGE"
+      "Unknown component ${_conduit_component}")
+
+    if(Conduit_FIND_REQUIRED_${_conduit_component})
+      set(Conduit_FOUND 0)
+      list(APPEND Conduit_NOT_FOUND_MESSAGE
+        "Unknown component ${_conduit_component}")
+    endif()
+  else()
+    if(NOT DEFINED Conduit_${_conduit_component}_FOUND)
+      set("Conduit_${_conduit_component}_FOUND" 0)
+      set("Conduit_${_conduit_component}_NOT_FOUND_MESSAGE"
+        "Component ${_conduit_component} was not found (unimplemented?)")
+    endif()
+    if(NOT Conduit_${_conduit_component}_FOUND AND
+       Conduit_FIND_REQUIRED_${_conduit_component})
+      set(Conduit_FOUND 0)
+      list(APPEND Conduit_NOT_FOUND_MESSAGE
+        "Component ${_conduit_component} was not found: ${Conduit_${_conduit_component}_NOT_FOUND_MESSAGE}")
+    endif()
+  endif()
+endforeach()
+unset(_conduit_known_components)
+unset(_conduit_component)
+
+set(CONDUIT_FOUND "${Conduit_FOUND}")

--- a/src/config/ConduitConfig.cmake.in
+++ b/src/config/ConduitConfig.cmake.in
@@ -59,8 +59,38 @@ if(NOT CONDUIT_FOUND)
     # finally setup our final imported targets
     include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit_setup_targets.cmake)
 
-    set(CONDUIT_FOUND TRUE)
     set(Conduit_FOUND TRUE)
+
+    set(_conduit_known_components)
+    foreach(_conduit_component IN LISTS Conduit_FIND_COMPONENTS)
+      if (NOT _conduit_component IN_LIST _conduit_known_components)
+        set("Conduit_${_conduit_component}_FOUND" 0)
+        set("Conduit_${_conduit_component}_NOT_FOUND_MESSAGE"
+          "Unknown component ${_conduit_component}")
+
+        if(Conduit_FIND_REQUIRED_${_conduit_component})
+          set(Conduit_FOUND 0)
+          list(APPEND Conduit_NOT_FOUND_MESSAGE
+            "Unknown component ${_conduit_component}")
+        endif()
+      else()
+        if(NOT DEFINED Conduit_${_conduit_component}_FOUND)
+          set("Conduit_${_conduit_component}_FOUND" 0)
+          set("Conduit_${_conduit_component}_NOT_FOUND_MESSAGE"
+            "Component ${_conduit_component} was not found (unimplemented?)")
+        endif()
+        if(NOT Conduit_${_conduit_component}_FOUND AND
+           Conduit_FIND_REQUIRED_${_conduit_component})
+          set(Conduit_FOUND 0)
+          list(APPEND Conduit_NOT_FOUND_MESSAGE
+            "Component ${_conduit_component} was not found: ${Conduit_${_conduit_component}_NOT_FOUND_MESSAGE}")
+        endif()
+      endif()
+    endforeach()
+    unset(_conduit_known_components)
+    unset(_conduit_component)
+
+    set(CONDUIT_FOUND "${Conduit_FOUND}")
 
 endif()
 

--- a/src/config/ConduitConfig.cmake.in
+++ b/src/config/ConduitConfig.cmake.in
@@ -32,6 +32,7 @@ if(NOT CONDUIT_FOUND)
     set(CONDUIT_USE_CXX14   "@CONDUIT_USE_CXX14@")
     set(CONDUIT_USE_FMT     "@CONDUIT_USE_FMT@")
     set(CONDUIT_USE_CALIPER "@CONDUIT_USE_CALIPER@")
+    set(CONDUIT_USE_MPI     "@ENABLE_MPI@")
     set(CONDUIT_USE_OPENMP  "@ENABLE_OPENMP@")
     set(CONDUIT_INSTALL_PREFIX "@CONDUIT_INSTALL_PREFIX@")
     set(CONDUIT_ZLIB_DIR  "@ZLIB_DIR@")
@@ -61,7 +62,8 @@ if(NOT CONDUIT_FOUND)
 
     set(Conduit_FOUND TRUE)
 
-    set(_conduit_known_components)
+    set(_conduit_known_components
+      MPI)
     foreach(_conduit_component IN LISTS Conduit_FIND_COMPONENTS)
       if (NOT _conduit_component IN_LIST _conduit_known_components)
         set("Conduit_${_conduit_component}_FOUND" 0)

--- a/src/config/ConduitConfig.cmake.in
+++ b/src/config/ConduitConfig.cmake.in
@@ -60,6 +60,7 @@ if(NOT CONDUIT_FOUND)
     include(${CONDUIT_CMAKE_CONFIG_DIR}/conduit_setup_targets.cmake)
 
     set(CONDUIT_FOUND TRUE)
+    set(Conduit_FOUND TRUE)
 
 endif()
 

--- a/src/config/conduit_setup_deps.cmake
+++ b/src/config/conduit_setup_deps.cmake
@@ -47,6 +47,39 @@ if(CONDUIT_USE_OPENMP)
 endif()
 
 ###############################################################################
+# Setup MPI
+###############################################################################
+if("MPI" IN_LIST Conduit_FIND_COMPONENTS)
+    set(Conduit_MPI_NOT_FOUND_MESSAGE "")
+
+    if(NOT CONDUIT_USE_CMAKE_MPI_TARGETS)
+        # The compiler is expected to have MPI implicitly available; MPI is
+        # found.
+    elseif(CONDUIT_USE_MPI)
+        if(NOT TARGET MPI::MPI_C)
+            set(_conduit_find_mpi_args "")
+            if(Conduit_FIND_QUIETLY)
+                list(APPEND _conduit_find_mpi_args QUIET)
+            endif()
+
+            find_dependency(MPI ${_conduit_find_mpi_args} COMPONENTS C)
+            unset(_conduit_find_mpi_args)
+        endif()
+
+        if(NOT TARGET MPI::MPI_C)
+            set(Conduit_MPI_NOT_FOUND_MESSAGE "MPI could not be found: ${MPI_NOT_FOUND_MESSAGE}")
+        endif()
+    else()
+        set(Conduit_MPI_NOT_FOUND_MESSAGE "MPI support is not available")
+    endif()
+
+    set(Conduit_MPI_FOUND 1)
+    if(Conduit_MPI_NOT_FOUND_MESSAGE)
+        set(Conduit_MPI_FOUND 0)
+    endif()
+endif()
+
+###############################################################################
 # Setup Caliper
 ###############################################################################
 if(NOT CALIPER_DIR)

--- a/src/examples/using-with-cmake-mpi/CMakeLists.txt
+++ b/src/examples/using-with-cmake-mpi/CMakeLists.txt
@@ -58,14 +58,13 @@ endif()
 #
 find_package(Conduit REQUIRED
              NO_DEFAULT_PATH 
-             PATHS ${CONDUIT_DIR}/lib/cmake/conduit)
+             PATHS ${CONDUIT_DIR}/lib/cmake/conduit
+             OPTIONAL_COMPONENTS MPI)
 
-# make sure we have mpi, since we are going to use
-# conduits mpi features
-if(NOT MPI_FOUND)
-    find_package(MPI COMPONENTS C)
+if(NOT Conduit_MPI_FOUND)
+    message(STATUS "This example requires an MPI-enabled Conduit")
+    return()
 endif()
-
 
 ################################################################
 # Option 2: import conduit using find_package search
@@ -91,8 +90,7 @@ add_executable(conduit_mpi_example conduit_mpi_example.cpp)
 
 # link to conduit targets
 target_link_libraries(conduit_mpi_example conduit::conduit
-                                          conduit::conduit_mpi
-                                          MPI::MPI_C)
+                                          conduit::conduit_mpi)
 
 # if you are using conduit's python CAPI capsule interface
 # target_link_libraries(conduit_mpi_example conduit::conduit_python)


### PR DESCRIPTION
Otherwise projects using `conduit::conduit_mpi` may get errors about `MPI::MPI_C` not being a target without finding it themselves.