### PR TITLE
Overlink species set requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added 2D block rotation support in `conduit::blueprint::mpi::mesh::to_polygonal()`.
 - Added field data to the `conduit::blueprint::mpi::mesh::to_polygonal()` transformation, including communication of vertex data on hanging nodes.
 - Added `conduit::blueprint::mesh::specset::to_multi_buffer_full()`, `conduit::blueprint::mesh::specset::to_uni_buffer_by_element()`, and `conduit::blueprint::mesh::specset::to_multi_buffer_by_material()`, which are converters that take species sets between the three supported species set/material set representations.
+- Added `conduit::blueprint::mesh::specset::is_multi_buffer()`, `conduit::blueprint::mesh::specset::is_uni_buffer()`, `conduit::blueprint::mesh::specset::get_num_species_for_material()`, and `conduit::blueprint::mesh::specset::get_material_names()`, which are simple species set utilities.
 
 ### Changed
 
@@ -34,12 +35,16 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Updates to use Silo 4.12 and HDF5 2.0.0.
 - Reworked HDF5 handle managment to avoid resource leaks with exceptions.
 - Relaxed the restriction on float and double volume fractions for data being read from Silo when the length of the mixed arrays is 0 (i.e. no mixed zones/volume fractions are present).
+- Added logic to enforce Overlink requirements when writing species sets to Overlink files.
 
 ### Fixed
 
 #### Conduit
 - Fixed a bug preventing explicit length 0 in `yaml` schema.
 - Fixed a bug where empty objects or lists were not written correctly to `yaml` schema.
+
+#### Relay
+- Fixed a bug preventing multiple species sets from being written when writing to Overlink.
 
 ## [0.9.5] - Released 2025-09-10
 

--- a/src/libs/blueprint/conduit_blueprint_mesh.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.cpp
@@ -7108,6 +7108,20 @@ bool verify_specset_species_names(const std::string &protocol,
     return res;
 }
 
+//-------------------------------------------------------------------------
+bool
+mesh::specset::is_multi_buffer(const Node &specset)
+{
+    return specset.child("matset_values").dtype().is_object();
+}
+
+//-------------------------------------------------------------------------
+bool
+mesh::specset::is_uni_buffer(const Node &specset)
+{
+    return specset.child("matset_values").dtype().is_number();
+}
+
 //-----------------------------------------------------------------------------
 bool
 mesh::specset::verify(const Node &specset,

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -942,6 +942,21 @@ namespace specset
                                       conduit::Node &info);
 
     //-------------------------------------------------------------------------
