### PR TITLE
Fix a bug in Node::swap() that affected find_reference_node().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added `set` methods to `DataAccessor` that take `DataArray`s and `DataAccessor`s.
 - Added optional device execution support via RAJA and Umpire.
 - Added `conduit_bin_yaml` protocol case to `Node::load()` and `Node::save()`. Also added `conduit_bin_json`, which does the same thing as `conduit_bin` (creates a json schema file to go with the `conduit_bin` file).
+- Fixed an issue in `Node::swap()` or `Node::move()` where child nodes moved to a new parent did not point to their new parent. This caused operations that call `Node::parent()` to traverse upwards to malfunction.
 
 #### Blueprint
 - Finished `bent_multi_grid_amr` mesh by adding adjacency sets between spatially adjacent domains at the same level of refinement.

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -440,7 +440,7 @@ find_reference_node(const Node &node, const std::string &ref_key)
 
     if(node.has_child(ref_key))
     {
-        const std::string &ref_value = node.fetch(ref_key).as_string();
+        const std::string ref_value = node.fetch(ref_key).as_string();
 
         const Node *traverse_node = node.parent();
         while(traverse_node != NULL)

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -8960,7 +8960,6 @@ Node::swap(Node &n_b)
         // find index in parent schema
         Schema *b_parent_schema = schema_b->parent();
         index_t idx = b_parent_schema->child_index(schema_b);
-
         // as we swap, we need to make sure the parent schema is updated
         if(idx < 0)
         {
@@ -8994,7 +8993,11 @@ Node::swap(Node &n_b)
     std::swap(m_allocator_id,n_b.m_allocator_id);
     // this should be an efficient O(1)
     std::swap(m_children,n_b.m_children);
-
+    // Make the children point to their new parent.
+    for(conduit::index_t i = 0; i < number_of_children(); i++)
+    {
+      m_children[i]->m_parent = this;
+    }
 }
 
 

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -8998,6 +8998,10 @@ Node::swap(Node &n_b)
     {
       m_children[i]->m_parent = this;
     }
+    for(conduit::index_t i = 0; i < n_b.number_of_children(); i++)
+    {
+      n_b.m_children[i]->m_parent = &n_b;
+    }
 }
 
 

--- a/src/tests/blueprint/t_blueprint_mesh_utils.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_utils.cpp
@@ -25,7 +25,7 @@
 using namespace conduit;
 using namespace conduit::utils;
 using namespace generate;
