### PR TITLE
Make sure conduit_blueprint_mesh_utils_iterate_elements.hpp gets installed

### DIFF
--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -31,21 +31,22 @@ set(blueprint_headers
     conduit_blueprint.hpp
     conduit_blueprint_curves.hpp
     conduit_blueprint_mesh.hpp
-    conduit_blueprint_mesh_utils.hpp
-    conduit_blueprint_mesh_kdtree.hpp
-    conduit_blueprint_mesh_topology_metadata.hpp
+    conduit_blueprint_mcarray_examples.hpp
+    conduit_blueprint_mcarray.hpp
+    conduit_blueprint_mesh_examples_generate.hpp
+    conduit_blueprint_mesh_examples_gyre.hpp
     conduit_blueprint_mesh_examples.hpp
     conduit_blueprint_mesh_examples_julia.hpp
-    conduit_blueprint_mesh_examples_venn.hpp
-    conduit_blueprint_mesh_examples_related_boundary.hpp
     conduit_blueprint_mesh_examples_polystar.hpp
+    conduit_blueprint_mesh_examples_related_boundary.hpp
     conduit_blueprint_mesh_examples_rz_cylinder.hpp
     conduit_blueprint_mesh_examples_tiled.hpp
-    conduit_blueprint_mesh_examples_gyre.hpp
-    conduit_blueprint_mesh_examples_generate.hpp
+    conduit_blueprint_mesh_examples_venn.hpp
     conduit_blueprint_mesh_flatten.hpp
-    conduit_blueprint_mcarray.hpp
-    conduit_blueprint_mcarray_examples.hpp
+    conduit_blueprint_mesh_kdtree.hpp
+    conduit_blueprint_mesh_topology_metadata.hpp
+    conduit_blueprint_mesh_utils.hpp
+    conduit_blueprint_mesh_utils_iterate_elements.hpp
     conduit_blueprint_o2mrelation.hpp
     conduit_blueprint_o2mrelation_utils.hpp
     conduit_blueprint_o2mrelation_iterator.hpp

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils_iterate_elements.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils_iterate_elements.hpp
@@ -582,35 +582,33 @@ traverse_structured(FuncType &&func, const Node &topo)
 }
 
 //-----------------------------------------------------------------------------
-inline void
-copy_subelements(entity &e,
-                 const index_t_accessor &se_conn,
-                 const index_t_accessor &se_sizes,
-                 const index_t_accessor &se_offsets)
-{
-    const index_t numFaces = static_cast<index_t>(e.element_ids.size());
-    e.subelement_ids.resize(numFaces);
-    for(index_t j = 0; j < numFaces; j++)
-    {
-        const auto faceId = e.element_ids[j];
-        const index_t se_size = se_sizes[faceId];
-        index_t se_offset = se_offsets[faceId];
-
-        auto &se_ids = e.subelement_ids[j];
-        se_ids.resize(se_size);
-
-        for(index_t k = 0; k < se_size; k++)
-        {
-            se_ids[k] = se_conn[se_offset++];
-        }
-    }
-}
-
-//-----------------------------------------------------------------------------
 template<typename FuncType>
 inline void
 traverse_mixed_elements(FuncType &&func, const Node &topo)
 {
+    auto copy_subelements = [](entity &e,
+                               const index_t_accessor &se_conn,
+                               const index_t_accessor &se_sizes,
+                               const index_t_accessor &se_offsets)
+    {
+        const index_t numFaces = static_cast<index_t>(e.element_ids.size());
+        e.subelement_ids.resize(numFaces);
+        for(index_t j = 0; j < numFaces; j++)
+        {
+            const auto faceId = e.element_ids[j];
+            const index_t se_size = se_sizes[faceId];
+            index_t se_offset = se_offsets[faceId];
+
+            auto &se_ids = e.subelement_ids[j];
+            se_ids.resize(se_size);
+
+            for(index_t k = 0; k < se_size; k++)
+            {
+                se_ids[k] = se_conn[se_offset++];
+            }
+        }
+    };
+
     const Node &elements = topo.fetch_existing("elements");
     if(!elements.has_child("shapes"))
     {


### PR DESCRIPTION
I wanted to use `conduit_blueprint_mesh_utils_iterate_elements.hpp` in some code outside of Conduit and found that was not in the installed `include` directory.

* Make sure the file gets installed
* I moved converted an inline function into a lambda in one of the template functions.