+    bool CONDUIT_BLUEPRINT_API is_multi_buffer(const conduit::Node &specset);
+
+    //-------------------------------------------------------------------------
+    bool CONDUIT_BLUEPRINT_API is_uni_buffer(const conduit::Node &specset);
+
+    //-------------------------------------------------------------------------
+    index_t CONDUIT_BLUEPRINT_API get_num_species_for_material(
+                                            const conduit::Node &specset,
+                                            const std::string &matname);
+
+    //-------------------------------------------------------------------------
+    void CONDUIT_BLUEPRINT_API get_material_names(const conduit::Node &specset,
+                                                  std::vector<std::string> &matnames);
+
+    //-------------------------------------------------------------------------
     // Converts a blueprint specset to the silo style sparse mixed slot 
     // representation.
     //

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -1543,6 +1543,50 @@ namespace specset
 {
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
+index_t
+get_num_species_for_material(const conduit::Node &specset,
+                             const std::string &matname)
+{
+    if (blueprint::mesh::specset::is_multi_buffer(specset))
+    {
+        if (specset["matset_values"].has_child(matname))
+        {
+            return specset["matset_values"][matname].number_of_children();
+        }
+        else
+        {
+            return 0;
+        }
+    }
+    else // uni buffer
+    {
+        if (specset["species_names"].has_child(matname))
+        {
+            return specset["species_names"][matname].number_of_children();
+        }
+        else
+        {
+            return 0;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+get_material_names(const conduit::Node &specset,
+                   std::vector<std::string> &matnames)
+{
+    if (blueprint::mesh::specset::is_multi_buffer(specset))
+    {
+        matnames = specset["matset_values"].child_names();
+    }
+    else // uni buffer
+    {
+        matnames = specset["species_names"].child_names();
+    }
+}
+
+//-----------------------------------------------------------------------------
 void
 to_silo(const conduit::Node &specset,
         const conduit::Node &matset,

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -9705,9 +9705,9 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                         opts_nameschemes);
 
         // TODO for overlink: Specie sets:
-        //    [ ] A domain may contain multiple specie sets.
+        //    [x] A domain may contain multiple specie sets.
         //    [ ] All domains must contain the same number of specie sets.
-        //    [ ] The numbers of species per material in each set may be 
+        //    [x] The numbers of species per material in each set may be 
         //        different for the same material in different sets.
         //    [x] The number of species per material in each set must be 
         //        the same for all domains.

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8523,10 +8523,12 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     // across domains, and agree with that specified in the corresponding
     // DBPutMultimatspecies call.
 
-    if (write_overlink)
+    // this is scoped since to avoid naming/declaration issues
     {
+        //
         // step 1. generate a map with the number of species per material for each
         //         specset and check that all local domains match
+        //
 
         // map from specset name to map from matname to number of species per material
         Node num_spec_for_mats;
@@ -8541,7 +8543,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
         // ...
 
         int error = 0;
-        std::stringstream errmsg;
 
         auto child_itr = multi_dom.children();
         while (child_itr.has_next())
@@ -8557,7 +8558,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                     const std::string specset_name = specset_itr.name();
 
                     std::vector<std::string> matnames;
-                    blueprint::mesh::specset::get_material_names(specset, matnames);
+                    conduit::blueprint::mesh::specset::get_material_names(specset, matnames);
 
                     // if we already have an entry for this specset from some domain
                     if (num_spec_for_mats.has_child(specset_name))
@@ -8567,19 +8568,17 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                         if (specset_entry.number_of_children() != static_cast<index_t>(matnames.size()))
                         {
                             error = 1;
-                            errmsg << "Mismatch in the number of materials between species sets on different domains.";
                             break;
                         }
                         else
                         {
                             for (const auto &matname : matnames)
                             {
-                                const index_t num_spec_for_mat = get_num_species_for_material(specset, matname);
+                                const index_t num_spec_for_mat = conduit::blueprint::mesh::specset::get_num_species_for_material(specset, matname);
                                 const index_t other_num_spec_for_mat = specset_entry[matname].to_index_t();
                                 if (num_spec_for_mat != other_num_spec_for_mat)
                                 {
                                     error = 1;
-                                    errmsg << "Mismatch in the number of species per material between species sets on different domains.";
                                     break;
                                 }
                             }
@@ -8590,7 +8589,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                     {
                         for (const auto &matname : matnames)
                         {
-                            const index_t num_spec_for_mat = get_num_species_for_material(specset, matname);
+                            const index_t num_spec_for_mat = conduit::blueprint::mesh::specset::get_num_species_for_material(specset, matname);
                             num_spec_for_mats[specset_name][matname] = num_spec_for_mat;
                         }
                     }
@@ -8602,7 +8601,9 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             }
         }
 
+        //
         // step 2. globally check that all local results are acceptable
+        //
 
 #ifdef CONDUIT_RELAY_IO_MPI_ENABLED
         Node n_local, n_global;
@@ -8622,17 +8623,33 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                                                         0,
                                                         mpi_comm);
 
-            CONDUIT_ERROR(n_global.as_string());
+            if (write_overlink)
+            {
+                CONDUIT_ERROR(n_global.as_string());
+            }
+            else
+            {
+                CONDUIT_INFO(n_global.as_string());
+            }
         }
 #else
         // non MPI case, throw error
         if (0 != error)
         {
-            CONDUIT_ERROR("Number of species per material within a set must agree across domains.");
+            if (write_overlink)
+            {
+                CONDUIT_ERROR("Number of species per material within a set must agree across domains.");
+            }
+            else
+            {
+                CONDUIT_INFO("Number of species per material within a set must agree across domains.");
+            }
         }
 #endif
 
-        // step 3. gather global results and check that they are the same
+        //
+        // step 3. gather global results
+        //
 
         Node global_num_spec_for_mats;
 #ifdef CONDUIT_RELAY_IO_MPI_ENABLED
@@ -8644,22 +8661,78 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
 #endif
         if (global_num_spec_for_mats.number_of_children() != 1)
         {
+            std::map<std::string, std::map<std::string, index_t>> global_n_spec_for_mats_map;
+            auto num_spec_for_mat_for_dom_itr = global_num_spec_for_mats.children();
+            while (num_spec_for_mat_for_dom_itr.has_next())
+            {
+                const Node &num_spec_for_mat_for_dom = num_spec_for_mat_for_dom_itr.next();
+                const std::vector<std::string> &specset_names = num_spec_for_mat_for_dom.child_names();
+                for (const auto &specset_name : specset_names)
+                {
+                    const Node &specset_entry = num_spec_for_mat_for_dom[specset_name];
+                    if (global_n_spec_for_mats_map.count(specset_name))
+                    {
+                        // investigate if each number is right
+                        const std::vector<std::string> &matnames = specset_entry.child_names();
+                        
+                        const size_t num_mat_in_specset = global_n_spec_for_mats_map.at(specset_name).size();
 
+                        if (num_mat_in_specset != matnames.size())
+                        {
+                            error = 1;
+                            break;
+                        }
+
+                        for (const auto &matname : matnames)
+                        {
+                            // if we contain an entry for this material
+                            if (global_n_spec_for_mats_map.at(specset_name).count(matname))
+                            {
+                                const index_t recorded_num = global_n_spec_for_mats_map.at(specset_name).at(matname);
+                                const index_t local_num = specset_entry[matname].to_index_t();
+                                if (recorded_num != local_num)
+                                {
+                                    error = 1;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                error = 1;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // fill the map
+                        const std::vector<std::string> &matnames = specset_entry.child_names();
+                        for (const auto &matname : matnames)
+                        {
+                            global_n_spec_for_mats_map[specset_name][matname] = specset_entry[matname].to_index_t();
+                        }
+                    }
+                }
+            }
         }
 
-        auto num_spec_for_mat_for_dom_itr = global_num_spec_for_mats.itr();
-        while (num_spec_for_mat_for_dom_itr.has_next())
+        //
+        // step 4. globally check that global results are acceptable
+        //
+
+        // we did an all gather above so every rank has everything; error will happen on all ranks
+        if (0 != error)
         {
-            num_spec_for_mat_for_dom
+            if (write_overlink)
+            {
+                CONDUIT_ERROR("Number of species per material within a set must agree across domains.");
+            }
+            else
+            {
+                CONDUIT_INFO("Number of species per material within a set must agree across domains.");
+            }
         }
-        
-
-        // TODO how does missing domain data play into this? Are you allowed
-        // to be missing for overlink?
     }
-
-
-
 
     // I want the names of specsets that are associated with the first
     // matset associated with the chosen topology

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8541,6 +8541,9 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
 
         int error = 0;
 
+        // TODO we only care about this for overlink specsets that we are actually going to write
+        // TODO we also need to enforce same number of specsets (that we are going to write) on each domain for overlink
+
         auto child_itr = multi_dom.children();
         while (child_itr.has_next())
         {

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8526,24 +8526,22 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     if (write_overlink)
     {
         // step 1. generate a map with the number of species per material for each
-        //         specset.
+        //         specset and check that all local domains match
 
         // map from specset name to map from matname to number of species per material
         Node num_spec_for_mats;
         // i.e.
-        //  -
-        //    specset1:
-        //       mat1: 3
-        //       mat2: 4
-        //    specset2:
-        //       mat1: 1
-        //       mat2: 2
-        //       mat3: 6
-        //  - 
-        //    specset1:
-        //       mat1: 3
-        //       mat2: 4
+        // specset1:
+        //    mat1: 3
+        //    mat2: 4
+        // specset2:
+        //    mat1: 1
+        //    mat2: 2
+        //    mat3: 6
         // ...
+
+        int error = 0;
+        std::stringstream errmsg;
 
         auto child_itr = multi_dom.children();
         while (child_itr.has_next())
@@ -8551,7 +8549,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             const Node &child = child_itr.next();
             if (child.has_child("specsets"))
             {
-                Node &curr_dom_info = num_spec_for_mats.append();
                 const Node &specsets = child["specsets"];
                 auto specset_itr = specsets.children();
                 while (specset_itr.has_next())
@@ -8562,10 +8559,40 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                     std::vector<std::string> matnames;
                     blueprint::mesh::specset::get_material_names(specset, matnames);
 
-                    for (const auto &matname : matnames)
+                    // if we already have an entry for this specset from some domain
+                    if (num_spec_for_mats.has_child(specset_name))
                     {
-                        const index_t num_spec_for_mat = get_num_species_for_material(specset, matname);
-                        curr_dom_info[specset_name][matname] = num_spec_for_mat;
+                        const Node &specset_entry = num_spec_for_mats[specset_name];
+                        // if there is a mismatch in the number of materials
+                        if (specset_entry.number_of_children() != static_cast<index_t>(matnames.size()))
+                        {
+                            error = 1;
+                            errmsg << "Mismatch in the number of materials between species sets on different domains.";
+                            break;
+                        }
+                        else
+                        {
+                            for (const auto &matname : matnames)
+                            {
+                                const index_t num_spec_for_mat = get_num_species_for_material(specset, matname);
+                                const index_t other_num_spec_for_mat = specset_entry[matname].to_index_t();
+                                if (num_spec_for_mat != other_num_spec_for_mat)
+                                {
+                                    error = 1;
+                                    errmsg << "Mismatch in the number of species per material between species sets on different domains.";
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    // our first time encountering this species set on any local domain
+                    else
+                    {
+                        for (const auto &matname : matnames)
+                        {
+                            const index_t num_spec_for_mat = get_num_species_for_material(specset, matname);
+                            num_spec_for_mats[specset_name][matname] = num_spec_for_mat;
+                        }
                     }
                 }
             }
@@ -8575,41 +8602,60 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             }
         }
 
-        // step 2. locally check that all domains have the same info
+        // step 2. globally check that all local results are acceptable
 
-        // step 3. globally check that all local results are the same
+#ifdef CONDUIT_RELAY_IO_MPI_ENABLED
+        Node n_local, n_global;
+        n_local.set((int)error);
+        relay::mpi::sum_all_reduce(n_local,
+                                   n_global,
+                                   mpi_comm);
 
-        // for both these steps we want to ignore domains that are missing data
+        error = n_global.as_int();
+
+        if (0 != error)
+        {
+            // we have a problem, broadcast string message
+            // from rank 0 all ranks can throw an error
+            n_global.set("Number of species per material within a set must agree across domains.");
+            conduit::relay::mpi::broadcast_using_schema(n_global,
+                                                        0,
+                                                        mpi_comm);
+
+            CONDUIT_ERROR(n_global.as_string());
+        }
+#else
+        // non MPI case, throw error
+        if (0 != error)
+        {
+            CONDUIT_ERROR("Number of species per material within a set must agree across domains.");
+        }
+#endif
+
+        // step 3. gather global results and check that they are the same
+
+        Node global_num_spec_for_mats;
+#ifdef CONDUIT_RELAY_IO_MPI_ENABLED
+        relay::mpi::all_gather_using_schema(num_spec_for_mats,
+                                            global_num_spec_for_mats,
+                                            mpi_comm);
+#else
+        global_num_spec_for_mats.append().set_external(num_spec_for_mats);
+#endif
+        if (global_num_spec_for_mats.number_of_children() != 1)
+        {
+
+        }
+
+        auto num_spec_for_mat_for_dom_itr = global_num_spec_for_mats.itr();
+        while (num_spec_for_mat_for_dom_itr.has_next())
+        {
+            num_spec_for_mat_for_dom
+        }
         
 
-// the following is some potentially useful junk
-// #ifdef CONDUIT_RELAY_IO_MPI_ENABLED
-//         Node n_local, n_global;
-//         n_local.set((int)error);
-//         relay::mpi::sum_all_reduce(n_local,
-//                                    n_global,
-//                                    mpi_comm);
-
-//         error = n_global.as_int();
-
-//         if (1 == error)
-//         {
-//             // we have a problem, broadcast string message
-//             // from rank 0 all ranks can throw an error
-//             n_global.set("Not all domains contain species sets");
-//             conduit::relay::mpi::broadcast_using_schema(n_global,
-//                                                         0,
-//                                                         mpi_comm);
-
-//             CONDUIT_ERROR(n_global.as_string());
-//         }
-// #else
-//         // non MPI case, throw error
-//         if (1 == error)
-//         {
-//             CONDUIT_ERROR("Not all domains contain species sets");
-//         }
-// #endif
+        // TODO how does missing domain data play into this? Are you allowed
+        // to be missing for overlink?
     }
 
 

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -9071,7 +9071,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     // - The number of species per material in each set must be 
     //   the same for all domains.
 
-    // We warn if Overlink is not enabled.
+    // We warn if Overlink is not enabled and one of these conditions is not true.
 
     // This is scoped since to avoid naming/declaration issues
     {

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -9056,7 +9056,17 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
         }
     }
 
-    // The number of species per material within a set must agree across domains.
+    //
+    // OVERLINK species set requirements
+    //
+
+    // We must enforce the following species set requirements:
+    // - All domains must contain the same number of specie sets.
+    // - The number of species per material in each set must be 
+    //   the same for all domains.
+
+    // We warn if Overlink is not enabled.
+
     // This is scoped since to avoid naming/declaration issues
     {
         //
@@ -9078,9 +9088,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
 
         int error = 0;
         int num_specsets_on_domain = -1;
-
-        // TODO we only care about this for overlink specsets that we are actually going to write
-        // TODO we also need to enforce same number of specsets (that we are going to write) on each domain for overlink
 
         auto child_itr = multi_dom.children();
         while (child_itr.has_next())
@@ -9736,14 +9743,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                         root,
                         write_overlink,
                         opts_nameschemes);
-
-        // TODO for overlink: Specie sets:
-        //    [x] A domain may contain multiple specie sets.
-        //    [x] All domains must contain the same number of specie sets.
-        //    [x] The numbers of species per material in each set may be 
-        //        different for the same material in different sets.
-        //    [x] The number of species per material in each set must be 
-        //        the same for all domains.
 
         const int num_specsets_written =
             write_multimatspecs(dbfile.getSiloObject(),

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8519,6 +8519,102 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     bp_idx[opts_out_mesh_name] = local_bp_idx;
 #endif
 
+    // TODO for overlink: Number of species per material within a set must agree
+    // across domains, and agree with that specified in the corresponding
+    // DBPutMultimatspecies call.
+
+    if (write_overlink)
+    {
+        // step 1. generate a map with the number of species per material for each
+        //         specset.
+
+        // map from specset name to map from matname to number of species per material
+        Node num_spec_for_mats;
+        // i.e.
+        //  -
+        //    specset1:
+        //       mat1: 3
+        //       mat2: 4
+        //    specset2:
+        //       mat1: 1
+        //       mat2: 2
+        //       mat3: 6
+        //  - 
+        //    specset1:
+        //       mat1: 3
+        //       mat2: 4
+        // ...
+
+        auto child_itr = multi_dom.children();
+        while (child_itr.has_next())
+        {
+            const Node &child = child_itr.next();
+            if (child.has_child("specsets"))
+            {
+                Node &curr_dom_info = num_spec_for_mats.append();
+                const Node &specsets = child["specsets"];
+                auto specset_itr = specsets.children();
+                while (specset_itr.has_next())
+                {
+                    const Node &specset = specset_itr.next();
+                    const std::string specset_name = specset_itr.name();
+
+                    std::vector<std::string> matnames;
+                    blueprint::mesh::specset::get_material_names(specset, matnames);
+
+                    for (const auto &matname : matnames)
+                    {
+                        const index_t num_spec_for_mat = get_num_species_for_material(specset, matname);
+                        curr_dom_info[specset_name][matname] = num_spec_for_mat;
+                    }
+                }
+            }
+            else
+            {
+                continue;
+            }
+        }
+
+        // step 2. locally check that all domains have the same info
+
+        // step 3. globally check that all local results are the same
+
+        // for both these steps we want to ignore domains that are missing data
+        
+
+// the following is some potentially useful junk
+// #ifdef CONDUIT_RELAY_IO_MPI_ENABLED
+//         Node n_local, n_global;
+//         n_local.set((int)error);
+//         relay::mpi::sum_all_reduce(n_local,
+//                                    n_global,
+//                                    mpi_comm);
+
+//         error = n_global.as_int();
+
+//         if (1 == error)
+//         {
+//             // we have a problem, broadcast string message
+//             // from rank 0 all ranks can throw an error
+//             n_global.set("Not all domains contain species sets");
+//             conduit::relay::mpi::broadcast_using_schema(n_global,
+//                                                         0,
+//                                                         mpi_comm);
+
+//             CONDUIT_ERROR(n_global.as_string());
+//         }
+// #else
+//         // non MPI case, throw error
+//         if (1 == error)
+//         {
+//             CONDUIT_ERROR("Not all domains contain species sets");
+//         }
+// #endif
+    }
+
+
+
+
     // I want the names of specsets that are associated with the first
     // matset associated with the chosen topology
     std::map<std::string, std::pair<std::string, std::string>> ovl_specset_names;
@@ -8586,10 +8682,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             }
         }
     }
-
-    // TODO for overlink: Number of species per material within a set must agree
-    // across domains, and agree with that specified in the corresponding
-    // DBPutMultimatspecies call.
 
     // new style bp index partition_map
     // NOTE: the part_map is inited during write process for N domains

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8519,11 +8519,8 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     bp_idx[opts_out_mesh_name] = local_bp_idx;
 #endif
 
-    // TODO for overlink: Number of species per material within a set must agree
-    // across domains, and agree with that specified in the corresponding
-    // DBPutMultimatspecies call.
-
-    // this is scoped since to avoid naming/declaration issues
+    // The number of species per material within a set must agree across domains.
+    // This is scoped since to avoid naming/declaration issues
     {
         //
         // step 1. generate a map with the number of species per material for each
@@ -9707,11 +9704,13 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
                         write_overlink,
                         opts_nameschemes);
 
-        // TODO for overlink: Specie sets: A domain may contain multiple specie
-        // sets. All domains must contain the same number of specie sets. The
-        // numbers of species per material in each set may be different for the
-        // same material in different sets. The number of species per material
-        // in each set must be the same for all domains.
+        // TODO for overlink: Specie sets:
+        //    [ ] A domain may contain multiple specie sets.
+        //    [ ] All domains must contain the same number of specie sets.
+        //    [ ] The numbers of species per material in each set may be 
+        //        different for the same material in different sets.
+        //    [x] The number of species per material in each set must be 
+        //        the same for all domains.
 
         const int num_specsets_written =
             write_multimatspecs(dbfile.getSiloObject(),

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8523,10 +8523,14 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     // I want the names of specsets that are associated with the first
     // matset associated with the chosen topology
     std::map<std::string, std::pair<std::string, std::string>> ovl_specset_names;
-    // we need this to ensure that all species get assigned a unique name
+    // maps the conduit specset name to the overlink name + an empty string OR
+    // maps the conduit specset name to the string "ERROR" + an error message
+    
+    // We need this to ensure that all species sets get assigned a unique name
     // for overlink, independent of the order they appear for a particular domain.
     // TODO test me, specset1 and specset2, specset1 appears first on one dom
     // and second on the other dom.
+    // TODO does this work in parallel?
     if (write_overlink)
     {
         int ovl_mspecies_object_index = 0;
@@ -8579,11 +8583,13 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
             if (ovl_mspecies_object_index == 0)
             {
                 ovl_specset_names[specset_name] = std::make_pair("SPECIES", "");
+                ovl_mspecies_object_index ++;
             }
             else
             {
                 ovl_specset_names[specset_name] = std::make_pair(
                     "SPECIES" + std::to_string(ovl_mspecies_object_index), "");
+                ovl_mspecies_object_index ++;
             }
         }
     }

--- a/src/libs/relay/conduit_relay_io_silo.cpp
+++ b/src/libs/relay/conduit_relay_io_silo.cpp
@@ -8519,221 +8519,6 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
     bp_idx[opts_out_mesh_name] = local_bp_idx;
 #endif
 
-    // The number of species per material within a set must agree across domains.
-    // This is scoped since to avoid naming/declaration issues
-    {
-        //
-        // step 1. generate a map with the number of species per material for each
-        //         specset and check that all local domains match
-        //
-
-        // map from specset name to map from matname to number of species per material
-        Node num_spec_for_mats;
-        // i.e.
-        // specset1:
-        //    mat1: 3
-        //    mat2: 4
-        // specset2:
-        //    mat1: 1
-        //    mat2: 2
-        //    mat3: 6
-        // ...
-
-        int error = 0;
-
-        // TODO we only care about this for overlink specsets that we are actually going to write
-        // TODO we also need to enforce same number of specsets (that we are going to write) on each domain for overlink
-
-        auto child_itr = multi_dom.children();
-        while (child_itr.has_next())
-        {
-            const Node &child = child_itr.next();
-            if (child.has_child("specsets"))
-            {
-                const Node &specsets = child["specsets"];
-                auto specset_itr = specsets.children();
-                while (specset_itr.has_next())
-                {
-                    const Node &specset = specset_itr.next();
-                    const std::string specset_name = specset_itr.name();
-
-                    std::vector<std::string> matnames;
-                    conduit::blueprint::mesh::specset::get_material_names(specset, matnames);
-
-                    // if we already have an entry for this specset from some domain
-                    if (num_spec_for_mats.has_child(specset_name))
-                    {
-                        const Node &specset_entry = num_spec_for_mats[specset_name];
-                        // if there is a mismatch in the number of materials
-                        if (specset_entry.number_of_children() != static_cast<index_t>(matnames.size()))
-                        {
-                            error = 1;
-                            break;
-                        }
-                        else
-                        {
-                            for (const auto &matname : matnames)
-                            {
-                                const index_t num_spec_for_mat = conduit::blueprint::mesh::specset::get_num_species_for_material(specset, matname);
-                                const index_t other_num_spec_for_mat = specset_entry[matname].to_index_t();
-                                if (num_spec_for_mat != other_num_spec_for_mat)
-                                {
-                                    error = 1;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    // our first time encountering this species set on any local domain
-                    else
-                    {
-                        for (const auto &matname : matnames)
-                        {
-                            const index_t num_spec_for_mat = conduit::blueprint::mesh::specset::get_num_species_for_material(specset, matname);
-                            num_spec_for_mats[specset_name][matname] = num_spec_for_mat;
-                        }
-                    }
-                }
-            }
-            else
-            {
-                continue;
-            }
-        }
-
-        //
-        // step 2. globally check that all local results are acceptable
-        //
-
-#ifdef CONDUIT_RELAY_IO_MPI_ENABLED
-        Node n_local, n_global;
-        n_local.set((int)error);
-        relay::mpi::sum_all_reduce(n_local,
-                                   n_global,
-                                   mpi_comm);
-
-        error = n_global.as_int();
-
-        if (0 != error)
-        {
-            // we have a problem, broadcast string message
-            // from rank 0 all ranks can throw an error
-            n_global.set("Number of species per material within a set must agree across domains.");
-            conduit::relay::mpi::broadcast_using_schema(n_global,
-                                                        0,
-                                                        mpi_comm);
-
-            if (write_overlink)
-            {
-                CONDUIT_ERROR(n_global.as_string());
-            }
-            else
-            {
-                CONDUIT_INFO(n_global.as_string());
-            }
-        }
-#else
-        // non MPI case, throw error
-        if (0 != error)
-        {
-            if (write_overlink)
-            {
-                CONDUIT_ERROR("Number of species per material within a set must agree across domains.");
-            }
-            else
-            {
-                CONDUIT_INFO("Number of species per material within a set must agree across domains.");
-            }
-        }
-#endif
-
-        //
-        // step 3. gather global results
-        //
-
-        Node global_num_spec_for_mats;
-#ifdef CONDUIT_RELAY_IO_MPI_ENABLED
-        relay::mpi::all_gather_using_schema(num_spec_for_mats,
-                                            global_num_spec_for_mats,
-                                            mpi_comm);
-#else
-        global_num_spec_for_mats.append().set_external(num_spec_for_mats);
-#endif
-        if (global_num_spec_for_mats.number_of_children() != 1)
-        {
-            std::map<std::string, std::map<std::string, index_t>> global_n_spec_for_mats_map;
-            auto num_spec_for_mat_for_dom_itr = global_num_spec_for_mats.children();
-            while (num_spec_for_mat_for_dom_itr.has_next())
-            {
-                const Node &num_spec_for_mat_for_dom = num_spec_for_mat_for_dom_itr.next();
-                const std::vector<std::string> &specset_names = num_spec_for_mat_for_dom.child_names();
-                for (const auto &specset_name : specset_names)
-                {
-                    const Node &specset_entry = num_spec_for_mat_for_dom[specset_name];
-                    if (global_n_spec_for_mats_map.count(specset_name))
-                    {
-                        // investigate if each number is right
-                        const std::vector<std::string> &matnames = specset_entry.child_names();
-                        
-                        const size_t num_mat_in_specset = global_n_spec_for_mats_map.at(specset_name).size();
-
-                        if (num_mat_in_specset != matnames.size())
-                        {
-                            error = 1;
-                            break;
-                        }
-
-                        for (const auto &matname : matnames)
-                        {
-                            // if we contain an entry for this material
-                            if (global_n_spec_for_mats_map.at(specset_name).count(matname))
-                            {
-                                const index_t recorded_num = global_n_spec_for_mats_map.at(specset_name).at(matname);
-                                const index_t local_num = specset_entry[matname].to_index_t();
-                                if (recorded_num != local_num)
-                                {
-                                    error = 1;
-                                    break;
-                                }
-                            }
-                            else
-                            {
-                                error = 1;
-                                break;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // fill the map
-                        const std::vector<std::string> &matnames = specset_entry.child_names();
-                        for (const auto &matname : matnames)
-                        {
-                            global_n_spec_for_mats_map[specset_name][matname] = specset_entry[matname].to_index_t();
-                        }
-                    }
-                }
-            }
-        }
-
-        //
-        // step 4. globally check that global results are acceptable
-        //
-
-        // we did an all gather above so every rank has everything; error will happen on all ranks
-        if (0 != error)
-        {
-            if (write_overlink)
-            {
-                CONDUIT_ERROR("Number of species per material within a set must agree across domains.");
-            }
-            else
-            {
-                CONDUIT_INFO("Number of species per material within a set must agree across domains.");
-            }
-        }
-    }
-
     // I want the names of specsets that are associated with the first
     // matset associated with the chosen topology
     std::map<std::string, std::pair<std::string, std::string>> ovl_specset_names;
@@ -9270,6 +9055,250 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
         }
     }
 
+    // The number of species per material within a set must agree across domains.
+    // This is scoped since to avoid naming/declaration issues
+    {
+        //
+        // step 1. generate a map with the number of species per material for each
+        //         specset and check that all local domains match
+        //
+
+        // map from specset name to map from matname to number of species per material
+        Node num_spec_for_mats;
+        // i.e.
+        // specset1:
+        //    mat1: 3
+        //    mat2: 4
+        // specset2:
+        //    mat1: 1
+        //    mat2: 2
+        //    mat3: 6
+        // ...
+
+        int error = 0;
+        int num_specsets_on_domain = -1;
+
+        // TODO we only care about this for overlink specsets that we are actually going to write
+        // TODO we also need to enforce same number of specsets (that we are going to write) on each domain for overlink
+
+        auto child_itr = multi_dom.children();
+        while (child_itr.has_next())
+        {
+            const Node &child = child_itr.next();
+            if (child.has_child("specsets") && local_type_domain_info.has_child("specsets"))
+            {
+                const Node &specsets = child["specsets"];
+                const int num_specsets_written = local_type_domain_info["specsets"].number_of_children();
+                if (-1 == num_specsets_on_domain)
+                {
+                    num_specsets_on_domain = num_specsets_written;
+                }
+                else
+                {
+                    if (num_specsets_written != num_specsets_on_domain)
+                    {
+                        error = 1;
+                        break;
+                    }
+                }
+                auto specset_itr = specsets.children();
+                while (specset_itr.has_next())
+                {
+                    const Node &specset = specset_itr.next();
+                    const std::string specset_name = specset_itr.name();
+
+                    if (! local_type_domain_info.has_path("specsets/" + specset_name))
+                    {
+                        continue;
+                    }
+
+                    std::vector<std::string> matnames;
+                    conduit::blueprint::mesh::specset::get_material_names(specset, matnames);
+
+                    // if we already have an entry for this specset from some domain
+                    if (num_spec_for_mats.has_child(specset_name))
+                    {
+                        const Node &specset_entry = num_spec_for_mats[specset_name];
+                        // if there is a mismatch in the number of materials
+                        if (specset_entry.number_of_children() != static_cast<index_t>(matnames.size()))
+                        {
+                            error = 1;
+                            break;
+                        }
+                        else
+                        {
+                            for (const auto &matname : matnames)
+                            {
+                                const index_t num_spec_for_mat = conduit::blueprint::mesh::specset::get_num_species_for_material(specset, matname);
+                                const index_t other_num_spec_for_mat = specset_entry[matname].to_index_t();
+                                if (num_spec_for_mat != other_num_spec_for_mat)
+                                {
+                                    error = 1;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    // our first time encountering this species set on any local domain
+                    else
+                    {
+                        for (const auto &matname : matnames)
+                        {
+                            const index_t num_spec_for_mat = conduit::blueprint::mesh::specset::get_num_species_for_material(specset, matname);
+                            num_spec_for_mats[specset_name][matname] = num_spec_for_mat;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                continue;
+            }
+        }
+
+        //
+        // step 2. globally check that all local results are acceptable
+        //
+
+#ifdef CONDUIT_RELAY_IO_MPI_ENABLED
+        Node n_local, n_global;
+        n_local["err"].set((int)error);
+        relay::mpi::sum_all_reduce(n_local["err"],
+                                   n_global["err"],
+                                   mpi_comm);
+
+        error = n_global["err"].as_int();
+
+        n_local["num_specsets_on_dom"].set(num_specsets_on_domain);
+        relay::mpi::min_all_reduce(n_local["num_specsets_on_dom"],
+                                   n_global["min_specsets_on_dom"],
+                                   mpi_comm);
+        relay::mpi::max_all_reduce(n_local["num_specsets_on_dom"],
+                                   n_global["max_specsets_on_dom"],
+                                   mpi_comm);
+        const int min_num_specsets_on_dom = n_global["min_specsets_on_dom"].as_int();
+        const int max_num_specsets_on_dom = n_global["max_specsets_on_dom"].as_int();
+
+        if (0 != error || min_num_specsets_on_dom != max_num_specsets_on_dom)
+        {
+            if (write_overlink)
+            {
+                CONDUIT_ERROR("Number of species per material within a set must agree across domains; "
+                              "Number of species sets must be the same on all domains.");
+            }
+            else
+            {
+                CONDUIT_INFO("Number of species per material within a set must agree across domains; "
+                             "Number of species sets must be the same on all domains.");
+            }
+        }
+
+#else
+        // non MPI case, throw error
+        if (0 != error)
+        {
+            if (write_overlink)
+            {
+                CONDUIT_ERROR("Number of species per material within a set must agree across domains; "
+                              "Number of species sets must be the same on all domains.");
+            }
+            else
+            {
+                CONDUIT_INFO("Number of species per material within a set must agree across domains; "
+                             "Number of species sets must be the same on all domains.");
+            }
+        }
+#endif
+
+        //
+        // step 3. gather global results
+        //
+
+        Node global_num_spec_for_mats;
+#ifdef CONDUIT_RELAY_IO_MPI_ENABLED
+        relay::mpi::all_gather_using_schema(num_spec_for_mats,
+                                            global_num_spec_for_mats,
+                                            mpi_comm);
+#else
+        global_num_spec_for_mats.append().set_external(num_spec_for_mats);
+#endif
+        if (global_num_spec_for_mats.number_of_children() != 1)
+        {
+            std::map<std::string, std::map<std::string, index_t>> global_n_spec_for_mats_map;
+            auto num_spec_for_mat_for_dom_itr = global_num_spec_for_mats.children();
+            while (num_spec_for_mat_for_dom_itr.has_next())
+            {
+                const Node &num_spec_for_mat_for_dom = num_spec_for_mat_for_dom_itr.next();
+                const std::vector<std::string> &specset_names = num_spec_for_mat_for_dom.child_names();
+                for (const auto &specset_name : specset_names)
+                {
+                    const Node &specset_entry = num_spec_for_mat_for_dom[specset_name];
+                    if (global_n_spec_for_mats_map.count(specset_name))
+                    {
+                        // investigate if each number is right
+                        const std::vector<std::string> &matnames = specset_entry.child_names();
+                        
+                        const size_t num_mat_in_specset = global_n_spec_for_mats_map.at(specset_name).size();
+
+                        if (num_mat_in_specset != matnames.size())
+                        {
+                            error = 1;
+                            break;
+                        }
+
+                        for (const auto &matname : matnames)
+                        {
+                            // if we contain an entry for this material
+                            if (global_n_spec_for_mats_map.at(specset_name).count(matname))
+                            {
+                                const index_t recorded_num = global_n_spec_for_mats_map.at(specset_name).at(matname);
+                                const index_t local_num = specset_entry[matname].to_index_t();
+                                if (recorded_num != local_num)
+                                {
+                                    error = 1;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                error = 1;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // fill the map
+                        const std::vector<std::string> &matnames = specset_entry.child_names();
+                        for (const auto &matname : matnames)
+                        {
+                            global_n_spec_for_mats_map[specset_name][matname] = specset_entry[matname].to_index_t();
+                        }
+                    }
+                }
+            }
+        }
+
+        //
+        // step 4. globally check that global results are acceptable
+        //
+
+        // we did an all gather above so every rank has everything; error will happen on all ranks
+        if (0 != error)
+        {
+            if (write_overlink)
+            {
+                CONDUIT_ERROR("Number of species per material within a set must agree across domains; "
+                              "Number of species sets must be the same on all domains.");
+            }
+            else
+            {
+                CONDUIT_INFO("Number of species per material within a set must agree across domains; "
+                             "Number of species sets must be the same on all domains.");
+            }
+        }
+    }
+
     int root_file_writer = 0;
     if(local_num_domains == 0)
     {
@@ -9709,7 +9738,7 @@ void CONDUIT_RELAY_API write_mesh(const Node &mesh,
 
         // TODO for overlink: Specie sets:
         //    [x] A domain may contain multiple specie sets.
-        //    [ ] All domains must contain the same number of specie sets.
+        //    [x] All domains must contain the same number of specie sets.
         //    [x] The numbers of species per material in each set may be 
         //        different for the same material in different sets.
         //    [x] The number of species per material in each set must be 

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1200,6 +1200,8 @@ TEST(conduit_relay_io_silo, unstructured_points)
 }
 
 //-----------------------------------------------------------------------------
+// Test this Overlink rule: Number of species per material within a set must
+// agree across domains
 TEST(conduit_relay_io_silo, overlink_specset_rules)
 {
     Node save_mesh, load_mesh, info;
@@ -1214,6 +1216,9 @@ TEST(conduit_relay_io_silo, overlink_specset_rules)
     save_mesh[1]["state"]["domain_id"] = 1;
 
     save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+
+    // the faulty specset passes verify
+    EXPECT_TRUE(blueprint::mesh::verify(save_mesh, info));
 
     Node write_opts;
     write_opts["file_style"] = "overlink";

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1200,8 +1200,9 @@ TEST(conduit_relay_io_silo, unstructured_points)
 }
 
 //-----------------------------------------------------------------------------
-// Test this Overlink rule: Number of species per material within a set must
+// Tests this Overlink rule: Number of species per material within a set must
 // agree across domains
+// This tests if we can find the error in the serial case.
 TEST(conduit_relay_io_silo, overlink_specset_rules)
 {
     Node save_mesh, load_mesh, info;

--- a/src/tests/relay/t_relay_io_silo.cpp
+++ b/src/tests/relay/t_relay_io_silo.cpp
@@ -1200,6 +1200,66 @@ TEST(conduit_relay_io_silo, unstructured_points)
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_relay_io_silo, overlink_specset_rules)
+{
+    Node save_mesh, load_mesh, info;
+    blueprint::mesh::examples::misc("specsets", 3, 3, 1, save_mesh.append());
+    save_mesh[0]["matsets"].rename_child("mesh", "matset");
+    save_mesh[0]["specsets"].rename_child("mesh", "specset");
+    save_mesh[0]["specsets"]["specset"]["matset"].set("matset");
+    save_mesh[0]["state"]["domain_id"] = 0;
+
+    // duplicate
+    save_mesh.append().set(save_mesh[0]);
+    save_mesh[1]["state"]["domain_id"] = 1;
+
+    save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+
+    Node write_opts;
+    write_opts["file_style"] = "overlink";
+
+    // We will first try to save with Overlink, which should fail.
+    // Then we will save with regular Silo which should succeed.
+    const std::string basename = "silo_save_overlink_specset_rules";
+    const std::string filename = basename + ".cycle_000100.root";
+    EXPECT_EQ(filename, io::blueprint::generate_root_filename(save_mesh, basename, "silo"));
+
+    Node read_opts;
+    read_opts["matset_style"] = "multi_buffer_full";
+
+    remove_path_if_exists(filename);
+
+    EXPECT_THROW(io::silo::save_mesh(save_mesh, basename, write_opts), conduit::Error);
+    
+    // now save without overlink
+    io::silo::save_mesh(save_mesh, basename);
+
+    io::silo::load_mesh(filename, read_opts, load_mesh);
+    EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+    // make changes to save mesh so the diff will pass
+    // add bogus numbers to the specset; read behavior assumes this exists
+    save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+    float64_array spec3 = save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].value();
+    spec3[0] = 1.0; spec3[1] = 0.0; spec3[2] = 1.0; spec3[3] = 0.0;
+    for (index_t child = 0; child < save_mesh.number_of_children(); child ++)
+    {
+        silo_name_changer("mesh", save_mesh[child]);
+    }
+
+    EXPECT_EQ(load_mesh.number_of_children(), save_mesh.number_of_children());
+    NodeConstIterator l_itr = load_mesh.children();
+    NodeConstIterator s_itr = save_mesh.children();
+    while (l_itr.has_next())
+    {
+        const Node &l_curr = l_itr.next();
+        const Node &s_curr = s_itr.next();
+
+        EXPECT_FALSE(l_curr.diff(s_curr, info, CONDUIT_EPSILON, true));
+    }
+}
+
+//-----------------------------------------------------------------------------
 
 // 
 // save option tests

--- a/src/tests/relay/t_relay_mpi_io_silo.cpp
+++ b/src/tests/relay/t_relay_mpi_io_silo.cpp
@@ -1418,6 +1418,234 @@ TEST(conduit_relay_mpi_io_silo, missing_domain_mesh)
 }
 
 //-----------------------------------------------------------------------------
+// Tests this Overlink rule: Number of species per material within a set must
+// agree across domains
+// This test specifically tests if the final phase of MPI communication can
+// find the error.
+TEST(conduit_relay_mpi_io_silo, overlink_specset_rules)
+{
+    //
+    // Set Up MPI
+    //
+    int par_rank;
+    int par_size;
+    MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(comm, &par_rank);
+    MPI_Comm_size(comm, &par_size);
+
+    CONDUIT_INFO("Rank "
+                  << par_rank
+                  << " of "
+                  << par_size
+                  << " reporting");
+
+    //
+    // Create an example mesh.
+    //
+    Node save_mesh, load_mesh, info;
+    blueprint::mesh::examples::misc("specsets", 3, 3, 1, save_mesh.append());
+    save_mesh[0]["matsets"].rename_child("mesh", "matset");
+    save_mesh[0]["specsets"].rename_child("mesh", "specset");
+    save_mesh[0]["specsets"]["specset"]["matset"].set("matset");
+    save_mesh[0]["state"]["domain_id"] = par_rank;
+
+    if (par_rank == 0)
+    {
+        // nothing to do
+    }
+    else if (par_rank == 1)
+    {
+        save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+    }
+    else
+    {
+        // cyrus was wrong about 2 mpi ranks.
+        EXPECT_TRUE(false);
+    }
+
+    MPI_Barrier(comm);
+
+    // the faulty specset passes verify
+    EXPECT_TRUE(blueprint::mesh::verify(save_mesh, info));
+
+    Node write_opts;
+    write_opts["file_style"] = "overlink";
+
+    // We will first try to save with Overlink, which should fail.
+    // Then we will save with regular Silo which should succeed.
+    const std::string basename = "silo_save_overlink_specset_rules";
+    const std::string filename = basename + ".cycle_000100.root";
+    EXPECT_EQ(filename, relay::mpi::io::blueprint::generate_root_filename(save_mesh, basename, "silo", comm));
+
+    Node read_opts;
+    read_opts["matset_style"] = "multi_buffer_full";
+
+    remove_path_if_exists(filename);
+
+    MPI_Barrier(comm);
+
+    EXPECT_THROW(relay::mpi::io::silo::save_mesh(save_mesh, basename, write_opts, comm), conduit::Error);
+    
+    MPI_Barrier(comm);
+
+    // now save without overlink
+    relay::mpi::io::silo::save_mesh(save_mesh, basename, comm);
+
+    MPI_Barrier(comm);
+
+    relay::mpi::io::silo::load_mesh(filename, read_opts, load_mesh, comm);
+    EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+    // make changes to save mesh so the diff will pass
+    if (par_rank == 0)
+    {
+        // add bogus numbers to the specset; read behavior assumes this exists
+        save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+        float64_array spec3 = save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].value();
+        spec3[0] = 1.0; spec3[1] = 0.0; spec3[2] = 1.0; spec3[3] = 0.0;
+    }
+    silo_name_changer("mesh", save_mesh[0]);
+
+    std::cout << "par_rank " << par_rank << "  read # of children " << load_mesh.number_of_children();
+
+    EXPECT_EQ(load_mesh.number_of_children(), save_mesh.number_of_children());
+    NodeConstIterator l_itr = load_mesh.children();
+    NodeConstIterator s_itr = save_mesh.children();
+    while (l_itr.has_next())
+    {
+        const Node &l_curr = l_itr.next();
+        const Node &s_curr = s_itr.next();
+
+        EXPECT_FALSE(l_curr.diff(s_curr, info, CONDUIT_EPSILON, true));
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Tests this Overlink rule: Number of species per material within a set must
+// agree across domains
+// This test specifically tests if MPI communication can propagate an error on
+// one of the processors to the others.
+TEST(conduit_relay_mpi_io_silo, overlink_specset_rules2)
+{
+    //
+    // Set Up MPI
+    //
+    int par_rank;
+    int par_size;
+    MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(comm, &par_rank);
+    MPI_Comm_size(comm, &par_size);
+
+    CONDUIT_INFO("Rank "
+                  << par_rank
+                  << " of "
+                  << par_size
+                  << " reporting");
+
+    //
+    // Create an example mesh.
+    //
+    Node save_mesh, load_mesh, info;
+    blueprint::mesh::examples::misc("specsets", 3, 3, 1, save_mesh.append());
+    save_mesh[0]["matsets"].rename_child("mesh", "matset");
+    save_mesh[0]["specsets"].rename_child("mesh", "specset");
+    save_mesh[0]["specsets"]["specset"]["matset"].set("matset");
+    // save_mesh[0]["state"]["domain_id"] = par_rank;
+
+    // duplicate
+    save_mesh.append().set(save_mesh[0]);
+
+    // rank 0 has an extra species for a material on one of its domains
+    if (par_rank == 0)
+    {
+        save_mesh[0]["state"]["domain_id"] = 0;
+        save_mesh[1]["state"]["domain_id"] = 1;
+        save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+    }
+    else if (par_rank == 1)
+    {
+        save_mesh[0]["state"]["domain_id"] = 2;
+        save_mesh[1]["state"]["domain_id"] = 3;
+    }
+    else
+    {
+        // cyrus was wrong about 2 mpi ranks.
+        EXPECT_TRUE(false);
+    }
+
+    MPI_Barrier(comm);
+
+    // the faulty specset passes verify
+    EXPECT_TRUE(blueprint::mesh::verify(save_mesh, info));
+
+    Node write_opts;
+    write_opts["file_style"] = "overlink";
+
+    // We will first try to save with Overlink, which should fail.
+    // Then we will save with regular Silo which should succeed.
+    const std::string basename = "silo_save_overlink_specset_rules";
+    const std::string filename = basename + ".cycle_000100.root";
+    EXPECT_EQ(filename, relay::mpi::io::blueprint::generate_root_filename(save_mesh, basename, "silo", comm));
+
+    Node read_opts;
+    read_opts["matset_style"] = "multi_buffer_full";
+
+    remove_path_if_exists(filename);
+
+    MPI_Barrier(comm);
+
+    EXPECT_THROW(relay::mpi::io::silo::save_mesh(save_mesh, basename, write_opts, comm), conduit::Error);
+    
+    MPI_Barrier(comm);
+
+    // now save without overlink
+    relay::mpi::io::silo::save_mesh(save_mesh, basename, comm);
+
+    MPI_Barrier(comm);
+
+    relay::mpi::io::silo::load_mesh(filename, read_opts, load_mesh, comm);
+    EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+    // make changes to save mesh so the diff will pass
+    if (par_rank == 0)
+    {
+        // add bogus numbers to the specset; read behavior assumes this exists
+        save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+        float64_array spec3 = save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].value();
+        spec3[0] = 1.0; spec3[1] = 0.0; spec3[2] = 1.0; spec3[3] = 0.0;
+    }
+    else if (par_rank == 1)
+    {
+        // add bogus numbers to the specset; read behavior assumes this exists
+        save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+        float64_array spec30 = save_mesh[0]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].value();
+        spec30[0] = 1.0; spec30[1] = 0.0; spec30[2] = 1.0; spec30[3] = 0.0;
+
+        // add bogus numbers to the specset; read behavior assumes this exists
+        save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].set(DataType::float64(4));
+        float64_array spec31 = save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].value();
+        spec31[0] = 1.0; spec31[1] = 0.0; spec31[2] = 1.0; spec31[3] = 0.0;
+    }
+    for (index_t child = 0; child < save_mesh.number_of_children(); child ++)
+    {
+        silo_name_changer("mesh", save_mesh[child]);
+    }
+
+    std::cout << "par_rank " << par_rank << "  read # of children " << load_mesh.number_of_children();
+
+    EXPECT_EQ(load_mesh.number_of_children(), save_mesh.number_of_children());
+    NodeConstIterator l_itr = load_mesh.children();
+    NodeConstIterator s_itr = save_mesh.children();
+    while (l_itr.has_next())
+    {
+        const Node &l_curr = l_itr.next();
+        const Node &s_curr = s_itr.next();
+
+        EXPECT_FALSE(l_curr.diff(s_curr, info, CONDUIT_EPSILON, true));
+    }
+}
+
+//-----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     int result = 0;

--- a/src/tests/relay/t_relay_mpi_io_silo.cpp
+++ b/src/tests/relay/t_relay_mpi_io_silo.cpp
@@ -1550,7 +1550,6 @@ TEST(conduit_relay_mpi_io_silo, overlink_specset_rules2)
     save_mesh[0]["matsets"].rename_child("mesh", "matset");
     save_mesh[0]["specsets"].rename_child("mesh", "specset");
     save_mesh[0]["specsets"]["specset"]["matset"].set("matset");
-    // save_mesh[0]["state"]["domain_id"] = par_rank;
 
     // duplicate
     save_mesh.append().set(save_mesh[0]);
@@ -1626,6 +1625,117 @@ TEST(conduit_relay_mpi_io_silo, overlink_specset_rules2)
         float64_array spec31 = save_mesh[1]["specsets"]["specset"]["matset_values"]["mat2"]["spec3"].value();
         spec31[0] = 1.0; spec31[1] = 0.0; spec31[2] = 1.0; spec31[3] = 0.0;
     }
+    for (index_t child = 0; child < save_mesh.number_of_children(); child ++)
+    {
+        silo_name_changer("mesh", save_mesh[child]);
+    }
+
+    std::cout << "par_rank " << par_rank << "  read # of children " << load_mesh.number_of_children();
+
+    EXPECT_EQ(load_mesh.number_of_children(), save_mesh.number_of_children());
+    NodeConstIterator l_itr = load_mesh.children();
+    NodeConstIterator s_itr = save_mesh.children();
+    while (l_itr.has_next())
+    {
+        const Node &l_curr = l_itr.next();
+        const Node &s_curr = s_itr.next();
+
+        EXPECT_FALSE(l_curr.diff(s_curr, info, CONDUIT_EPSILON, true));
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Tests this Overlink rule: Number of species sets per domain must be the same
+TEST(conduit_relay_mpi_io_silo, overlink_specset_rules3)
+{
+    //
+    // Set Up MPI
+    //
+    int par_rank;
+    int par_size;
+    MPI_Comm comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(comm, &par_rank);
+    MPI_Comm_size(comm, &par_size);
+
+    CONDUIT_INFO("Rank "
+                  << par_rank
+                  << " of "
+                  << par_size
+                  << " reporting");
+
+    //
+    // Create an example mesh.
+    //
+    Node save_mesh, load_mesh, info;
+    blueprint::mesh::examples::misc("specsets", 3, 3, 1, save_mesh.append());
+    save_mesh[0]["matsets"].rename_child("mesh", "matset");
+    save_mesh[0]["specsets"].rename_child("mesh", "specset");
+    save_mesh[0]["specsets"]["specset"]["matset"].set("matset");
+
+    // duplicate
+    save_mesh.append().set(save_mesh[0]);
+
+    // rank 1 has an extra species set on one of its domains
+    if (par_rank == 0)
+    {
+        save_mesh[0]["state"]["domain_id"] = 0;
+        save_mesh[1]["state"]["domain_id"] = 1;
+    }
+    else if (par_rank == 1)
+    {
+        save_mesh[0]["state"]["domain_id"] = 2;
+        save_mesh[0]["specsets"]["specset2"].set(save_mesh[0]["specsets"]["specset"]);
+        save_mesh[1]["state"]["domain_id"] = 3;
+    }
+    else
+    {
+        // cyrus was wrong about 2 mpi ranks.
+        EXPECT_TRUE(false);
+    }
+
+    MPI_Barrier(comm);
+
+    // the faulty mesh passes verify
+    EXPECT_TRUE(blueprint::mesh::verify(save_mesh, info));
+
+    Node write_opts;
+    write_opts["file_style"] = "overlink";
+
+    // We will first try to save with Overlink, which should fail.
+    // Then we will save with regular Silo which should succeed.
+    const std::string basename = "silo_save_overlink_specset_rules";
+    const std::string filename = basename + ".cycle_000100.root";
+    EXPECT_EQ(filename, relay::mpi::io::blueprint::generate_root_filename(save_mesh, basename, "silo", comm));
+
+    Node read_opts;
+    read_opts["matset_style"] = "multi_buffer_full";
+
+    remove_path_if_exists(filename);
+
+    MPI_Barrier(comm);
+
+    EXPECT_THROW(relay::mpi::io::silo::save_mesh(save_mesh, basename, write_opts, comm), conduit::Error);
+    
+    MPI_Barrier(comm);
+
+    // now save without overlink
+    relay::mpi::io::silo::save_mesh(save_mesh, basename, comm);
+
+    MPI_Barrier(comm);
+
+    relay::mpi::io::silo::load_mesh(filename, read_opts, load_mesh, comm);
+    EXPECT_TRUE(blueprint::mesh::verify(load_mesh, info));
+
+    if (par_rank == 0)
+    {
+        load_mesh.print();
+    }
+    MPI_Barrier(comm);
+    if (par_rank == 1)
+    {
+        load_mesh.print();
+    }
+
     for (index_t child = 0; child < save_mesh.number_of_children(); child ++)
     {
         silo_name_changer("mesh", save_mesh[child]);


### PR DESCRIPTION
Overlink has several rules for writing species sets. We now enforce them.

Also adds species set utilities.
Fixes a bug preventing the writing of multiple species sets to Overlink.