-
+#if 0
 //---------------------------------------------------------------------------
 /**
  @brief Save the node to an HDF5 compatible with VisIt or the
@@ -1326,4 +1326,99 @@ topologies:
     EXPECT_NEAR(info.maxExtents[2], 6., eps);
     EXPECT_NEAR(info.minEdgeLength, 0.1, eps);
     EXPECT_NEAR(info.maxEdgeLength, 4., eps);
+}
+#endif
+//-----------------------------------------------------------------------------
+void make_mesh(conduit::Node &mesh)
+{
+  const char *yaml = R"(
+mesh:
+  coordsets: 
+    coords: 
+      type: explicit
+      values: 
+        x: [0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0]
+        y: [0.0, 0.0, 0.0, 1., 1., 1., 2., 2., 2.]
+  topologies: 
+    topo: 
+      type: unstructured
+      coordset: coords
+      elements:
+        shape: quad
+        connectivity: [0,1,4,3, 1,2,5,4, 3,4,7,6, 4,5,8,7]
+        sizes: [4,4,4,4]
+        offsets: [0,4,8,12]
+  matsets: 
+    mat: 
+      topology: topo
+      material_map: 
+        mat0: 0
+        mat1: 1
+        mat2: 2
+      material_ids: [0, 1, 2, 1, 2]
+      volume_fractions: [1., 1., 1., 0.5, 0.5]
+      sizes: [1, 1, 1, 2]
+      offsets: [0, 1, 2, 3]
+      indices: [0, 1, 2, 4, 5]
+  fields: 
+    elems: 
+      topology: topo
+      association: element
+      values: [0, 1, 2, 3]
+  state: 
+    cycle: 0
+    time: 0.0
+    domain_id: 0
+)";
+
+    // "Read" the mesh.
+    mesh.parse(yaml);
+}
+
+void test_find_reference_node(const conduit::Node &mesh)
+{
+    namespace bputils = conduit::blueprint::mesh::utils;
+    const conduit::Node *fr_coordset = bputils::find_reference_node(mesh.fetch_existing("topologies/topo"), "coordset");
+    const conduit::Node *coordset = mesh.fetch_ptr("coordsets/coords");
+    EXPECT_TRUE(coordset != nullptr);
+    EXPECT_EQ(fr_coordset, coordset);
+
+    const conduit::Node *fr_topo = bputils::find_reference_node(mesh.fetch_existing("matsets/mat"), "topology");
+    const conduit::Node *topo = mesh.fetch_ptr("topologies/topo");
+    EXPECT_TRUE(fr_topo != nullptr);
+    EXPECT_EQ(fr_topo, topo);
+
+    const conduit::Node *fr_topo2 = bputils::find_reference_node(mesh.fetch_existing("fields/elems"), "topology");
+    EXPECT_TRUE(fr_topo2 != nullptr);
+    EXPECT_EQ(fr_topo2, topo);
+}
+
+TEST(conduit_blueprint_mesh_utils, find_reference_node)
+{
+  conduit::Node whole;
+  make_mesh(whole);
+
+  test_find_reference_node(whole["mesh"]);
+}
+
+TEST(conduit_blueprint_mesh_utils, find_reference_node_set)
+{
+  conduit::Node whole;
+  make_mesh(whole);
+
+  // Use find_reference_node with a copy.
+  conduit::Node mesh;
+  mesh.set(whole["mesh"]);
+  test_find_reference_node(mesh);
+}
+
+TEST(conduit_blueprint_mesh_utils, find_reference_node_move)
+{
+  conduit::Node whole;
+  make_mesh(whole);
+  
+  // Use find_reference_node with a moved mesh.
+  conduit::Node mesh;
+  mesh.move(whole["mesh"]);
+  test_find_reference_node(mesh);
 }

--- a/src/tests/blueprint/t_blueprint_mesh_utils.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_utils.cpp
@@ -25,7 +25,7 @@
 using namespace conduit;
 using namespace conduit::utils;
 using namespace generate;
-#if 0
+
 //---------------------------------------------------------------------------
 /**
  @brief Save the node to an HDF5 compatible with VisIt or the
@@ -1327,7 +1327,7 @@ topologies:
     EXPECT_NEAR(info.minEdgeLength, 0.1, eps);
     EXPECT_NEAR(info.maxEdgeLength, 4., eps);
 }
-#endif
+
 //-----------------------------------------------------------------------------
 void make_mesh(conduit::Node &mesh)
 {
@@ -1375,6 +1375,7 @@ mesh:
     mesh.parse(yaml);
 }
 
+//-----------------------------------------------------------------------------
 void test_find_reference_node(const conduit::Node &mesh)
 {
     namespace bputils = conduit::blueprint::mesh::utils;
@@ -1382,43 +1383,71 @@ void test_find_reference_node(const conduit::Node &mesh)
     const conduit::Node *coordset = mesh.fetch_ptr("coordsets/coords");
     EXPECT_TRUE(coordset != nullptr);
     EXPECT_EQ(fr_coordset, coordset);
+    EXPECT_TRUE(fr_coordset->parent() != nullptr);
 
     const conduit::Node *fr_topo = bputils::find_reference_node(mesh.fetch_existing("matsets/mat"), "topology");
     const conduit::Node *topo = mesh.fetch_ptr("topologies/topo");
     EXPECT_TRUE(fr_topo != nullptr);
     EXPECT_EQ(fr_topo, topo);
+    EXPECT_TRUE(fr_topo->parent() != nullptr);
 
     const conduit::Node *fr_topo2 = bputils::find_reference_node(mesh.fetch_existing("fields/elems"), "topology");
     EXPECT_TRUE(fr_topo2 != nullptr);
     EXPECT_EQ(fr_topo2, topo);
+    EXPECT_TRUE(fr_topo2->parent() != nullptr);
 }
 
+//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_utils, find_reference_node)
 {
-  conduit::Node whole;
-  make_mesh(whole);
+    conduit::Node whole;
+    make_mesh(whole);
 
-  test_find_reference_node(whole["mesh"]);
+    test_find_reference_node(whole["mesh"]);
 }
 
+//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_utils, find_reference_node_set)
 {
-  conduit::Node whole;
-  make_mesh(whole);
+    conduit::Node whole;
+    make_mesh(whole);
 
-  // Use find_reference_node with a copy.
-  conduit::Node mesh;
-  mesh.set(whole["mesh"]);
-  test_find_reference_node(mesh);
+    conduit::Node mesh;
+    mesh.set(whole["mesh"]);
+
+    // Test find_reference_node with a copy.
+    test_find_reference_node(mesh);
 }
 
+//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_utils, find_reference_node_move)
 {
-  conduit::Node whole;
-  make_mesh(whole);
+    conduit::Node whole;
+    make_mesh(whole);
   
-  // Use find_reference_node with a moved mesh.
-  conduit::Node mesh;
-  mesh.move(whole["mesh"]);
-  test_find_reference_node(mesh);
+    conduit::Node mesh;
+    mesh.move(whole["mesh"]);
+
+    // Make sure the mesh node still has no parent.
+    EXPECT_EQ(mesh.parent(), nullptr);
+
+    // Make sure the paths to the children are right
+    EXPECT_EQ(mesh["coordsets"].path(), "coordsets");
+    EXPECT_EQ(mesh["topologies"].path(), "topologies");
+    EXPECT_EQ(mesh["matsets"].path(), "matsets");
+    EXPECT_EQ(mesh["fields"].path(), "fields");
+
+    // Make sure the children do not point to the old parent.
+    EXPECT_NE(mesh["topologies"].parent(), whole.fetch_ptr("mesh"));
+    EXPECT_NE(mesh["coordsets"].parent(), whole.fetch_ptr("mesh"));
+    EXPECT_NE(mesh["matsets"].parent(), whole.fetch_ptr("mesh"));
+    EXPECT_NE(mesh["fields"].parent(), whole.fetch_ptr("mesh"));
+
+    // Make sure they have the same parent.
+    EXPECT_EQ(mesh["topologies"].parent(), mesh["coordsets"].parent());
+    EXPECT_EQ(mesh["topologies"].parent(), mesh["matsets"].parent());
+    EXPECT_EQ(mesh["topologies"].parent(), mesh["fields"].parent());
+
+    // Test find_reference_node with a moved mesh.
+    test_find_reference_node(mesh);
 }


### PR DESCRIPTION
This PR resolves #1485

* Changed `Node::swap()` so it makes children that were swapped point at their new parents.
* Added tests for swap/move and `find_reference_node()`.