### PR TITLE
Changes to topology::compute_mesh_info() that avoid SIGFPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added 2D block rotation support in `conduit::blueprint::mpi::mesh::to_polygonal()`.
 - Added field data to the `conduit::blueprint::mpi::mesh::to_polygonal()` transformation, including communication of vertex data on hanging nodes.
 - Added `conduit::blueprint::mesh::specset::to_multi_buffer_full()`, `conduit::blueprint::mesh::specset::to_uni_buffer_by_element()`, and `conduit::blueprint::mesh::specset::to_multi_buffer_by_material()`, which are converters that take species sets between the three supported species set/material set representations.
+- Fixed `conduit::blueprint::mesh::utils::topology::compute_mesh_info()` so it does not generate a floating point exception when processing 1-d meshes under the Intel 25 compiler with C++20.
 
 ### Changed
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2694,16 +2694,28 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
             // Compute diagonal info.
             if(nIds >= 4)
             {
-               polygonDiagInfo(e.element_ids);
+                polygonDiagInfo(e.element_ids);
+            }
+            else
+            {
+                // triangle - just use the longest edge length.
+                info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
+                info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
             }
         }
         else if(e.shape.dim == 1)
         {
             computeEdgeInfo(e.element_ids[0], e.element_ids[1]);
+
+            info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
+            info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
         }
         else if(e.shape.dim == 0)
         {
             computeEdgeInfo(e.element_ids[0], e.element_ids[0]);
+
+            info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
+            info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
         }
     });
 
@@ -2713,7 +2725,10 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
     info.maxEdgeLength = (info.maxEdgeLength > 0.) ? sqrt(info.maxEdgeLength) : 1.;
 
     // Initialize the diagonal lengths.
-    if(info.minDiagonalLength == std::numeric_limits<double>::max())
+    constexpr double dOffset = 100. * std::numeric_limits<double>::epsilon();
+    constexpr double upperLimit = std::numeric_limits<double>::max() - dOffset;
+    constexpr double lowerLimit = std::numeric_limits<double>::lowest() + dOffset;
+    if(info.minDiagonalLength >= upperLimit)
     {
        // The value has not been set. Use minEdgeLength.
        info.minDiagonalLength = info.minEdgeLength;
@@ -2722,7 +2737,7 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
     {
        info.minDiagonalLength = sqrt(info.minDiagonalLength);
     }
-    if(info.maxDiagonalLength == std::numeric_limits<double>::lowest())
+    if(info.maxDiagonalLength <= lowerLimit)
     {
        // The value has not been set. Use maxEdgeLength.
        info.maxDiagonalLength = info.maxEdgeLength;

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2700,30 +2700,16 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
             if(nIds >= 4)
             {
                 polygonDiagInfo(e.element_ids);
+                diagonalsSet = true;
             }
-            else
-            {
-                // triangle - just use the longest edge length.
-                info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
-                info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
-            }
-            diagonalsSet = true;
         }
         else if(e.shape.dim == 1)
         {
             computeEdgeInfo(e.element_ids[0], e.element_ids[1]);
-
-            info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
-            info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
-            diagonalsSet = true;
         }
         else if(e.shape.dim == 0)
         {
             computeEdgeInfo(e.element_ids[0], e.element_ids[0]);
-
-            info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
-            info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
-            diagonalsSet = true;
         }
     });
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2651,6 +2651,7 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
     // Iterate over all of the elements in the topology and compute the edge info
     // for each element.
     CONDUIT_ANNOTATE_MARK_BEGIN("edgeLength");
+    bool diagonalsSet = false;
     iterate_elements(n_topo, [&](const entity &e)
     {
         // NOTE: For shapes where we do not compute the diagonal info, we just
@@ -2665,7 +2666,10 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
                 {
                     computeEdgeInfo(faceIds[i], faceIds[(i + 1) % nIds]);
                 }
+                // Compute diagonals across the face (good enough)
+                polygonDiagInfo(faceIds);
             }
+            diagonalsSet = true;
         }
         else if(e.shape.dim == 3)
         {
@@ -2681,6 +2685,7 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
             }
             // Compute diagonal info.
             shapeDiagInfo(e.element_ids);
+            diagonalsSet = true;
         }
         else if(e.shape.dim == 2)
         {
@@ -2702,6 +2707,7 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
                 info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
                 info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
             }
+            diagonalsSet = true;
         }
         else if(e.shape.dim == 1)
         {
@@ -2709,6 +2715,7 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
 
             info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
             info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
+            diagonalsSet = true;
         }
         else if(e.shape.dim == 0)
         {
@@ -2716,6 +2723,7 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
 
             info.minDiagonalLength = std::min(info.minDiagonalLength, info.minEdgeLength);
             info.maxDiagonalLength = std::max(info.maxDiagonalLength, info.maxEdgeLength);
+            diagonalsSet = true;
         }
     });
 
@@ -2725,26 +2733,17 @@ topology::compute_mesh_info(const conduit::Node &n_topo, topology::MeshInfo &inf
     info.maxEdgeLength = (info.maxEdgeLength > 0.) ? sqrt(info.maxEdgeLength) : 1.;
 
     // Initialize the diagonal lengths.
-    constexpr double dOffset = 100. * std::numeric_limits<double>::epsilon();
-    constexpr double upperLimit = std::numeric_limits<double>::max() - dOffset;
-    constexpr double lowerLimit = std::numeric_limits<double>::lowest() + dOffset;
-    if(info.minDiagonalLength >= upperLimit)
+    if(diagonalsSet)
+    {
+       info.minDiagonalLength = sqrt(info.minDiagonalLength);
+       info.maxDiagonalLength = sqrt(info.maxDiagonalLength);
+    }
+    else
     {
        // The value has not been set. Use minEdgeLength.
        info.minDiagonalLength = info.minEdgeLength;
-    }
-    else
-    {
-       info.minDiagonalLength = sqrt(info.minDiagonalLength);
-    }
-    if(info.maxDiagonalLength <= lowerLimit)
-    {
        // The value has not been set. Use maxEdgeLength.
        info.maxDiagonalLength = info.maxEdgeLength;
-    }
-    else
-    {
-       info.maxDiagonalLength = sqrt(info.maxDiagonalLength);
     }
     CONDUIT_ANNOTATE_MARK_END("edgeLength");
 }


### PR DESCRIPTION
We observed that `compute_mesh_info()` could issue a SIGFPE on 1-d meshes and polyhedral meshes when using Intel 2025 with C++20. This happened when comparing doubles to `numeric_limits<double>::max()` and `numeric_limits<double>::lowest()`.

This PR:
 * Changes the comparison so it is based on a bool
 * Computes diagonal values for polyhedral zones (face diagonals)