### PR TITLE
Matset Accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added `conduit::blueprint::mesh::specset::to_multi_buffer_full()`, `conduit::blueprint::mesh::specset::to_uni_buffer_by_element()`, and `conduit::blueprint::mesh::specset::to_multi_buffer_by_material()`, which are converters that take species sets between the three supported species set/material set representations.
 - Added `conduit::blueprint::mesh::specset::is_multi_buffer()`, `conduit::blueprint::mesh::specset::is_uni_buffer()`, `conduit::blueprint::mesh::specset::get_num_species_for_material()`, and `conduit::blueprint::mesh::specset::get_material_names()`, which are simple species set utilities.
 - Fixed `conduit::blueprint::mesh::utils::topology::compute_mesh_info()` so it does not generate a floating point exception when processing 1-d meshes under the Intel 25 compiler with C++20.
+- Added `conduit::blueprint::mesh::matset::MatsetAccessor`, a class for fetching material set/field/species set data independent of material set layout. It provides methods that fetch data for zone id and material id pairs (or zone id, material id, species id triples).
 
 ### Changed
 

--- a/src/libs/blueprint/CMakeLists.txt
+++ b/src/libs/blueprint/CMakeLists.txt
@@ -44,6 +44,7 @@ set(blueprint_headers
     conduit_blueprint_mesh_examples_venn.hpp
     conduit_blueprint_mesh_flatten.hpp
     conduit_blueprint_mesh_kdtree.hpp
+    conduit_blueprint_mesh_matset_accessor.hpp
     conduit_blueprint_mesh_topology_metadata.hpp
     conduit_blueprint_mesh_utils.hpp
     conduit_blueprint_mesh_utils_iterate_elements.hpp
@@ -81,6 +82,7 @@ set(blueprint_sources
     conduit_blueprint_mesh_utils.cpp
     conduit_blueprint_mesh_topology_metadata.cpp
     conduit_blueprint_mesh_matset_xforms.cpp
+    conduit_blueprint_mesh_matset_accessor.cpp
     conduit_blueprint_mesh_examples.cpp
     conduit_blueprint_mesh_examples_julia.cpp
     conduit_blueprint_mesh_examples_venn.cpp

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.cpp
@@ -56,8 +56,8 @@ MatsetAccessor::MatsetAccessor()
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
    m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
-   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
-   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nmats_for_elem(&MatsetAccessor::get_error_nmats_for_elem),
+   m_get_nelems_for_mat(&MatsetAccessor::get_error_nelems_for_mat),
    m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
 {
     // empty
@@ -70,8 +70,8 @@ MatsetAccessor::MatsetAccessor(const Node &matset)
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
    m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
-   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
-   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nmats_for_elem(&MatsetAccessor::get_error_nmats_for_elem),
+   m_get_nelems_for_mat(&MatsetAccessor::get_error_nelems_for_mat),
    m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
 {
     init(matset, nullptr, nullptr);
@@ -85,8 +85,8 @@ MatsetAccessor::MatsetAccessor(const Node &matset,
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
    m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
-   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
-   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nmats_for_elem(&MatsetAccessor::get_error_nmats_for_elem),
+   m_get_nelems_for_mat(&MatsetAccessor::get_error_nelems_for_mat),
    m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
 {
     if (specset_or_field.has_child("topology"))
@@ -112,8 +112,8 @@ MatsetAccessor::MatsetAccessor(const Node &matset,
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
    m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
-   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
-   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nmats_for_elem(&MatsetAccessor::get_error_nmats_for_elem),
+   m_get_nelems_for_mat(&MatsetAccessor::get_error_nelems_for_mat),
    m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
 {
     init(matset, &field, &specset);
@@ -126,12 +126,12 @@ MatsetAccessor::MatsetAccessor(const MatsetAccessor &m_acc)
   m_get_vol_frac(m_acc.m_get_vol_frac),
   m_get_mset_val(m_acc.m_get_mset_val),
   m_get_mass_frac(m_acc.m_get_mass_frac),
-  m_get_nmats_for_zone(m_acc.m_get_nmats_for_zone),
-  m_get_nzones_for_mat(m_acc.m_get_nzones_for_mat),
+  m_get_nmats_for_elem(m_acc.m_get_nmats_for_elem),
+  m_get_nelems_for_mat(m_acc.m_get_nelems_for_mat),
   m_get_nspec_for_mat(m_acc.m_get_nspec_for_mat),
   m_is_uni_buffer(m_acc.m_is_uni_buffer),
   m_is_element_dominant(m_acc.m_is_element_dominant),
-  m_num_zones(m_acc.m_num_zones),
+  m_num_elems(m_acc.m_num_elems),
   m_num_mats(m_acc.m_num_mats),
   m_has_field(m_acc.m_has_field),
   m_has_specset(m_acc.m_has_specset),
@@ -163,12 +163,12 @@ MatsetAccessor::operator=(const MatsetAccessor &m_acc)
         m_get_vol_frac = m_acc.m_get_vol_frac;
         m_get_mset_val = m_acc.m_get_mset_val;
         m_get_mass_frac = m_acc.m_get_mass_frac;
-        m_get_nmats_for_zone = m_acc.m_get_nmats_for_zone;
-        m_get_nzones_for_mat = m_acc.m_get_nzones_for_mat;
+        m_get_nmats_for_elem = m_acc.m_get_nmats_for_elem;
+        m_get_nelems_for_mat = m_acc.m_get_nelems_for_mat;
         m_get_nspec_for_mat = m_acc.m_get_nspec_for_mat;
         m_is_uni_buffer = m_acc.m_is_uni_buffer;
         m_is_element_dominant = m_acc.m_is_element_dominant;
-        m_num_zones = m_acc.m_num_zones;
+        m_num_elems = m_acc.m_num_elems;
         m_num_mats = m_acc.m_num_mats;
         m_has_field = m_acc.m_has_field;
         m_has_specset = m_acc.m_has_specset;
@@ -230,7 +230,7 @@ MatsetAccessor::init(const Node &matset,
     m_is_uni_buffer       = blueprint::mesh::matset::is_uni_buffer(matset);
     m_is_element_dominant = blueprint::mesh::matset::is_element_dominant(matset);
 
-    m_num_zones = count_zones_from_matset(matset);
+    m_num_elems = count_zones_from_matset(matset);
     m_num_mats  = count_materials_from_matset(matset);
 
     Node material_map;
@@ -256,12 +256,12 @@ MatsetAccessor::init(const Node &matset,
 
                 // For sparse by element material sets, the matset accessor uses the following
                 // ranges:
-                //     0 <= zone_idx < num zones
-                //     0 <= mat_idx < num mats for zone zone_idx
-                //     0 <= spec_idx < num species for material mat_idx in zone zone_idx
-                // To know which species mass fraction to fetch for a given (zone_idx, mat_idx, spec_idx),
+                //     0 <= elem_idx < num elems
+                //     0 <= mat_idx < num mats for element elem_idx
+                //     0 <= spec_idx < num species for material mat_idx in element elem_idx
+                // To know which species mass fraction to fetch for a given (elem_idx, mat_idx, spec_idx),
                 // we need to know the number of species contained in all of the materials that
-                // appear in zone zone_idx. Consider this example:
+                // appear in element elem_idx. Consider this example:
 
                 // matset: 
                 //   topology: "topo"
@@ -295,8 +295,8 @@ MatsetAccessor::init(const Node &matset,
                 //   offsets:       [0,   1,   2,   3                                      ]
 
                 // Let's say I want to extract the mass fraction for
-                // (zone_idx, mat_idx, spec_idx) = (3, 1, 1).
-                // Here is the relevant information for zone 3 (remember that zones start at 0):
+                // (elem_idx, mat_idx, spec_idx) = (3, 1, 1).
+                // Here is the relevant information for element 3 (remember that elements start at 0):
 
                 // material information:
                 //   volume_fractions: [0.33, 0.33, 0.33]
@@ -308,16 +308,16 @@ MatsetAccessor::init(const Node &matset,
                 //   size:           7
                 //   offset:         3
 
-                // We have three materials in zone 3, with material ids 1, 2, and 3.
-                // We have 7 species mass fractions in zone 3.
+                // We have three materials in element 3, with material ids 1, 2, and 3.
+                // We have 7 species mass fractions in element 3.
 
-                // We are looking to get data for (zone_idx, mat_idx, spec_idx) = (3, 1, 1), so
+                // We are looking to get data for (elem_idx, mat_idx, spec_idx) = (3, 1, 1), so
                 // now we want to extract the species data for mat_idx = 1. Because this is a
-                // sparse by element material set, 0 <= mat_idx < num mats for zone zone_idx, so
+                // sparse by element material set, 0 <= mat_idx < num mats for element elem_idx, so
                 // mat_idx = 1 corresponds in this case to material id 2.
 
                 // I can extract the volume fraction and material id for mat_idx = 1, but I cannot
-                // get the species value of 0.45 for (zone_idx, mat_idx, spec_idx) = (3, 1, 1)
+                // get the species value of 0.45 for (elem_idx, mat_idx, spec_idx) = (3, 1, 1)
                 // without first knowing how many species there are in the current material and all
                 // the materials that came before mat_idx = 1. I need to know how many species there
                 // were for mat_idx = 0 in this case.
@@ -337,11 +337,11 @@ MatsetAccessor::init(const Node &matset,
 
                 // Our approach then is to add two new data arrays that can help us, the
                 // number of material species and the number of material species offsets.
-                // These arrays will encode information that is relevant to each zone's materials.
+                // These arrays will encode information that is relevant to each element's materials.
                 //    "nmatspec" will record the number of material species for material mat_idx
-                //    in zone zone_idx.
+                //    in element elem_idx.
                 //    "nmatspec_offsets" will record the number of material species seen thus far
-                //    in the current zone zone_idx up to the current material mat_idx.
+                //    in the current element elem_idx up to the current material mat_idx.
                 // The easiest way to explain is via example:
 
                 // matset: 
@@ -379,9 +379,9 @@ MatsetAccessor::init(const Node &matset,
 
                 // These arrays tell us the answers we are looking for. Let us proceed by taking
                 // another look at our earlier example, mass fraction extraction for 
-                // (zone_idx, mat_idx, spec_idx) = (3, 1, 1).
+                // (elem_idx, mat_idx, spec_idx) = (3, 1, 1).
 
-                // Here is now the relevant information for zone 3 (remember that zones start at 0):
+                // Here is now the relevant information for element 3 (remember that elements start at 0):
 
                 // material information:
                 //   volume_fractions: [0.33, 0.33, 0.33]
@@ -405,9 +405,9 @@ MatsetAccessor::init(const Node &matset,
                 // So in the matset values array, we need to go to index 2 (species offset) to get
                 // the species data for this material. Additionally, there are num species = 2 values
                 // to read for this material. So now we can move another level down the hierarchy
-                // and only look at information for zone_idx = 3, mat_idx = 1:
+                // and only look at information for elem_idx = 3, mat_idx = 1:
 
-                // Here is the relevant information for zone_idx 3, mat_idx 1: (remember that both start at 0):
+                // Here is the relevant information for elem_idx 3, mat_idx 1: (remember that both start at 0):
                 // material information:
                 //   volume_fraction: 0.33
                 //   material_id:     2  
@@ -417,7 +417,7 @@ MatsetAccessor::init(const Node &matset,
                 //   matset_values: [0.55, 0.45]
 
                 // Now we can finally extract data for spec_idx = 1, and arrive at our requested
-                // mass fraction for (zone_idx, mat_idx, spec_idx) = (3, 1, 1), 0.45.
+                // mass fraction for (elem_idx, mat_idx, spec_idx) = (3, 1, 1), 0.45.
 
                 // The following code below creates the nmatspec and nmatspec_offsets arrays.
                 // We pay a price at the start when creating these arrays, but we enable quick
@@ -447,13 +447,13 @@ MatsetAccessor::init(const Node &matset,
                 }
 
                 // now we can fill the arrays using the information we've collected
-                for (index_t zone_idx = 0; zone_idx < m_num_zones; zone_idx ++)
+                for (index_t elem_idx = 0; elem_idx < m_num_elems; elem_idx ++)
                 {
-                    const index_t num_mats_in_zone = m_sbe_o2m_idx.size(zone_idx);
+                    const index_t num_mats_in_elem = m_sbe_o2m_idx.size(elem_idx);
                     index_t nmatspec_offset = 0;
-                    for (index_t mat_idx = 0; mat_idx < num_mats_in_zone; mat_idx ++)
+                    for (index_t mat_idx = 0; mat_idx < num_mats_in_elem; mat_idx ++)
                     {
-                        const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+                        const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
                         const index_t mat_id = m_sbe_material_ids[data_index];
                         const index_t nmatspec_for_mat = mat_id_to_nmatspec.at(mat_id);
 
@@ -472,7 +472,7 @@ MatsetAccessor::init(const Node &matset,
             {
                 m_get_mset_val = &MatsetAccessor::get_sbe_mset_val;
             }
-            m_get_nmats_for_zone = &MatsetAccessor::get_sbe_nmats_for_zone;
+            m_get_nmats_for_elem = &MatsetAccessor::get_sbe_nmats_for_elem;
 
             if (nullptr != specset)
             {
@@ -600,7 +600,7 @@ MatsetAccessor::init(const Node &matset,
             {
                 m_get_mset_val = &MatsetAccessor::get_sbm_mset_val;
             }
-            m_get_nzones_for_mat = &MatsetAccessor::get_sbm_nzones_for_mat;
+            m_get_nelems_for_mat = &MatsetAccessor::get_sbm_nelems_for_mat;
             if (nullptr != specset)
             {
                 m_get_mass_frac = &MatsetAccessor::get_sbm_mass_frac;
@@ -617,49 +617,49 @@ MatsetAccessor::init(const Node &matset,
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_full_mat_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_full_mat_id(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     return m_multi_mat_idx_map_acc[mat_idx];
 }
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_full_elem_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_full_elem_id(const index_t elem_idx, const index_t mat_idx) const
 {
     (void) mat_idx;
-    return zone_idx;
+    return elem_idx;
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_full_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_full_vol_frac(const index_t elem_idx, const index_t mat_idx) const
 {
-    return m_multi_vol_fracs[mat_idx][zone_idx];
+    return m_multi_vol_fracs[mat_idx][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_full_mset_val(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_full_mset_val(const index_t elem_idx, const index_t mat_idx) const
 {
-    return m_multi_mset_vals[mat_idx][zone_idx];
+    return m_multi_mset_vals[mat_idx][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_full_mass_frac(const index_t zone_idx,
+MatsetAccessor::get_full_mass_frac(const index_t elem_idx,
                                    const index_t mat_idx,
                                    const index_t spec_idx) const
 {
     const index_t spec_data_index = m_nmatspec_offsets_acc[mat_idx] + spec_idx;
-    return m_multi_mass_fracs[spec_data_index][zone_idx];
+    return m_multi_mass_fracs[spec_data_index][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 index_t
-MatsetAccessor::get_full_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_full_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     return m_nmatspec_acc[mat_idx];
 }
 
@@ -670,55 +670,55 @@ MatsetAccessor::get_full_nspec_for_mat(const index_t zone_idx, const index_t mat
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_sbm_mat_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbm_mat_id(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     return m_multi_mat_idx_map_acc[mat_idx];
 }
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_sbm_elem_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbm_elem_id(const index_t elem_idx, const index_t mat_idx) const
 {
-    return m_sbm_elem_ids[mat_idx][zone_idx];
+    return m_sbm_elem_ids[mat_idx][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_sbm_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbm_vol_frac(const index_t elem_idx, const index_t mat_idx) const
 {
-    return m_multi_vol_fracs[mat_idx][zone_idx];
+    return m_multi_vol_fracs[mat_idx][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_sbm_mset_val(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbm_mset_val(const index_t elem_idx, const index_t mat_idx) const
 {
-    return m_multi_mset_vals[mat_idx][zone_idx];
+    return m_multi_mset_vals[mat_idx][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_sbm_mass_frac(const index_t zone_idx,
+MatsetAccessor::get_sbm_mass_frac(const index_t elem_idx,
                                   const index_t mat_idx,
                                   const index_t spec_idx) const
 {
     const index_t spec_data_index = m_nmatspec_offsets_acc[mat_idx] + spec_idx;
-    return m_multi_mass_fracs[spec_data_index][zone_idx];
+    return m_multi_mass_fracs[spec_data_index][elem_idx];
 }
 
 //-----------------------------------------------------------------------------
 index_t
-MatsetAccessor::get_sbm_nzones_for_mat(const index_t mat_idx) const
+MatsetAccessor::get_sbm_nelems_for_mat(const index_t mat_idx) const
 {
     return m_sbm_elem_ids[mat_idx].number_of_elements();
 }
 
 //-----------------------------------------------------------------------------
 index_t
-MatsetAccessor::get_sbm_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbm_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     return m_nmatspec_acc[mat_idx];
 }
 
@@ -729,46 +729,46 @@ MatsetAccessor::get_sbm_nspec_for_mat(const index_t zone_idx, const index_t mat_
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_sbe_mat_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbe_mat_id(const index_t elem_idx, const index_t mat_idx) const
 {
-    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
     return m_sbe_material_ids[data_index];
 }
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_sbe_elem_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbe_elem_id(const index_t elem_idx, const index_t mat_idx) const
 {
     (void) mat_idx;
-    return zone_idx;
+    return elem_idx;
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_sbe_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbe_vol_frac(const index_t elem_idx, const index_t mat_idx) const
 {
-    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
     return m_sbe_vol_fracs[data_index];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_sbe_mset_val(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbe_mset_val(const index_t elem_idx, const index_t mat_idx) const
 {
-    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
     return m_sbe_mset_vals[data_index];
 }
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_sbe_mass_frac(const index_t zone_idx,
+MatsetAccessor::get_sbe_mass_frac(const index_t elem_idx,
                                   const index_t mat_idx,
                                   const index_t spec_idx) const
 {
-    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
     const index_t nmatspec_offset = m_nmatspec_offsets_acc[data_index];
 
-    // We need an index that is between 0 and the number of species in this zone.
+    // We need an index that is between 0 and the number of species in this elem.
     // The way to calculate this is to add out num material species offset
     // with the current species value index, which ranges between 0 and the
     // number of species for this material.
@@ -778,7 +778,7 @@ MatsetAccessor::get_sbe_mass_frac(const index_t zone_idx,
     // relation with our element id and the local species index, which is
     // an index into the number of species in this element. The result is
     // an index into the "matset_values", which store species mass fractions.
-    const index_t spec_mf_idx = m_sbe_specset_o2m_idx.index(zone_idx, local_spec_id);
+    const index_t spec_mf_idx = m_sbe_specset_o2m_idx.index(elem_idx, local_spec_id);
 
     // fetch the species mass fraction
     return m_sbe_mass_fracs[spec_mf_idx];
@@ -786,16 +786,16 @@ MatsetAccessor::get_sbe_mass_frac(const index_t zone_idx,
 
 //-----------------------------------------------------------------------------
 index_t
-MatsetAccessor::get_sbe_nmats_for_zone(const index_t zone_idx) const
+MatsetAccessor::get_sbe_nmats_for_elem(const index_t elem_idx) const
 {
-    return m_sbe_o2m_idx.size(zone_idx);
+    return m_sbe_o2m_idx.size(elem_idx);
 }
 
 //-----------------------------------------------------------------------------
 index_t
-MatsetAccessor::get_sbe_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_sbe_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const
 {
-    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
     return m_nmatspec_acc[data_index];
 }
 
@@ -806,9 +806,9 @@ MatsetAccessor::get_sbe_nspec_for_mat(const index_t zone_idx, const index_t mat_
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_error_mat_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_error_mat_id(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     (void) mat_idx;
     CONDUIT_ERROR("Impossible to fetch mat_id from material set.");
     return 0;
@@ -816,9 +816,9 @@ MatsetAccessor::get_error_mat_id(const index_t zone_idx, const index_t mat_idx) 
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_error_elem_id(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_error_elem_id(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     (void) mat_idx;
     CONDUIT_ERROR("Impossible to fetch elem_id from material set.");
     return 0;
@@ -826,9 +826,9 @@ MatsetAccessor::get_error_elem_id(const index_t zone_idx, const index_t mat_idx)
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_error_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_error_vol_frac(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     (void) mat_idx;
     CONDUIT_ERROR("Impossible to fetch vol_frac from material set.");
     return 0.0;
@@ -836,9 +836,9 @@ MatsetAccessor::get_error_vol_frac(const index_t zone_idx, const index_t mat_idx
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_error_mset_val(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_error_mset_val(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     (void) mat_idx;
     CONDUIT_ERROR("Impossible to fetch mset_val from field.");
     return 0.0;
@@ -846,11 +846,11 @@ MatsetAccessor::get_error_mset_val(const index_t zone_idx, const index_t mat_idx
 
 //-----------------------------------------------------------------------------
 float64 
-MatsetAccessor::get_error_mass_frac(const index_t zone_idx,
+MatsetAccessor::get_error_mass_frac(const index_t elem_idx,
                                     const index_t mat_idx,
                                     const index_t spec_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     (void) mat_idx;
     (void) spec_idx;
     CONDUIT_ERROR("Impossible to fetch mass_frac from specset.");
@@ -859,34 +859,34 @@ MatsetAccessor::get_error_mass_frac(const index_t zone_idx,
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_error_nmats_for_zone(const index_t zone_idx) const
+MatsetAccessor::get_error_nmats_for_elem(const index_t elem_idx) const
 {
-    (void) zone_idx;
-    CONDUIT_ERROR("Impossible to fetch number of materials for zone from "
+    (void) elem_idx;
+    CONDUIT_ERROR("Impossible to fetch number of materials for elem from "
                   "non-sparse by element material set.");
     return 0;
 }
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_error_nzones_for_mat(const index_t mat_idx) const
+MatsetAccessor::get_error_nelems_for_mat(const index_t mat_idx) const
 {
     (void) mat_idx;
-    CONDUIT_ERROR("Impossible to fetch number of zones for a material from "
+    CONDUIT_ERROR("Impossible to fetch number of elems for a material from "
                   "non-sparse by material material set.");
     return 0;
 }
 
 //-----------------------------------------------------------------------------
 index_t 
-MatsetAccessor::get_error_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+MatsetAccessor::get_error_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const
 {
-    (void) zone_idx;
+    (void) elem_idx;
     (void) mat_idx;
     // CONDUIT_ERROR("Impossible to fetch number of species for a material from "
     //               "specset.");
     // no need to error in this case, as we wish to support looping over 
-    // zones/materials and then species in the case that species
+    // elems/materials and then species in the case that species
     // do not exist. Then loops can be more general with minimal performance
     // costs.
     return 0;

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.cpp
@@ -1,0 +1,924 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_blueprint_mesh_matset_accessor.cpp
+///
+//-----------------------------------------------------------------------------
+#include <sstream>
+
+#include "conduit_blueprint_mesh_matset_accessor.hpp"
+
+#include "conduit_error.hpp"
+#include "conduit_utils.hpp"
+#include "conduit_blueprint_mesh.hpp"
+
+//-----------------------------------------------------------------------------
+// -- begin conduit:: --
+//-----------------------------------------------------------------------------
+namespace conduit
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint --
+//-----------------------------------------------------------------------------
+namespace blueprint
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::mesh --
+//-----------------------------------------------------------------------------
+namespace mesh
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::mesh::matset --
+//-----------------------------------------------------------------------------
+namespace matset
+{
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// MatsetAccessor
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+// MatsetAccessor Construction and Destruction
+//-----------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------//
+MatsetAccessor::MatsetAccessor()
+ : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_elem_id(&MatsetAccessor::get_error_elem_id),
+   m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
+   m_get_mset_val(&MatsetAccessor::get_error_mset_val),
+   m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
+   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
+   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
+{
+    // empty
+}
+
+//---------------------------------------------------------------------------//
+MatsetAccessor::MatsetAccessor(const Node &matset)
+ : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_elem_id(&MatsetAccessor::get_error_elem_id),
+   m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
+   m_get_mset_val(&MatsetAccessor::get_error_mset_val),
+   m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
+   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
+   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
+{
+    init(matset, nullptr, nullptr);
+}
+
+//---------------------------------------------------------------------------//
+MatsetAccessor::MatsetAccessor(const Node &matset,
+                               const Node &specset_or_field)
+ : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_elem_id(&MatsetAccessor::get_error_elem_id),
+   m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
+   m_get_mset_val(&MatsetAccessor::get_error_mset_val),
+   m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
+   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
+   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
+{
+    if (specset_or_field.has_child("topology"))
+    {
+        // then it is a field
+        const Node &field = specset_or_field;
+        init(matset, &field, nullptr);
+    }
+    else
+    {
+        // then it is a specset
+        const Node &specset = specset_or_field;
+        init(matset, nullptr, &specset);
+    }
+}
+
+//---------------------------------------------------------------------------//
+MatsetAccessor::MatsetAccessor(const Node &matset,
+                               const Node &field,
+                               const Node &specset)
+ : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_elem_id(&MatsetAccessor::get_error_elem_id),
+   m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
+   m_get_mset_val(&MatsetAccessor::get_error_mset_val),
+   m_get_mass_frac(&MatsetAccessor::get_error_mass_frac),
+   m_get_nmats_for_zone(&MatsetAccessor::get_error_nmats_for_zone),
+   m_get_nzones_for_mat(&MatsetAccessor::get_error_nzones_for_mat),
+   m_get_nspec_for_mat(&MatsetAccessor::get_error_nspec_for_mat)
+{
+    init(matset, &field, &specset);
+}   
+
+//---------------------------------------------------------------------------//
+MatsetAccessor::MatsetAccessor(const MatsetAccessor &m_acc)
+: m_get_mat_id(m_acc.m_get_mat_id),
+  m_get_elem_id(m_acc.m_get_elem_id),
+  m_get_vol_frac(m_acc.m_get_vol_frac),
+  m_get_mset_val(m_acc.m_get_mset_val),
+  m_get_mass_frac(m_acc.m_get_mass_frac),
+  m_get_nmats_for_zone(m_acc.m_get_nmats_for_zone),
+  m_get_nzones_for_mat(m_acc.m_get_nzones_for_mat),
+  m_get_nspec_for_mat(m_acc.m_get_nspec_for_mat),
+  m_is_uni_buffer(m_acc.m_is_uni_buffer),
+  m_is_element_dominant(m_acc.m_is_element_dominant),
+  m_num_zones(m_acc.m_num_zones),
+  m_num_mats(m_acc.m_num_mats),
+  m_has_field(m_acc.m_has_field),
+  m_has_specset(m_acc.m_has_specset),
+  m_nmatspec(m_acc.m_nmatspec),
+  m_nmatspec_acc(m_acc.m_nmatspec_acc),
+  m_nmatspec_offsets_acc(m_acc.m_nmatspec_offsets_acc),
+  m_multi_vol_fracs(m_acc.m_multi_vol_fracs),
+  m_multi_mset_vals(m_acc.m_multi_mset_vals),
+  m_multi_mat_idx_map(m_acc.m_multi_mat_idx_map),
+  m_multi_mat_idx_map_acc(m_acc.m_multi_mat_idx_map_acc),
+  m_multi_mass_fracs(m_acc.m_multi_mass_fracs),
+  m_sbm_elem_ids(m_acc.m_sbm_elem_ids),
+  m_sbe_material_ids(m_acc.m_sbe_material_ids),
+  m_sbe_vol_fracs(m_acc.m_sbe_vol_fracs),
+  m_sbe_mset_vals(m_acc.m_sbe_mset_vals),
+  m_sbe_o2m_idx(m_acc.m_sbe_o2m_idx),
+  m_sbe_mass_fracs(m_acc.m_sbe_mass_fracs),
+  m_sbe_specset_o2m_idx(m_acc.m_sbe_specset_o2m_idx)
+{ }
+
+//---------------------------------------------------------------------------//
+MatsetAccessor &
+MatsetAccessor::operator=(const MatsetAccessor &m_acc)
+{
+    if (this != &m_acc)
+    {
+        m_get_mat_id = m_acc.m_get_mat_id;
+        m_get_elem_id = m_acc.m_get_elem_id;
+        m_get_vol_frac = m_acc.m_get_vol_frac;
+        m_get_mset_val = m_acc.m_get_mset_val;
+        m_get_mass_frac = m_acc.m_get_mass_frac;
+        m_get_nmats_for_zone = m_acc.m_get_nmats_for_zone;
+        m_get_nzones_for_mat = m_acc.m_get_nzones_for_mat;
+        m_get_nspec_for_mat = m_acc.m_get_nspec_for_mat;
+        m_is_uni_buffer = m_acc.m_is_uni_buffer;
+        m_is_element_dominant = m_acc.m_is_element_dominant;
+        m_num_zones = m_acc.m_num_zones;
+        m_num_mats = m_acc.m_num_mats;
+        m_has_field = m_acc.m_has_field;
+        m_has_specset = m_acc.m_has_specset;
+        m_nmatspec = m_acc.m_nmatspec;
+        m_nmatspec_acc = m_acc.m_nmatspec_acc;
+        m_nmatspec_offsets_acc = m_acc.m_nmatspec_offsets_acc;
+        m_multi_vol_fracs = m_acc.m_multi_vol_fracs;
+        m_multi_mset_vals = m_acc.m_multi_mset_vals;
+        m_multi_mat_idx_map = m_acc.m_multi_mat_idx_map;
+        m_multi_mat_idx_map_acc = m_acc.m_multi_mat_idx_map_acc;
+        m_multi_mass_fracs = m_acc.m_multi_mass_fracs;
+        m_sbm_elem_ids = m_acc.m_sbm_elem_ids;
+        m_sbe_material_ids = m_acc.m_sbe_material_ids;
+        m_sbe_vol_fracs = m_acc.m_sbe_vol_fracs;
+        m_sbe_mset_vals = m_acc.m_sbe_mset_vals;
+        m_sbe_o2m_idx = m_acc.m_sbe_o2m_idx;
+        m_sbe_mass_fracs = m_acc.m_sbe_mass_fracs;
+        m_sbe_specset_o2m_idx = m_acc.m_sbe_specset_o2m_idx;
+    }
+    return *this;
+}
+
+//-----------------------------------------------------------------------------
+void
+MatsetAccessor::init(const Node &matset,
+                     const Node *field,
+                     const Node *specset)
+{
+    // extra seat belts here
+    if (! matset.dtype().is_object())
+    {
+        CONDUIT_ERROR("blueprint::mesh::matset::MatsetAccessor"
+                      " passed matset node must be a valid matset tree.");
+    }
+
+    m_has_field = false;
+    m_has_specset = false;
+
+    if (nullptr != field)
+    {
+        if (! (*field).dtype().is_object())
+        {
+            CONDUIT_ERROR("blueprint::mesh::matset::MatsetAccessor"
+                          " passed field node must be a valid field tree.");
+        }
+
+        m_has_field = true;
+    }
+    if (nullptr != specset)
+    {
+        if (! (*specset).dtype().is_object())
+        {
+            CONDUIT_ERROR("blueprint::mesh::matset::MatsetAccessor"
+                          " passed specset node must be a valid specset tree.");
+        }
+        m_has_specset = true;
+    }
+
+    m_is_uni_buffer       = blueprint::mesh::matset::is_uni_buffer(matset);
+    m_is_element_dominant = blueprint::mesh::matset::is_element_dominant(matset);
+
+    m_num_zones = count_zones_from_matset(matset);
+    m_num_mats  = count_materials_from_matset(matset);
+
+    Node material_map;
+    create_or_reuse_material_map(matset, material_map);
+
+    if (m_is_uni_buffer)
+    {
+        // uni-buffer by element (sparse by element)
+        if (m_is_element_dominant)
+        {
+            // set our accessors
+            m_sbe_material_ids = matset["material_ids"].value();
+            m_sbe_vol_fracs = matset["volume_fractions"].value();
+            m_sbe_o2m_idx = o2mrelation::O2MIndex(matset);
+            if (nullptr != field)
+            {
+                m_sbe_mset_vals = (*field)["matset_values"].value();
+            }
+            if (nullptr != specset)
+            {
+                m_sbe_mass_fracs = (*specset)["matset_values"].value();
+                m_sbe_specset_o2m_idx = o2mrelation::O2MIndex(*specset);
+
+                // For sparse by element material sets, the matset accessor uses the following
+                // ranges:
+                //     0 <= zone_idx < num zones
+                //     0 <= mat_idx < num mats for zone zone_idx
+                //     0 <= spec_idx < num species for material mat_idx in zone zone_idx
+                // To know which species mass fraction to fetch for a given (zone_idx, mat_idx, spec_idx),
+                // we need to know the number of species contained in all of the materials that
+                // appear in zone zone_idx. Consider this example:
+
+                // matset: 
+                //   topology: "topo"
+                //   material_map: 
+                //     circle_a: 1
+                //     circle_b: 2
+                //     circle_c: 3
+                //     background: 4
+                //   volume_fractions: [1.0, 1.0, 1.0, 0.33, 0.33, 0.33]
+                //   material_ids:     [4,   4,   4,   1,    2,    3   ]
+                //   sizes:            [1,   1,   1,   3               ]
+                //   offsets:          [0,   1,   2,   3               ]
+
+                // specset: 
+                //   matset: "matset"
+                //   species_names: 
+                //     background: 
+                //       bg_spec1: 
+                //     circle_a: 
+                //       a_spec1: 
+                //       a_spec2: 
+                //     circle_b: 
+                //       b_spec1: 
+                //       b_spec2: 
+                //     circle_c: 
+                //       c_spec1: 
+                //       c_spec2: 
+                //       c_spec3: 
+                //   matset_values: [1.0, 1.0, 1.0, 0.4, 0.6, 0.55, 0.45, 0.5, 0.375, 0.125]
+                //   sizes:         [1,   1,   1,   7                                      ]
+                //   offsets:       [0,   1,   2,   3                                      ]
+
+                // Let's say I want to extract the mass fraction for
+                // (zone_idx, mat_idx, spec_idx) = (3, 1, 1).
+                // Here is the relevant information for zone 3 (remember that zones start at 0):
+
+                // material information:
+                //   volume_fractions: [0.33, 0.33, 0.33]
+                //   material_ids:     [1,    2,    3   ]
+                //   size:              3
+                //   offset:            3
+                // species information:
+                //   matset_values: [0.4, 0.6, 0.55, 0.45, 0.5, 0.375, 0.125]
+                //   size:           7
+                //   offset:         3
+
+                // We have three materials in zone 3, with material ids 1, 2, and 3.
+                // We have 7 species mass fractions in zone 3.
+
+                // We are looking to get data for (zone_idx, mat_idx, spec_idx) = (3, 1, 1), so
+                // now we want to extract the species data for mat_idx = 1. Because this is a
+                // sparse by element material set, 0 <= mat_idx < num mats for zone zone_idx, so
+                // mat_idx = 1 corresponds in this case to material id 2.
+
+                // I can extract the volume fraction and material id for mat_idx = 1, but I cannot
+                // get the species value of 0.45 for (zone_idx, mat_idx, spec_idx) = (3, 1, 1)
+                // without first knowing how many species there are in the current material and all
+                // the materials that came before mat_idx = 1. I need to know how many species there
+                // were for mat_idx = 0 in this case.
+
+                // One approach would be as follows:
+                //    1. Fetch material ids for the current and previous materials
+                //          "current" material mat_idx = 1 -> material id = 2
+                //          "previous" material mat_idx = 0 -> material id = 1
+                //       Our intention is to somehow look up the number of material species
+                //       for each of these materials.
+                //    2. But how to get the number of material species? We won't have access to the 
+                //       material map or species names during execution, just pointers to data arrays.
+                //       Due to the fact that material ids need not go from 0 to the number of materials
+                //       minus 1, it is very convoluted to create a mapping scheme from material ids
+                //       to the number of material species that can be flattened into data arrays.
+                //       So this approach is not workable.
+
+                // Our approach then is to add two new data arrays that can help us, the
+                // number of material species and the number of material species offsets.
+                // These arrays will encode information that is relevant to each zone's materials.
+                //    "nmatspec" will record the number of material species for material mat_idx
+                //    in zone zone_idx.
+                //    "nmatspec_offsets" will record the number of material species seen thus far
+                //    in the current zone zone_idx up to the current material mat_idx.
+                // The easiest way to explain is via example:
+
+                // matset: 
+                //   topology: "topo"
+                //   material_map: 
+                //     circle_a: 1
+                //     circle_b: 2
+                //     circle_c: 3
+                //     background: 4
+                //   volume_fractions: [1.0, 1.0, 1.0, 0.33, 0.33, 0.33]
+                //   material_ids:     [4,   4,   4,   1,    2,    3   ]
+                //***nmatspec:*********[1,   1,   1,   2,    2,    3   ]****************
+                //***nmatspec_offsets:*[0,   0,   0,   0,    2,    4   ]****************
+                //   sizes:            [1,   1,   1,   3               ]
+                //   offsets:          [0,   1,   2,   3               ]
+
+                // specset: 
+                //   matset: "matset"
+                //   species_names: 
+                //     background: 
+                //       bg_spec1: 
+                //     circle_a: 
+                //       a_spec1: 
+                //       a_spec2: 
+                //     circle_b: 
+                //       b_spec1: 
+                //       b_spec2: 
+                //     circle_c: 
+                //       c_spec1: 
+                //       c_spec2: 
+                //       c_spec3: 
+                //   matset_values: [1.0, 1.0, 1.0, 0.4, 0.6, 0.55, 0.45, 0.5, 0.375, 0.125]
+                //   sizes:         [1,   1,   1,   7                                      ]
+                //   offsets:       [0,   1,   2,   3                                      ]
+
+                // These arrays tell us the answers we are looking for. Let us proceed by taking
+                // another look at our earlier example, mass fraction extraction for 
+                // (zone_idx, mat_idx, spec_idx) = (3, 1, 1).
+
+                // Here is now the relevant information for zone 3 (remember that zones start at 0):
+
+                // material information:
+                //   volume_fractions: [0.33, 0.33, 0.33]
+                //   material_ids:     [1,    2,    3   ]
+                //***nmatspec:*********[2,    2,    3   ]*********
+                //***nmatspec_offsets:*[0,    2,    4   ]*********
+                //   size:              3
+                //   offset:            3 // irrelevant now since we have used the offset to get to the right place
+                // species information:
+                //   matset_values: [0.4, 0.6, 0.55, 0.45, 0.5, 0.375, 0.125]
+                //   size:           7
+                //   offset:         3 // irrelevant now since we have used the offset to get to the right place
+
+                // Now we have what we need to interpret the species values appropriately.
+                // For mat_idx = 1, we see that we are dealing with
+                //    volume fraction = 0.33
+                //    material id     = 2
+                //    num species     = 2
+                //    species offset  = 2
+
+                // So in the matset values array, we need to go to index 2 (species offset) to get
+                // the species data for this material. Additionally, there are num species = 2 values
+                // to read for this material. So now we can move another level down the hierarchy
+                // and only look at information for zone_idx = 3, mat_idx = 1:
+
+                // Here is the relevant information for zone_idx 3, mat_idx 1: (remember that both start at 0):
+                // material information:
+                //   volume_fraction: 0.33
+                //   material_id:     2  
+                //***nmatspec:********2**
+                //***nmatspec_offset:*2** // irrelevant now since we have used the offset to get to the right place
+                // species information:
+                //   matset_values: [0.55, 0.45]
+
+                // Now we can finally extract data for spec_idx = 1, and arrive at our requested
+                // mass fraction for (zone_idx, mat_idx, spec_idx) = (3, 1, 1), 0.45.
+
+                // The following code below creates the nmatspec and nmatspec_offsets arrays.
+                // We pay a price at the start when creating these arrays, but we enable quick
+                // access of species mass fraction data.
+
+                const index_t num_vol_fracs = matset["volume_fractions"].dtype().number_of_elements();
+                m_nmatspec["nmatspec"].set(DataType::index_t(num_vol_fracs));
+                m_nmatspec_acc = m_nmatspec["nmatspec"].value();
+                m_nmatspec["nmatspec_offsets"].set(DataType::index_t(num_vol_fracs));
+                m_nmatspec_offsets_acc = m_nmatspec["nmatspec_offsets"].value();
+
+                // create a map from material id to nmatspec
+                std::map<index_t, index_t> mat_id_to_nmatspec;
+                for (index_t mat_idx = 0; mat_idx < m_num_mats; mat_idx ++)
+                {
+                    const Node &matmap_entry = material_map.child(mat_idx);
+                    const std::string matname = matmap_entry.name();
+                    const index_t mat_id = matmap_entry.to_index_t();
+
+                    index_t nmatspec = 0;
+                    if ((*specset)["species_names"].has_child(matname))
+                    {
+                        nmatspec = (*specset)["species_names"][matname].number_of_children();
+                    }
+
+                    mat_id_to_nmatspec[mat_id] = nmatspec;
+                }
+
+                // now we can fill the arrays using the information we've collected
+                for (index_t zone_idx = 0; zone_idx < m_num_zones; zone_idx ++)
+                {
+                    const index_t num_mats_in_zone = m_sbe_o2m_idx.size(zone_idx);
+                    index_t nmatspec_offset = 0;
+                    for (index_t mat_idx = 0; mat_idx < num_mats_in_zone; mat_idx ++)
+                    {
+                        const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+                        const index_t mat_id = m_sbe_material_ids[data_index];
+                        const index_t nmatspec_for_mat = mat_id_to_nmatspec.at(mat_id);
+
+                        m_nmatspec_acc.set(data_index, nmatspec_for_mat);
+                        m_nmatspec_offsets_acc.set(data_index, nmatspec_offset);
+                        nmatspec_offset += nmatspec_for_mat;
+                    }
+                }
+            }
+
+            // set our fetch methods
+            m_get_mat_id   = &MatsetAccessor::get_sbe_mat_id;
+            m_get_elem_id  = &MatsetAccessor::get_sbe_elem_id;
+            m_get_vol_frac = &MatsetAccessor::get_sbe_vol_frac;
+            if (nullptr != field)
+            {
+                m_get_mset_val = &MatsetAccessor::get_sbe_mset_val;
+            }
+            m_get_nmats_for_zone = &MatsetAccessor::get_sbe_nmats_for_zone;
+
+            if (nullptr != specset)
+            {
+                m_get_mass_frac = &MatsetAccessor::get_sbe_mass_frac;
+                m_get_nspec_for_mat = &MatsetAccessor::get_sbe_nspec_for_mat;
+            }
+        }
+        // uni-buffer by material (unsupported)
+        else
+        {
+            CONDUIT_ERROR("conduit::blueprint::mesh::matset::MatsetAccessor "
+                          "uni-buffer by material matset is currently unsupported.");
+        }
+    }
+    else // multi-buffer case
+    {
+        // multi-buffer material index map
+        // we save an indirection array from material order id (the order materials appear
+        // in the matset) to actual material id. Not all material sets are numbered from
+        // 0 to N-1, so we must support this case.
+        m_multi_mat_idx_map.set(DataType::index_t(m_num_mats));
+        m_multi_mat_idx_map_acc = m_multi_mat_idx_map.value();
+
+        if (nullptr != specset)
+        {
+            // number of material species map
+            // we save an array from the material order id (the order materials appear
+            // in the matset) to the number of species for that material.
+            m_nmatspec["nmatspec"].set(DataType::index_t(m_num_mats));
+            m_nmatspec_acc = m_nmatspec["nmatspec"].value();
+
+            // we save an additional offsets array so we can quickly get the index
+            // of our desired species array since we are flattening:
+            // e.g.
+            //    mat1:
+            //       spec1:
+            //       spec2:
+            //       spec3:
+            //    mat2:
+            //       spec4:
+            //       spec5:
+            // becomes
+            //    [spec1, spec2, spec3, spec4, spec5]
+            // then the nmatspec array is
+            //    [3, 2]
+            // and the nmatspec offsets array is
+            //    [0, 3]
+            m_nmatspec["nmatspec_offsets"].set(DataType::index_t(m_num_mats));
+            m_nmatspec_offsets_acc = m_nmatspec["nmatspec_offsets"].value();
+        }
+
+        index_t nmatspec_offset = 0;
+
+        // now we loop over materials, saving relevant information as we go
+        // we are careful to loop over materials in the order of the matset,
+        // as fields and specsets need not have the same material order
+        for (index_t mat_idx = 0; mat_idx < m_num_mats; mat_idx ++)
+        {
+            const Node &matmap_entry = material_map.child(mat_idx);
+            const std::string matname = matmap_entry.name();
+            const index_t mat_id = matmap_entry.to_index_t();
+
+            // save material map entry
+            m_multi_mat_idx_map_acc.set(mat_idx, mat_id);
+
+            // save volume fraction array
+            m_multi_vol_fracs.push_back(matset["volume_fractions"][matname].value());
+
+            if (nullptr != field)
+            {
+                // save matset values array
+                m_multi_mset_vals.push_back((*field)["matset_values"][matname].value());
+            }
+
+            if (nullptr != specset)
+            {
+                // save nmatspec value
+                index_t nmatspec = 0;
+                if ((*specset)["matset_values"].has_child(matname))
+                {
+                    nmatspec = (*specset)["matset_values"][matname].number_of_children();
+                }
+                m_nmatspec_acc.set(mat_idx, nmatspec);
+
+                // save nmatspec offset value
+                m_nmatspec_offsets_acc.set(mat_idx, nmatspec_offset);
+                nmatspec_offset += nmatspec;
+
+                for (index_t spec_idx = 0; spec_idx < nmatspec; spec_idx ++)
+                {
+                    m_multi_mass_fracs.push_back((*specset)["matset_values"][matname].child(spec_idx).value());
+                }
+            }
+        }
+
+        // multi-buffer by element (full)
+        if (m_is_element_dominant)
+        {
+            m_get_mat_id   = &MatsetAccessor::get_full_mat_id;
+            m_get_elem_id  = &MatsetAccessor::get_full_elem_id;
+            m_get_vol_frac = &MatsetAccessor::get_full_vol_frac;
+            if (nullptr != field)
+            {
+                m_get_mset_val = &MatsetAccessor::get_full_mset_val;
+            }
+            if (nullptr != specset)
+            {
+                m_get_mass_frac = &MatsetAccessor::get_full_mass_frac;
+                m_get_nspec_for_mat = &MatsetAccessor::get_full_nspec_for_mat;
+            }
+        }
+        // multi-buffer by material (sparse by material)
+        else
+        {
+            for (index_t mat_idx = 0; mat_idx < m_num_mats; mat_idx ++)
+            {
+                const std::string matname = material_map.child(mat_idx).name();
+                m_sbm_elem_ids.push_back(matset["element_ids"][matname].value());
+            }
+
+            m_get_mat_id   = &MatsetAccessor::get_sbm_mat_id;
+            m_get_elem_id  = &MatsetAccessor::get_sbm_elem_id;
+            m_get_vol_frac = &MatsetAccessor::get_sbm_vol_frac;
+            if (nullptr != field)
+            {
+                m_get_mset_val = &MatsetAccessor::get_sbm_mset_val;
+            }
+            m_get_nzones_for_mat = &MatsetAccessor::get_sbm_nzones_for_mat;
+            if (nullptr != specset)
+            {
+                m_get_mass_frac = &MatsetAccessor::get_sbm_mass_frac;
+                m_get_nspec_for_mat = &MatsetAccessor::get_sbm_nspec_for_mat;
+            }
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+//
+// -- getters for multi-buffer by element (full) matsets --
+//
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_full_mat_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    return m_multi_mat_idx_map_acc[mat_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_full_elem_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) mat_idx;
+    return zone_idx;
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_full_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+{
+    return m_multi_vol_fracs[mat_idx][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_full_mset_val(const index_t zone_idx, const index_t mat_idx) const
+{
+    return m_multi_mset_vals[mat_idx][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_full_mass_frac(const index_t zone_idx,
+                                   const index_t mat_idx,
+                                   const index_t spec_idx) const
+{
+    const index_t spec_data_index = m_nmatspec_offsets_acc[mat_idx] + spec_idx;
+    return m_multi_mass_fracs[spec_data_index][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t
+MatsetAccessor::get_full_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    return m_nmatspec_acc[mat_idx];
+}
+
+//-----------------------------------------------------------------------------
+//
+// -- getters for multi-buffer by material (sparse by material) matsets --
+//
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_sbm_mat_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    return m_multi_mat_idx_map_acc[mat_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_sbm_elem_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    return m_sbm_elem_ids[mat_idx][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_sbm_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+{
+    return m_multi_vol_fracs[mat_idx][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_sbm_mset_val(const index_t zone_idx, const index_t mat_idx) const
+{
+    return m_multi_mset_vals[mat_idx][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_sbm_mass_frac(const index_t zone_idx,
+                                  const index_t mat_idx,
+                                  const index_t spec_idx) const
+{
+    const index_t spec_data_index = m_nmatspec_offsets_acc[mat_idx] + spec_idx;
+    return m_multi_mass_fracs[spec_data_index][zone_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t
+MatsetAccessor::get_sbm_nzones_for_mat(const index_t mat_idx) const
+{
+    return m_sbm_elem_ids[mat_idx].number_of_elements();
+}
+
+//-----------------------------------------------------------------------------
+index_t
+MatsetAccessor::get_sbm_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    return m_nmatspec_acc[mat_idx];
+}
+
+//-----------------------------------------------------------------------------
+//
+// -- getters for uni-buffer by element (sparse by element) matsets --
+//
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_sbe_mat_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    return m_sbe_material_ids[data_index];
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_sbe_elem_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) mat_idx;
+    return zone_idx;
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_sbe_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+{
+    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    return m_sbe_vol_fracs[data_index];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_sbe_mset_val(const index_t zone_idx, const index_t mat_idx) const
+{
+    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    return m_sbe_mset_vals[data_index];
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_sbe_mass_frac(const index_t zone_idx,
+                                  const index_t mat_idx,
+                                  const index_t spec_idx) const
+{
+    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    const index_t nmatspec_offset = m_nmatspec_offsets_acc[data_index];
+
+    // We need an index that is between 0 and the number of species in this zone.
+    // The way to calculate this is to add out num material species offset
+    // with the current species value index, which ranges between 0 and the
+    // number of species for this material.
+    const index_t local_spec_id = nmatspec_offset + spec_idx;
+
+    // Now we can provide the one (element id) to many (species in element)
+    // relation with our element id and the local species index, which is
+    // an index into the number of species in this element. The result is
+    // an index into the "matset_values", which store species mass fractions.
+    const index_t spec_mf_idx = m_sbe_specset_o2m_idx.index(zone_idx, local_spec_id);
+
+    // fetch the species mass fraction
+    return m_sbe_mass_fracs[spec_mf_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t
+MatsetAccessor::get_sbe_nmats_for_zone(const index_t zone_idx) const
+{
+    return m_sbe_o2m_idx.size(zone_idx);
+}
+
+//-----------------------------------------------------------------------------
+index_t
+MatsetAccessor::get_sbe_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+{
+    const index_t data_index = m_sbe_o2m_idx.index(zone_idx, mat_idx);
+    return m_nmatspec_acc[data_index];
+}
+
+//-----------------------------------------------------------------------------
+//
+// -- getters for the error case --
+//
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_error_mat_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    (void) mat_idx;
+    CONDUIT_ERROR("Impossible to fetch mat_id from material set.");
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_error_elem_id(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    (void) mat_idx;
+    CONDUIT_ERROR("Impossible to fetch elem_id from material set.");
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_error_vol_frac(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    (void) mat_idx;
+    CONDUIT_ERROR("Impossible to fetch vol_frac from material set.");
+    return 0.0;
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_error_mset_val(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    (void) mat_idx;
+    CONDUIT_ERROR("Impossible to fetch mset_val from field.");
+    return 0.0;
+}
+
+//-----------------------------------------------------------------------------
+float64 
+MatsetAccessor::get_error_mass_frac(const index_t zone_idx,
+                                    const index_t mat_idx,
+                                    const index_t spec_idx) const
+{
+    (void) zone_idx;
+    (void) mat_idx;
+    (void) spec_idx;
+    CONDUIT_ERROR("Impossible to fetch mass_frac from specset.");
+    return 0.0;
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_error_nmats_for_zone(const index_t zone_idx) const
+{
+    (void) zone_idx;
+    CONDUIT_ERROR("Impossible to fetch number of materials for zone from "
+                  "non-sparse by element material set.");
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_error_nzones_for_mat(const index_t mat_idx) const
+{
+    (void) mat_idx;
+    CONDUIT_ERROR("Impossible to fetch number of zones for a material from "
+                  "non-sparse by material material set.");
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_error_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const
+{
+    (void) zone_idx;
+    (void) mat_idx;
+    // CONDUIT_ERROR("Impossible to fetch number of species for a material from "
+    //               "specset.");
+    // no need to error in this case, as we wish to support looping over 
+    // zones/materials and then species in the case that species
+    // do not exist. Then loops can be more general with minimal performance
+    // costs.
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// End MatsetAccessor
+//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::mesh::matset --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::mesh --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit:: --
+//-----------------------------------------------------------------------------
+
+

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.hpp
@@ -71,11 +71,11 @@ public:
 //-----------------------------------------------------------------------------
 using GetMatIdPtr        = index_t (MatsetAccessor::*)(index_t, index_t) const;
 using GetElemIdPtr       = index_t (MatsetAccessor::*)(index_t, index_t) const;
-using GetVolFracPtr      = double  (MatsetAccessor::*)(index_t, index_t) const;
-using GetMsetValPtr      = double  (MatsetAccessor::*)(index_t, index_t) const;
-using GetMassFracPtr     = double  (MatsetAccessor::*)(index_t, index_t, index_t) const;
-using GetNMatsForZonePtr = index_t (MatsetAccessor::*)(index_t) const;
-using GetNZonesForMatPtr = index_t (MatsetAccessor::*)(index_t) const;
+using GetVolFracPtr      = float64 (MatsetAccessor::*)(index_t, index_t) const;
+using GetMsetValPtr      = float64 (MatsetAccessor::*)(index_t, index_t) const;
+using GetMassFracPtr     = float64 (MatsetAccessor::*)(index_t, index_t, index_t) const;
+using GetNMatsForElemPtr = index_t (MatsetAccessor::*)(index_t) const;
+using GetNElemsForMatPtr = index_t (MatsetAccessor::*)(index_t) const;
 using GetNMatSpecPtr     = index_t (MatsetAccessor::*)(index_t, index_t) const;
 
 //-----------------------------------------------------------------------------
@@ -145,9 +145,9 @@ using GetNMatSpecPtr     = index_t (MatsetAccessor::*)(index_t, index_t) const;
     }
 
     inline
-    index_t     num_zones() const
+    index_t     num_elems() const
     {
-        return m_num_zones;
+        return m_num_elems;
     }
 
     inline
@@ -161,62 +161,62 @@ using GetNMatSpecPtr     = index_t (MatsetAccessor::*)(index_t, index_t) const;
 //-----------------------------------------------------------------------------
     // use this for elem-dom sparse matsets
     inline
-    index_t     num_mats_for_zone(const index_t zone_idx) const
+    index_t     num_mats_for_elem(const index_t elem_idx) const
     {
-        return (this->*m_get_nmats_for_zone)(zone_idx);
+        return (this->*m_get_nmats_for_elem)(elem_idx);
     }
 
     // use this for mat-dom sparse matsets
     inline
-    index_t     num_zones_for_mat(const index_t mat_idx) const
+    index_t     num_elems_for_mat(const index_t mat_idx) const
     {
-        return (this->*m_get_nzones_for_mat)(mat_idx);
+        return (this->*m_get_nelems_for_mat)(mat_idx);
     }
 
     inline
-    index_t     num_spec_for_mat(const index_t zone_idx,
+    index_t     num_spec_for_mat(const index_t elem_idx,
                                  const index_t mat_idx) const
     {
-        return (this->*m_get_nspec_for_mat)(zone_idx, mat_idx);
+        return (this->*m_get_nspec_for_mat)(elem_idx, mat_idx);
     }
 
 //-----------------------------------------------------------------------------
 /// Retrieve data
 //-----------------------------------------------------------------------------
     inline
-    index_t     get_mat_id(const index_t zone_idx,
+    index_t     get_mat_id(const index_t elem_idx,
                            const index_t mat_idx) const
     {
-        return (this->*m_get_mat_id)(zone_idx, mat_idx);
+        return (this->*m_get_mat_id)(elem_idx, mat_idx);
     }
 
     inline
-    index_t     get_elem_id(const index_t zone_idx,
+    index_t     get_elem_id(const index_t elem_idx,
                             const index_t mat_idx) const
     {
-        return (this->*m_get_elem_id)(zone_idx, mat_idx);
+        return (this->*m_get_elem_id)(elem_idx, mat_idx);
     }
 
     inline
-    float64     get_vol_frac(const index_t zone_idx,
+    float64     get_vol_frac(const index_t elem_idx,
                              const index_t mat_idx) const
     {
-        return (this->*m_get_vol_frac)(zone_idx, mat_idx);
+        return (this->*m_get_vol_frac)(elem_idx, mat_idx);
     }
 
     inline
-    float64     get_mset_val(const index_t zone_idx,
+    float64     get_mset_val(const index_t elem_idx,
                              const index_t mat_idx) const
     {
-        return (this->*m_get_mset_val)(zone_idx, mat_idx);
+        return (this->*m_get_mset_val)(elem_idx, mat_idx);
     }
 
     inline
-    float64     get_mass_frac(const index_t zone_idx,
+    float64     get_mass_frac(const index_t elem_idx,
                               const index_t mat_idx,
                               const index_t spec_idx) const
     {
-        return (this->*m_get_mass_frac)(zone_idx, mat_idx, spec_idx);
+        return (this->*m_get_mass_frac)(elem_idx, mat_idx, spec_idx);
     }
 
 private:
@@ -242,57 +242,57 @@ private:
     //
 
     // multi-buffer by element (full)
-    // 0 <= zone_idx < num zones
+    // 0 <= elem_idx < num elems
     // 0 <= mat_idx < num mats
     // 0 <= spec_idx < num species for material mat_idx
-    index_t get_full_mat_id(const index_t zone_idx, const index_t mat_idx) const;
-    index_t get_full_elem_id(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_full_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_full_mset_val(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_full_mass_frac(const index_t zone_idx,
+    index_t get_full_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_full_elem_id(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_full_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_full_mset_val(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_full_mass_frac(const index_t elem_idx,
                                const index_t mat_idx,
                                const index_t spec_idx) const;
     // omitted because this method is used for knowing how many
     // materials to iterate over in a sparse representation
-    // index_t get_full_nmats_for_zone(const index_t zone_idx) const;
+    // index_t get_full_nmats_for_elem(const index_t elem_idx) const;
     // omitted because this method is used for knowing how many
-    // zones to iterate over in a sparse representation
-    // index_t get_full_nzones_for_mat(const index_t mat_idx) const;
-    index_t get_full_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+    // elems to iterate over in a sparse representation
+    // index_t get_full_nelems_for_mat(const index_t mat_idx) const;
+    index_t get_full_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const;
 
     // multi-buffer by material (sparse by material)
-    // 0 <= zone_idx < num zones for material mat_idx
+    // 0 <= elem_idx < num elems for material mat_idx
     // 0 <= mat_idx < num mats
     // 0 <= spec_idx < num species for material mat_idx
-    index_t get_sbm_mat_id(const index_t zone_idx, const index_t mat_idx) const;
-    index_t get_sbm_elem_id(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_sbm_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_sbm_mset_val(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_sbm_mass_frac(const index_t zone_idx,
+    index_t get_sbm_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_sbm_elem_id(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_sbm_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_sbm_mset_val(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_sbm_mass_frac(const index_t elem_idx,
                               const index_t mat_idx,
                               const index_t spec_idx) const;
-    index_t get_sbm_nzones_for_mat(const index_t mat_idx) const;
+    index_t get_sbm_nelems_for_mat(const index_t mat_idx) const;
     // omitted because this method is used for knowing how many
     // materials to iterate over in a sparse representation
-    // index_t get_sbm_nmats_for_zone(const index_t zone_idx) const;
-    index_t get_sbm_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+    // index_t get_sbm_nmats_for_elem(const index_t elem_idx) const;
+    index_t get_sbm_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const;
 
     // uni-buffer by element (sparse by element)
-    // 0 <= zone_idx < num zones
-    // 0 <= mat_idx < num mats for zone zone_idx
-    // 0 <= spec_idx < num species for material mat_idx in zone zone_idx
-    index_t get_sbe_mat_id(const index_t zone_idx, const index_t mat_idx) const;
-    index_t get_sbe_elem_id(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_sbe_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_sbe_mset_val(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_sbe_mass_frac(const index_t zone_idx,
+    // 0 <= elem_idx < num elems
+    // 0 <= mat_idx < num mats for elem elem_idx
+    // 0 <= spec_idx < num species for material mat_idx in elem elem_idx
+    index_t get_sbe_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_sbe_elem_id(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_sbe_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_sbe_mset_val(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_sbe_mass_frac(const index_t elem_idx,
                               const index_t mat_idx,
                               const index_t spec_idx) const;
     // omitted because this method is used for knowing how many
-    // zones to iterate over in a sparse representation
-    // index_t get_sbe_nzones_for_mat(const index_t mat_idx) const;
-    index_t get_sbe_nmats_for_zone(const index_t zone_idx) const;
-    index_t get_sbe_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+    // elems to iterate over in a sparse representation
+    // index_t get_sbe_nelems_for_mat(const index_t mat_idx) const;
+    index_t get_sbe_nmats_for_elem(const index_t elem_idx) const;
+    index_t get_sbe_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const;
 
     // uni-buffer by material
     // not implemented; error in constructor
@@ -301,16 +301,16 @@ private:
     // accessor is used improperly users will get a helpful error instead
     // of just a segfault. The field and specset access methods will only be
     // turned on if a field or a specset is provided.
-    index_t get_error_mat_id(const index_t zone_idx, const index_t mat_idx) const;
-    index_t get_error_elem_id(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_error_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_error_mset_val(const index_t zone_idx, const index_t mat_idx) const;
-    float64 get_error_mass_frac(const index_t zone_idx, 
+    index_t get_error_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_error_elem_id(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_error_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_error_mset_val(const index_t elem_idx, const index_t mat_idx) const;
+    float64 get_error_mass_frac(const index_t elem_idx, 
                                 const index_t mat_idx,
                                 const index_t spec_idx) const;
-    index_t get_error_nmats_for_zone(const index_t zone_idx) const;
-    index_t get_error_nzones_for_mat(const index_t mat_idx) const;
-    index_t get_error_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+    index_t get_error_nmats_for_elem(const index_t elem_idx) const;
+    index_t get_error_nelems_for_mat(const index_t mat_idx) const;
+    index_t get_error_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const;
 
 //-----------------------------------------------------------------------------
 //
@@ -325,14 +325,14 @@ private:
     GetVolFracPtr      m_get_vol_frac;
     GetMsetValPtr      m_get_mset_val;
     GetMassFracPtr     m_get_mass_frac;
-    GetNMatsForZonePtr m_get_nmats_for_zone;
-    GetNZonesForMatPtr m_get_nzones_for_mat;
+    GetNMatsForElemPtr m_get_nmats_for_elem;
+    GetNElemsForMatPtr m_get_nelems_for_mat;
     GetNMatSpecPtr     m_get_nspec_for_mat;
 
     // information members
     bool m_is_uni_buffer;
     bool m_is_element_dominant;
-    index_t m_num_zones;
+    index_t m_num_elems;
     index_t m_num_mats;
     bool m_has_field;
     bool m_has_specset;

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.hpp
@@ -1,0 +1,394 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_blueprint_mesh_matset_accessor.hpp
+///
+//-----------------------------------------------------------------------------
+
+#ifndef CONDUIT_BLUEPRINT_MESH_MATSET_ACCESSOR_HPP
+#define CONDUIT_BLUEPRINT_MESH_MATSET_ACCESSOR_HPP
+
+//-----------------------------------------------------------------------------
+// conduit lib includes
+//-----------------------------------------------------------------------------
+#include "conduit.hpp"
+#include "conduit_blueprint_exports.h"
+#include "conduit_blueprint_o2mrelation_index.hpp"
+
+using namespace conduit;
+// access one-to-many index types
+namespace o2mrelation = conduit::blueprint::o2mrelation;
+
+
+//-----------------------------------------------------------------------------
+// -- begin conduit:: --
+//-----------------------------------------------------------------------------
+namespace conduit
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint --
+//-----------------------------------------------------------------------------
+namespace blueprint
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::mesh --
+//-----------------------------------------------------------------------------
+namespace mesh
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::mesh::matset --
+//-----------------------------------------------------------------------------
+namespace matset
+{
+
+//-----------------------------------------------------------------------------
+// -- begin conduit::blueprint::mesh::matset::MatsetAccessor --
+//-----------------------------------------------------------------------------
+///
+/// class: conduit::blueprint::mesh::MatsetAccessor
+///
+/// description:
+///  Generic accessor for material sets, material fields, and species sets
+///
+//-----------------------------------------------------------------------------
+class CONDUIT_BLUEPRINT_API MatsetAccessor
+{
+public:
+//-----------------------------------------------------------------------------
+//
+// -- conduit::blueprint::mesh::matset::MatsetAccessor public members --
+//
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+/// MatsetAccessor Function pointer types
+//-----------------------------------------------------------------------------
+using GetMatIdPtr        = index_t (MatsetAccessor::*)(index_t, index_t) const;
+using GetElemIdPtr       = index_t (MatsetAccessor::*)(index_t, index_t) const;
+using GetVolFracPtr      = double  (MatsetAccessor::*)(index_t, index_t) const;
+using GetMsetValPtr      = double  (MatsetAccessor::*)(index_t, index_t) const;
+using GetMassFracPtr     = double  (MatsetAccessor::*)(index_t, index_t, index_t) const;
+using GetNMatsForZonePtr = index_t (MatsetAccessor::*)(index_t) const;
+using GetNZonesForMatPtr = index_t (MatsetAccessor::*)(index_t) const;
+using GetNMatSpecPtr     = index_t (MatsetAccessor::*)(index_t, index_t) const;
+
+//-----------------------------------------------------------------------------
+/// MatsetAccessor Construction and Destruction
+//-----------------------------------------------------------------------------
+    /// Default constructor.
+    MatsetAccessor();
+
+    /// Copy constructor.
+    MatsetAccessor(const MatsetAccessor &m_acc);
+
+    /// Construct with just a matset
+    MatsetAccessor(const Node &matset);
+
+    /// Construct with a matset and either a specset or a field
+    MatsetAccessor(const Node &matset, const Node &specset_or_field);
+
+    /// Construct with a matset, specset, and field
+    MatsetAccessor(const Node &matset, const Node &field, const Node &specset);
+
+    /// Destructor
+    ~MatsetAccessor() { };
+
+    /// Assignment operator.
+    MatsetAccessor &operator=(const MatsetAccessor &m_acc);
+
+//-----------------------------------------------------------------------------
+/// Get accessor information
+//-----------------------------------------------------------------------------
+    inline
+    bool        has_field() const
+    {
+        return m_has_field;
+    }
+
+    inline
+    bool        has_specset() const
+    {
+        return m_has_specset;
+    }
+
+//-----------------------------------------------------------------------------
+/// Get general matset information
+//-----------------------------------------------------------------------------
+    inline
+    bool        is_uni_buffer() const
+    {
+        return m_is_uni_buffer;
+    }
+
+    inline
+    bool        is_multi_buffer() const
+    {
+        return ! m_is_uni_buffer;
+    }
+
+    inline
+    bool        is_element_dominant() const
+    {
+        return m_is_element_dominant;
+    }
+
+    inline
+    bool        is_material_dominant() const
+    {
+        return ! m_is_element_dominant;
+    }
+
+    inline
+    index_t     num_zones() const
+    {
+        return m_num_zones;
+    }
+
+    inline
+    index_t     num_mats() const
+    {
+        return m_num_mats;
+    }
+
+//-----------------------------------------------------------------------------
+/// Get information about the sizes
+//-----------------------------------------------------------------------------
+    // use this for elem-dom sparse matsets
+    inline
+    index_t     num_mats_for_zone(const index_t zone_idx) const
+    {
+        return (this->*m_get_nmats_for_zone)(zone_idx);
+    }
+
+    // use this for mat-dom sparse matsets
+    inline
+    index_t     num_zones_for_mat(const index_t mat_idx) const
+    {
+        return (this->*m_get_nzones_for_mat)(mat_idx);
+    }
+
+    inline
+    index_t     num_spec_for_mat(const index_t zone_idx,
+                                 const index_t mat_idx) const
+    {
+        return (this->*m_get_nspec_for_mat)(zone_idx, mat_idx);
+    }
+
+//-----------------------------------------------------------------------------
+/// Retrieve data
+//-----------------------------------------------------------------------------
+    inline
+    index_t     get_mat_id(const index_t zone_idx,
+                           const index_t mat_idx) const
+    {
+        return (this->*m_get_mat_id)(zone_idx, mat_idx);
+    }
+
+    inline
+    index_t     get_elem_id(const index_t zone_idx,
+                            const index_t mat_idx) const
+    {
+        return (this->*m_get_elem_id)(zone_idx, mat_idx);
+    }
+
+    inline
+    float64     get_vol_frac(const index_t zone_idx,
+                             const index_t mat_idx) const
+    {
+        return (this->*m_get_vol_frac)(zone_idx, mat_idx);
+    }
+
+    inline
+    float64     get_mset_val(const index_t zone_idx,
+                             const index_t mat_idx) const
+    {
+        return (this->*m_get_mset_val)(zone_idx, mat_idx);
+    }
+
+    inline
+    float64     get_mass_frac(const index_t zone_idx,
+                              const index_t mat_idx,
+                              const index_t spec_idx) const
+    {
+        return (this->*m_get_mass_frac)(zone_idx, mat_idx, spec_idx);
+    }
+
+private:
+
+//-----------------------------------------------------------------------------
+//
+// -- conduit::blueprint::mesh::matset::MatsetAccessor private members --
+//
+//-----------------------------------------------------------------------------
+
+//-----------------------------------------------------------------------------
+//
+// -- private methods that help with init, and handle different matset flavors --
+//
+//-----------------------------------------------------------------------------
+
+    void init(const Node &matset,
+              const Node *field,
+              const Node *specset);
+
+    //
+    // Per layout implementations, only declarations here
+    //
+
+    // multi-buffer by element (full)
+    // 0 <= zone_idx < num zones
+    // 0 <= mat_idx < num mats
+    // 0 <= spec_idx < num species for material mat_idx
+    index_t get_full_mat_id(const index_t zone_idx, const index_t mat_idx) const;
+    index_t get_full_elem_id(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_full_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_full_mset_val(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_full_mass_frac(const index_t zone_idx,
+                               const index_t mat_idx,
+                               const index_t spec_idx) const;
+    // omitted because this method is used for knowing how many
+    // materials to iterate over in a sparse representation
+    // index_t get_full_nmats_for_zone(const index_t zone_idx) const;
+    // omitted because this method is used for knowing how many
+    // zones to iterate over in a sparse representation
+    // index_t get_full_nzones_for_mat(const index_t mat_idx) const;
+    index_t get_full_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+
+    // multi-buffer by material (sparse by material)
+    // 0 <= zone_idx < num zones for material mat_idx
+    // 0 <= mat_idx < num mats
+    // 0 <= spec_idx < num species for material mat_idx
+    index_t get_sbm_mat_id(const index_t zone_idx, const index_t mat_idx) const;
+    index_t get_sbm_elem_id(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_sbm_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_sbm_mset_val(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_sbm_mass_frac(const index_t zone_idx,
+                              const index_t mat_idx,
+                              const index_t spec_idx) const;
+    index_t get_sbm_nzones_for_mat(const index_t mat_idx) const;
+    // omitted because this method is used for knowing how many
+    // materials to iterate over in a sparse representation
+    // index_t get_sbm_nmats_for_zone(const index_t zone_idx) const;
+    index_t get_sbm_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+
+    // uni-buffer by element (sparse by element)
+    // 0 <= zone_idx < num zones
+    // 0 <= mat_idx < num mats for zone zone_idx
+    // 0 <= spec_idx < num species for material mat_idx in zone zone_idx
+    index_t get_sbe_mat_id(const index_t zone_idx, const index_t mat_idx) const;
+    index_t get_sbe_elem_id(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_sbe_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_sbe_mset_val(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_sbe_mass_frac(const index_t zone_idx,
+                              const index_t mat_idx,
+                              const index_t spec_idx) const;
+    // omitted because this method is used for knowing how many
+    // zones to iterate over in a sparse representation
+    // index_t get_sbe_nzones_for_mat(const index_t mat_idx) const;
+    index_t get_sbe_nmats_for_zone(const index_t zone_idx) const;
+    index_t get_sbe_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+
+    // uni-buffer by material
+    // not implemented; error in constructor
+
+    // The following methods are guard rails; they just throw errors. If the 
+    // accessor is used improperly users will get a helpful error instead
+    // of just a segfault. The field and specset access methods will only be
+    // turned on if a field or a specset is provided.
+    index_t get_error_mat_id(const index_t zone_idx, const index_t mat_idx) const;
+    index_t get_error_elem_id(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_error_vol_frac(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_error_mset_val(const index_t zone_idx, const index_t mat_idx) const;
+    float64 get_error_mass_frac(const index_t zone_idx, 
+                                const index_t mat_idx,
+                                const index_t spec_idx) const;
+    index_t get_error_nmats_for_zone(const index_t zone_idx) const;
+    index_t get_error_nzones_for_mat(const index_t mat_idx) const;
+    index_t get_error_nspec_for_mat(const index_t zone_idx, const index_t mat_idx) const;
+
+//-----------------------------------------------------------------------------
+//
+// -- private data members --
+//
+//-----------------------------------------------------------------------------
+
+    // function pointer members
+    // these take us to implementations for each layout type
+    GetMatIdPtr        m_get_mat_id;
+    GetElemIdPtr       m_get_elem_id;
+    GetVolFracPtr      m_get_vol_frac;
+    GetMsetValPtr      m_get_mset_val;
+    GetMassFracPtr     m_get_mass_frac;
+    GetNMatsForZonePtr m_get_nmats_for_zone;
+    GetNZonesForMatPtr m_get_nzones_for_mat;
+    GetNMatSpecPtr     m_get_nspec_for_mat;
+
+    // information members
+    bool m_is_uni_buffer;
+    bool m_is_element_dominant;
+    index_t m_num_zones;
+    index_t m_num_mats;
+    bool m_has_field;
+    bool m_has_specset;
+
+    // universal members
+    // these are members that are useful for all layout types
+    Node m_nmatspec;
+    index_t_accessor m_nmatspec_acc;
+    index_t_accessor m_nmatspec_offsets_acc;
+
+    // multi-buffer (full AND sparse by material) members
+    std::vector<float64_accessor> m_multi_vol_fracs;
+    std::vector<float64_accessor> m_multi_mset_vals;
+    Node m_multi_mat_idx_map; // multi-buffer material index map
+    index_t_accessor m_multi_mat_idx_map_acc;
+    std::vector<float64_accessor> m_multi_mass_fracs;
+    
+    // multi-buffer material dominant (sparse by material) members
+    std::vector<index_t_accessor> m_sbm_elem_ids;
+
+    // uni-buffer element-dominant (sparse by element) members
+    index_t_accessor m_sbe_material_ids;
+    float64_accessor m_sbe_vol_fracs;
+    float64_accessor m_sbe_mset_vals;
+    o2mrelation::O2MIndex m_sbe_o2m_idx;
+    float64_accessor m_sbe_mass_fracs;
+    o2mrelation::O2MIndex m_sbe_specset_o2m_idx;
+
+    // uni-buffer material-dominant (???) members
+    // not implemented; error case in constructor
+    
+};
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::mesh::matset::MatsetAccessor --
+//-----------------------------------------------------------------------------
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::mesh::matset --
+//-----------------------------------------------------------------------------
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint::mesh --
+//-----------------------------------------------------------------------------
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit::blueprint --
+//-----------------------------------------------------------------------------
+
+
+}
+//-----------------------------------------------------------------------------
+// -- end conduit:: --
+//-----------------------------------------------------------------------------
+
+
+#endif

--- a/src/tests/blueprint/CMakeLists.txt
+++ b/src/tests/blueprint/CMakeLists.txt
@@ -27,6 +27,7 @@ set(BLUEPRINT_TESTS t_blueprint_smoke
                     t_blueprint_mesh_examples_generate
                     t_blueprint_mesh_flatten
                     t_blueprint_mesh_matset_xforms
+                    t_blueprint_mesh_matset_accessor
                     t_blueprint_mesh_topology_metadata
                     t_blueprint_mesh_utils
                     t_blueprint_table_verify

--- a/src/tests/blueprint/t_blueprint_mesh_matset_accessor.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_accessor.cpp
@@ -101,11 +101,11 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_layout_information)
         EXPECT_TRUE(m_acc.is_multi_buffer());
         EXPECT_TRUE(m_acc.is_element_dominant());
         EXPECT_FALSE(m_acc.is_material_dominant());
-        EXPECT_EQ(16, m_acc.num_zones());
+        EXPECT_EQ(16, m_acc.num_elems());
         EXPECT_EQ(4, m_acc.num_mats());
 
-        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(0), conduit::Error);
     }
 
     CONDUIT_INFO("venn sparse_by_element layout information");
@@ -118,11 +118,11 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_layout_information)
         EXPECT_FALSE(m_acc.is_multi_buffer());
         EXPECT_TRUE(m_acc.is_element_dominant());
         EXPECT_FALSE(m_acc.is_material_dominant());
-        EXPECT_EQ(16, m_acc.num_zones());
+        EXPECT_EQ(16, m_acc.num_elems());
         EXPECT_EQ(4, m_acc.num_mats());
 
-        EXPECT_NO_THROW(m_acc.num_mats_for_zone(0));
-        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
+        EXPECT_NO_THROW(m_acc.num_mats_for_elem(0));
+        EXPECT_THROW(m_acc.num_elems_for_mat(0), conduit::Error);
     }
 
     CONDUIT_INFO("venn sparse_by_material layout information");
@@ -135,11 +135,11 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_layout_information)
         EXPECT_TRUE(m_acc.is_multi_buffer());
         EXPECT_FALSE(m_acc.is_element_dominant());
         EXPECT_TRUE(m_acc.is_material_dominant());
-        EXPECT_EQ(16, m_acc.num_zones());
+        EXPECT_EQ(16, m_acc.num_elems());
         EXPECT_EQ(4, m_acc.num_mats());
 
-        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
-        EXPECT_NO_THROW(m_acc.num_zones_for_mat(0));
+        EXPECT_THROW(m_acc.num_mats_for_elem(0), conduit::Error);
+        EXPECT_NO_THROW(m_acc.num_elems_for_mat(0));
     }
 }
 
@@ -161,17 +161,17 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_sizes_information)
 
         MatsetAccessor m_acc = MatsetAccessor(mset, sset);
 
-        // you cannot ask a full matset for num mats for zone
-        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
-        EXPECT_THROW(m_acc.num_mats_for_zone(1), conduit::Error);
-        EXPECT_THROW(m_acc.num_mats_for_zone(2), conduit::Error);
-        EXPECT_THROW(m_acc.num_mats_for_zone(3), conduit::Error);
+        // you cannot ask a full matset for num mats for elem
+        EXPECT_THROW(m_acc.num_mats_for_elem(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(3), conduit::Error);
 
-        // you cannot ask a full matset for num zones for mat
-        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(1), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(2), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(3), conduit::Error);
+        // you cannot ask a full matset for num elems for mat
+        EXPECT_THROW(m_acc.num_elems_for_mat(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(3), conduit::Error);
 
         EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
         EXPECT_EQ(1, m_acc.num_spec_for_mat(1, 0));
@@ -198,24 +198,24 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_sizes_information)
 
         MatsetAccessor m_acc = MatsetAccessor(mset, sset);
 
-        EXPECT_EQ(1, m_acc.num_mats_for_zone(0));
-        EXPECT_EQ(1, m_acc.num_mats_for_zone(1));
-        EXPECT_EQ(1, m_acc.num_mats_for_zone(2));
-        EXPECT_EQ(3, m_acc.num_mats_for_zone(3));
+        EXPECT_EQ(1, m_acc.num_mats_for_elem(0));
+        EXPECT_EQ(1, m_acc.num_mats_for_elem(1));
+        EXPECT_EQ(1, m_acc.num_mats_for_elem(2));
+        EXPECT_EQ(3, m_acc.num_mats_for_elem(3));
 
-        // you cannot ask a sbe matset for num zones for mat
-        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(1), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(2), conduit::Error);
-        EXPECT_THROW(m_acc.num_zones_for_mat(3), conduit::Error);
+        // you cannot ask a sbe matset for num elems for mat
+        EXPECT_THROW(m_acc.num_elems_for_mat(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_elems_for_mat(3), conduit::Error);
 
-        // 1 material in zone 0
+        // 1 material in element 0
         EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
-        // 1 material in zone 1
+        // 1 material in element 1
         EXPECT_EQ(1, m_acc.num_spec_for_mat(1, 0));
-        // 1 material in zone 2
+        // 1 material in element 2
         EXPECT_EQ(1, m_acc.num_spec_for_mat(2, 0));
-        // 3 materials in zone 3
+        // 3 materials in element 3
         EXPECT_EQ(2, m_acc.num_spec_for_mat(3, 0));
         EXPECT_EQ(2, m_acc.num_spec_for_mat(3, 1));
         EXPECT_EQ(3, m_acc.num_spec_for_mat(3, 2));
@@ -228,26 +228,26 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_sizes_information)
 
         MatsetAccessor m_acc = MatsetAccessor(mset, sset);
 
-        // you cannot ask a sbm matset for num mats for zone
-        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
-        EXPECT_THROW(m_acc.num_mats_for_zone(1), conduit::Error);
-        EXPECT_THROW(m_acc.num_mats_for_zone(2), conduit::Error);
-        EXPECT_THROW(m_acc.num_mats_for_zone(3), conduit::Error);
+        // you cannot ask a sbm matset for num mats for elem
+        EXPECT_THROW(m_acc.num_mats_for_elem(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_elem(3), conduit::Error);
 
-        EXPECT_EQ(3, m_acc.num_zones_for_mat(0));
-        EXPECT_EQ(1, m_acc.num_zones_for_mat(1));
-        EXPECT_EQ(1, m_acc.num_zones_for_mat(2));
-        EXPECT_EQ(1, m_acc.num_zones_for_mat(3));
+        EXPECT_EQ(3, m_acc.num_elems_for_mat(0));
+        EXPECT_EQ(1, m_acc.num_elems_for_mat(1));
+        EXPECT_EQ(1, m_acc.num_elems_for_mat(2));
+        EXPECT_EQ(1, m_acc.num_elems_for_mat(3));
 
-        // 3 zones for material 0
+        // 3 elements for material 0
         EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
         EXPECT_EQ(1, m_acc.num_spec_for_mat(1, 0));
         EXPECT_EQ(1, m_acc.num_spec_for_mat(2, 0));
-        // 1 zone for material 1
+        // 1 element for material 1
         EXPECT_EQ(2, m_acc.num_spec_for_mat(0, 1));
-        // 1 zone for material 2
+        // 1 element for material 2
         EXPECT_EQ(2, m_acc.num_spec_for_mat(0, 2));
-        // 1 zone for material 3
+        // 1 element for material 3
         EXPECT_EQ(3, m_acc.num_spec_for_mat(0, 3));
     }
 }
@@ -265,7 +265,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
 
     CONDUIT_INFO("venn full data retrieval");
     {
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
             /* background */ {0, 0, 0, 0},
             /* circle_a   */ {1, 1, 1, 1},
@@ -273,7 +273,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {3, 3, 3, 3},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
             /* background */ {1.0, 1.0, 1.0, 0.0},
             /* circle_a   */ {0.0, 0.0, 0.0, 0.333333333333333},
@@ -281,7 +281,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {0.0, 0.0, 0.0, 0.333333333333333},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> mset_vals_baseline = {
             /* background */ {0.0, 0.5, 0.5, 0.0},
             /* circle_a   */ {0.0, 0.0, 0.0, 0.100000001490116},
@@ -289,7 +289,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {0.0, 0.0, 0.0, 0.600000023841858},
         };
 
-        // index [mat_idx][spec_idx][zone_idx]
+        // index [mat_idx][spec_idx][elem_idx]
         const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
             /* background  */ {
             /*    bg_spec1 */    {1.0, 1.0, 1.0, 1.0},
@@ -315,30 +315,30 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
 
         MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
 
-        // we iterate over zones
-        const index_t num_zones = m_acc.num_zones();
-        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        // we iterate over elements
+        const index_t num_elems = m_acc.num_elems();
+        for (index_t elem_idx = 0; elem_idx < num_elems; elem_idx ++)
         {
             // we ask for the total number of materials
             const index_t num_mats = m_acc.num_mats();
             for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
             {
-                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
-                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
-                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
-                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+                const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
-                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
-                EXPECT_EQ(zone_idx, elem_id);
-                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
-                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+                EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(elem_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
 
-                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(elem_idx, mat_idx);
                 for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
                 {
-                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+                    const float64 mf_val = m_acc.get_mass_frac(elem_idx, mat_idx, spec_idx);
 
-                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][elem_idx], mf_val);
                 }
             }
         }
@@ -346,45 +346,45 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
 
     CONDUIT_INFO("venn sparse_by_element data retrieval");
     {
-        // index [zone_idx][mat_idx]
+        // index [elem_idx][mat_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
-            /* zone 0 */ {0},
-            /* zone 1 */ {0},
-            /* zone 2 */ {0},
-            /* zone 3 */ {1, 2, 3},
+            /* element 0 */ {0},
+            /* element 1 */ {0},
+            /* element 2 */ {0},
+            /* element 3 */ {1, 2, 3},
         };
 
-        // index [zone_idx][mat_idx]
+        // index [elem_idx][mat_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
-            /* zone 0 */ {1.0},
-            /* zone 1 */ {1.0},
-            /* zone 2 */ {1.0},
-            /* zone 3 */ {0.333333333333333, 0.333333333333333, 0.333333333333333},
+            /* element 0 */ {1.0},
+            /* element 1 */ {1.0},
+            /* element 2 */ {1.0},
+            /* element 3 */ {0.333333333333333, 0.333333333333333, 0.333333333333333},
         };
 
-        // index [zone_idx][mat_idx]
+        // index [elem_idx][mat_idx]
         const std::vector<std::vector<float64>> mset_vals_baseline = {
-            /* zone 0 */ {0.0},
-            /* zone 1 */ {0.5},
-            /* zone 2 */ {0.5},
-            /* zone 3 */ {0.100000001490116, 0.200000002980232, 0.600000023841858},
+            /* element 0 */ {0.0},
+            /* element 1 */ {0.5},
+            /* element 2 */ {0.5},
+            /* element 3 */ {0.100000001490116, 0.200000002980232, 0.600000023841858},
         };
 
-        // index [zone_idx][mat_idx][spec_idx]
+        // index [elem_idx][mat_idx][spec_idx]
         const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
-            /* zone 0        */ {
+            /* element 0     */ {
             /*    background */     {1.0},
             },
-            /* zone 1         */ {
-            /*    background  */    {1.0},
+            /* element 1     */ {
+            /*    background */    {1.0},
             },
-            /* zone 2         */ {
-            /*    background  */    {1.0},
+            /* element 2     */ {
+            /*    background */    {1.0},
             },
-            /* zone 3         */ {
-            /*    circle_a    */    {0.5, 0.5},
-            /*    circle_b    */    {0.5, 0.5},
-            /*    circle_c    */    {0.5, 0.375, 0.125},
+            /* element 3     */ {
+            /*    circle_a   */    {0.5, 0.5},
+            /*    circle_b   */    {0.5, 0.5},
+            /*    circle_c   */    {0.5, 0.375, 0.125},
             },
         };
 
@@ -394,30 +394,30 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
 
         MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
 
-        // we iterate over zones
-        const index_t num_zones = m_acc.num_zones();
-        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        // we iterate over elements
+        const index_t num_elems = m_acc.num_elems();
+        for (index_t elem_idx = 0; elem_idx < num_elems; elem_idx ++)
         {
-            // we ask for the number of materials in this zone
-            const index_t num_mats_for_zone = m_acc.num_mats_for_zone(zone_idx);
-            for (index_t mat_idx = 0; mat_idx < num_mats_for_zone; mat_idx ++)
+            // we ask for the number of materials in this element
+            const index_t num_mats_for_elem = m_acc.num_mats_for_elem(elem_idx);
+            for (index_t mat_idx = 0; mat_idx < num_mats_for_elem; mat_idx ++)
             {
-                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
-                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
-                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
-                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+                const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
-                EXPECT_EQ(mat_ids_baseline[zone_idx][mat_idx], mat_id);
-                EXPECT_EQ(zone_idx, elem_id);
-                EXPECT_FLOAT_EQ(vol_fracs_baseline[zone_idx][mat_idx], vol_frac);
-                EXPECT_FLOAT_EQ(mset_vals_baseline[zone_idx][mat_idx], mset_val);
+                EXPECT_EQ(mat_ids_baseline[elem_idx][mat_idx], mat_id);
+                EXPECT_EQ(elem_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[elem_idx][mat_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[elem_idx][mat_idx], mset_val);
 
-                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(elem_idx, mat_idx);
                 for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
                 {
-                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+                    const float64 mf_val = m_acc.get_mass_frac(elem_idx, mat_idx, spec_idx);
 
-                    EXPECT_EQ(mf_vals_baseline[zone_idx][mat_idx][spec_idx], mf_val);
+                    EXPECT_EQ(mf_vals_baseline[elem_idx][mat_idx][spec_idx], mf_val);
                 }
             }
         }
@@ -425,7 +425,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
 
     CONDUIT_INFO("venn sparse_by_material data retrieval");
     {
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
             /* background */ {0, 0, 0},
             /* circle_a   */ {1},
@@ -433,7 +433,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {3},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> elem_ids_baseline = {
             /* background */ {0, 1, 2},
             /* circle_a   */ {3},
@@ -441,7 +441,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {3},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
             /* background */ {1.0, 1.0, 1.0},
             /* circle_a   */ {0.333333333333333},
@@ -449,7 +449,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {0.333333333333333},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> mset_vals_baseline = {
             /* background */ {0.0, 0.5, 0.5},
             /* circle_a   */ {0.100000001490116},
@@ -457,7 +457,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* circle_c   */ {0.600000023841858},
         };
 
-        // index [mat_idx][spec_idx][zone_idx]
+        // index [mat_idx][spec_idx][elem_idx]
         const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
             /* background  */ {
             /*    bg_spec1 */    {1.0, 1.0, 1.0},
@@ -487,26 +487,26 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
         const index_t num_mats = m_acc.num_mats();
         for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
         {
-            // we ask for the number of zones for this material
-            const index_t num_zones_for_mat = m_acc.num_zones_for_mat(mat_idx);
-            for (index_t zone_idx = 0; zone_idx < num_zones_for_mat; zone_idx ++)
+            // we ask for the number of elements for this material
+            const index_t num_elems_for_mat = m_acc.num_elems_for_mat(mat_idx);
+            for (index_t elem_idx = 0; elem_idx < num_elems_for_mat; elem_idx ++)
             {
-                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
-                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
-                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
-                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+                const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
-                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
-                EXPECT_EQ(elem_ids_baseline[mat_idx][zone_idx], elem_id);
-                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
-                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+                EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(elem_ids_baseline[mat_idx][elem_idx], elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
 
-                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(elem_idx, mat_idx);
                 for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
                 {
-                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+                    const float64 mf_val = m_acc.get_mass_frac(elem_idx, mat_idx, spec_idx);
 
-                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][elem_idx], mf_val);
                 }
             }
         }
@@ -595,7 +595,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
 
     CONDUIT_INFO("venn full complicated data retrieval");
     {
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
             /* circle_a   */ {6, 6, 6, 6},
             /* circle_b   */ {2, 2, 2, 2},
@@ -603,7 +603,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {17, 17, 17, 17},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
             /* circle_a   */ {0.0, 0.0, 0.0, 0.333333333333333},
             /* circle_b   */ {0.0, 0.0, 0.0, 0.333333333333333},
@@ -611,7 +611,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {1.0, 1.0, 1.0, 0.0},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> mset_vals_baseline = {
             /* circle_a   */ {0.0, 0.0, 0.0, 0.100000001490116},
             /* circle_b   */ {0.0, 0.0, 0.0, 0.200000002980232},
@@ -619,7 +619,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {0.0, 0.5, 0.5, 0.0},
         };
 
-        // index [mat_idx][spec_idx][zone_idx]
+        // index [mat_idx][spec_idx][elem_idx]
         const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
             /* circle_a    */ {
             /*    a_spec1  */    {0.0, 0.5, 0.0, 0.5},
@@ -645,30 +645,30 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
 
         MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
 
-        // we iterate over zones
-        const index_t num_zones = m_acc.num_zones();
-        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        // we iterate over elements
+        const index_t num_elems = m_acc.num_elems();
+        for (index_t elem_idx = 0; elem_idx < num_elems; elem_idx ++)
         {
             // we ask for the total number of materials
             const index_t num_mats = m_acc.num_mats();
             for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
             {
-                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
-                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
-                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
-                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+                const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
-                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
-                EXPECT_EQ(zone_idx, elem_id);
-                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
-                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+                EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(elem_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
 
-                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(elem_idx, mat_idx);
                 for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
                 {
-                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+                    const float64 mf_val = m_acc.get_mass_frac(elem_idx, mat_idx, spec_idx);
 
-                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][elem_idx], mf_val);
                 }
             }
         }
@@ -676,45 +676,45 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
 
     CONDUIT_INFO("venn sparse_by_element complicated data retrieval");
     {
-        // index [zone_idx][mat_idx]
+        // index [elem_idx][mat_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
-            /* zone 0 */ {17},
-            /* zone 1 */ {17},
-            /* zone 2 */ {17},
-            /* zone 3 */ {6, 2, 9},
+            /* element 0 */ {17},
+            /* element 1 */ {17},
+            /* element 2 */ {17},
+            /* element 3 */ {6, 2, 9},
         };
 
-        // index [zone_idx][mat_idx]
+        // index [elem_idx][mat_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
-            /* zone 0 */ {1.0},
-            /* zone 1 */ {1.0},
-            /* zone 2 */ {1.0},
-            /* zone 3 */ {0.333333333333333, 0.333333333333333, 0.333333333333333},
+            /* element 0 */ {1.0},
+            /* element 1 */ {1.0},
+            /* element 2 */ {1.0},
+            /* element 3 */ {0.333333333333333, 0.333333333333333, 0.333333333333333},
         };
 
-        // index [zone_idx][mat_idx]
+        // index [elem_idx][mat_idx]
         const std::vector<std::vector<float64>> mset_vals_baseline = {
-            /* zone 0 */ {0.0},
-            /* zone 1 */ {0.5},
-            /* zone 2 */ {0.5},
-            /* zone 3 */ {0.100000001490116, 0.200000002980232, 0.600000023841858},
+            /* element 0 */ {0.0},
+            /* element 1 */ {0.5},
+            /* element 2 */ {0.5},
+            /* element 3 */ {0.100000001490116, 0.200000002980232, 0.600000023841858},
         };
 
-        // index [zone_idx][mat_idx][spec_idx]
+        // index [elem_idx][mat_idx][spec_idx]
         const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
-            /* zone 0        */ {
+            /* element 0     */ {
             /*    background */     {1.0},
             },
-            /* zone 1         */ {
-            /*    background  */    {1.0},
+            /* element 1     */ {
+            /*    background */    {1.0},
             },
-            /* zone 2         */ {
-            /*    background  */    {1.0},
+            /* element 2     */ {
+            /*    background */    {1.0},
             },
-            /* zone 3         */ {
-            /*    circle_a    */    {0.5, 0.5},
-            /*    circle_b    */    {0.5, 0.5},
-            /*    circle_c    */    {0.5, 0.375, 0.125},
+            /* element 3     */ {
+            /*    circle_a   */    {0.5, 0.5},
+            /*    circle_b   */    {0.5, 0.5},
+            /*    circle_c   */    {0.5, 0.375, 0.125},
             },
         };
 
@@ -724,30 +724,30 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
 
         MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
 
-        // we iterate over zones
-        const index_t num_zones = m_acc.num_zones();
-        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        // we iterate over elements
+        const index_t num_elems = m_acc.num_elems();
+        for (index_t elem_idx = 0; elem_idx < num_elems; elem_idx ++)
         {
-            // we ask for the number of materials in this zone
-            const index_t num_mats_for_zone = m_acc.num_mats_for_zone(zone_idx);
-            for (index_t mat_idx = 0; mat_idx < num_mats_for_zone; mat_idx ++)
+            // we ask for the number of materials in this element
+            const index_t num_mats_for_elem = m_acc.num_mats_for_elem(elem_idx);
+            for (index_t mat_idx = 0; mat_idx < num_mats_for_elem; mat_idx ++)
             {
-                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
-                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
-                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
-                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+                const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
-                EXPECT_EQ(mat_ids_baseline[zone_idx][mat_idx], mat_id);
-                EXPECT_EQ(zone_idx, elem_id);
-                EXPECT_FLOAT_EQ(vol_fracs_baseline[zone_idx][mat_idx], vol_frac);
-                EXPECT_FLOAT_EQ(mset_vals_baseline[zone_idx][mat_idx], mset_val);
+                EXPECT_EQ(mat_ids_baseline[elem_idx][mat_idx], mat_id);
+                EXPECT_EQ(elem_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[elem_idx][mat_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[elem_idx][mat_idx], mset_val);
 
-                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(elem_idx, mat_idx);
                 for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
                 {
-                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+                    const float64 mf_val = m_acc.get_mass_frac(elem_idx, mat_idx, spec_idx);
 
-                    EXPECT_EQ(mf_vals_baseline[zone_idx][mat_idx][spec_idx], mf_val);
+                    EXPECT_EQ(mf_vals_baseline[elem_idx][mat_idx][spec_idx], mf_val);
                 }
             }
         }
@@ -755,7 +755,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
 
     CONDUIT_INFO("venn sparse_by_material complicated data retrieval");
     {
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
             /* circle_a   */ {6},
             /* circle_b   */ {2},
@@ -763,7 +763,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {17, 17, 17},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> elem_ids_baseline = {
             /* circle_a   */ {3},
             /* circle_b   */ {3},
@@ -771,7 +771,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {0, 1, 2},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
             /* circle_a   */ {0.333333333333333},
             /* circle_b   */ {0.333333333333333},
@@ -779,7 +779,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {1.0, 1.0, 1.0},
         };
 
-        // index [mat_idx][zone_idx]
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> mset_vals_baseline = {
             /* circle_a   */ {0.100000001490116},
             /* circle_b   */ {0.200000002980232},
@@ -787,7 +787,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* background */ {0.0, 0.5, 0.5},
         };
 
-        // index [mat_idx][spec_idx][zone_idx]
+        // index [mat_idx][spec_idx][elem_idx]
         const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
             /* circle_a    */ {
             /*    a_spec1  */    {0.5},
@@ -817,26 +817,26 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
         const index_t num_mats = m_acc.num_mats();
         for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
         {
-            // we ask for the number of zones for this material
-            const index_t num_zones_for_mat = m_acc.num_zones_for_mat(mat_idx);
-            for (index_t zone_idx = 0; zone_idx < num_zones_for_mat; zone_idx ++)
+            // we ask for the number of elements for this material
+            const index_t num_elems_for_mat = m_acc.num_elems_for_mat(mat_idx);
+            for (index_t elem_idx = 0; elem_idx < num_elems_for_mat; elem_idx ++)
             {
-                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
-                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
-                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
-                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+                const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
-                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
-                EXPECT_EQ(elem_ids_baseline[mat_idx][zone_idx], elem_id);
-                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
-                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+                EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(elem_ids_baseline[mat_idx][elem_idx], elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
 
-                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(elem_idx, mat_idx);
                 for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
                 {
-                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+                    const float64 mf_val = m_acc.get_mass_frac(elem_idx, mat_idx, spec_idx);
 
-                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][elem_idx], mf_val);
                 }
             }
         }

--- a/src/tests/blueprint/t_blueprint_mesh_matset_accessor.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_accessor.cpp
@@ -1,0 +1,973 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: t_blueprint_mesh_matset_accessor.cpp
+///
+//-----------------------------------------------------------------------------
+
+#include "conduit.hpp"
+#include "conduit_blueprint.hpp"
+#include "conduit_log.hpp"
+#include "conduit_blueprint_mesh_matset_accessor.hpp"
+
+#include <algorithm>
+#include <vector>
+#include <string>
+#include "gtest/gtest.h"
+
+using namespace conduit;
+
+using MatsetAccessor = conduit::blueprint::mesh::matset::MatsetAccessor;
+
+//-----------------------------------------------------------------------------
+
+/// Test Cases ///
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_constructions)
+{
+    const index_t nx = 4, ny = 4;
+    const float64 radius = 0.25;
+
+    Node mesh;
+    blueprint::mesh::examples::venn_specsets("full", nx, ny, radius, mesh);
+
+    const Node &mset = mesh["matsets/matset"];
+    const Node &field = mesh["fields/importance"];
+    const Node &sset = mesh["specsets/specset"];
+
+    CONDUIT_INFO("construct with matset only");
+    {
+        MatsetAccessor m_acc = MatsetAccessor(mset);
+
+        EXPECT_FALSE(m_acc.has_field());
+        EXPECT_FALSE(m_acc.has_specset());
+
+        EXPECT_EQ(0, m_acc.num_spec_for_mat(0, 0));
+    }
+
+    CONDUIT_INFO("construct with matset and field");
+    {
+        MatsetAccessor m_acc = MatsetAccessor(mset, field);
+
+        EXPECT_TRUE(m_acc.has_field());
+        EXPECT_FALSE(m_acc.has_specset());
+
+        EXPECT_EQ(0, m_acc.num_spec_for_mat(0, 0));
+    }
+
+    CONDUIT_INFO("construct with matset and specset");
+    {
+        MatsetAccessor m_acc = MatsetAccessor(mset, sset);
+
+        EXPECT_FALSE(m_acc.has_field());
+        EXPECT_TRUE(m_acc.has_specset());
+
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
+    }
+
+    CONDUIT_INFO("construct with matset, field, and specset");
+    {
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        EXPECT_TRUE(m_acc.has_field());
+        EXPECT_TRUE(m_acc.has_specset());
+
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_layout_information)
+{
+    const index_t nx = 4, ny = 4;
+    const float64 radius = 0.25;
+
+    Node mesh_full, mesh_sbe, mesh_sbm;
+    blueprint::mesh::examples::venn("full", nx, ny, radius, mesh_full);
+    blueprint::mesh::examples::venn("sparse_by_element", nx, ny, radius, mesh_sbe);
+    blueprint::mesh::examples::venn("sparse_by_material", nx, ny, radius, mesh_sbm);
+
+    CONDUIT_INFO("venn full layout information");
+    {
+        const Node &mset = mesh_full["matsets/matset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset);
+
+        EXPECT_FALSE(m_acc.is_uni_buffer());
+        EXPECT_TRUE(m_acc.is_multi_buffer());
+        EXPECT_TRUE(m_acc.is_element_dominant());
+        EXPECT_FALSE(m_acc.is_material_dominant());
+        EXPECT_EQ(16, m_acc.num_zones());
+        EXPECT_EQ(4, m_acc.num_mats());
+
+        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
+    }
+
+    CONDUIT_INFO("venn sparse_by_element layout information");
+    {
+        const Node &mset = mesh_sbe["matsets/matset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset);
+
+        EXPECT_TRUE(m_acc.is_uni_buffer());
+        EXPECT_FALSE(m_acc.is_multi_buffer());
+        EXPECT_TRUE(m_acc.is_element_dominant());
+        EXPECT_FALSE(m_acc.is_material_dominant());
+        EXPECT_EQ(16, m_acc.num_zones());
+        EXPECT_EQ(4, m_acc.num_mats());
+
+        EXPECT_NO_THROW(m_acc.num_mats_for_zone(0));
+        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
+    }
+
+    CONDUIT_INFO("venn sparse_by_material layout information");
+    {
+        const Node &mset = mesh_sbm["matsets/matset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset);
+
+        EXPECT_FALSE(m_acc.is_uni_buffer());
+        EXPECT_TRUE(m_acc.is_multi_buffer());
+        EXPECT_FALSE(m_acc.is_element_dominant());
+        EXPECT_TRUE(m_acc.is_material_dominant());
+        EXPECT_EQ(16, m_acc.num_zones());
+        EXPECT_EQ(4, m_acc.num_mats());
+
+        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
+        EXPECT_NO_THROW(m_acc.num_zones_for_mat(0));
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_sizes_information)
+{
+    const index_t nx = 2, ny = 2;
+    const float64 radius = 0.25;
+
+    Node mesh_full, mesh_sbe, mesh_sbm;
+    blueprint::mesh::examples::venn_specsets("full", nx, ny, radius, mesh_full);
+    blueprint::mesh::examples::venn_specsets("sparse_by_element", nx, ny, radius, mesh_sbe);
+    blueprint::mesh::examples::venn_specsets("sparse_by_material", nx, ny, radius, mesh_sbm);
+
+    CONDUIT_INFO("venn full sizes information");
+    {
+        const Node &mset = mesh_full["matsets/matset"];
+        const Node &sset = mesh_full["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, sset);
+
+        // you cannot ask a full matset for num mats for zone
+        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_zone(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_zone(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_zone(3), conduit::Error);
+
+        // you cannot ask a full matset for num zones for mat
+        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(3), conduit::Error);
+
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(1, 0));
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(2, 0));
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(3, 0));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(0, 1));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(1, 1));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(2, 1));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(3, 1));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(0, 2));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(1, 2));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(2, 2));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(3, 2));
+        EXPECT_EQ(3, m_acc.num_spec_for_mat(0, 3));
+        EXPECT_EQ(3, m_acc.num_spec_for_mat(1, 3));
+        EXPECT_EQ(3, m_acc.num_spec_for_mat(2, 3));
+        EXPECT_EQ(3, m_acc.num_spec_for_mat(3, 3));
+    }
+
+    CONDUIT_INFO("venn sparse_by_element sizes information");
+    {
+        const Node &mset = mesh_sbe["matsets/matset"];
+        const Node &sset = mesh_sbe["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, sset);
+
+        EXPECT_EQ(1, m_acc.num_mats_for_zone(0));
+        EXPECT_EQ(1, m_acc.num_mats_for_zone(1));
+        EXPECT_EQ(1, m_acc.num_mats_for_zone(2));
+        EXPECT_EQ(3, m_acc.num_mats_for_zone(3));
+
+        // you cannot ask a sbe matset for num zones for mat
+        EXPECT_THROW(m_acc.num_zones_for_mat(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_zones_for_mat(3), conduit::Error);
+
+        // 1 material in zone 0
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
+        // 1 material in zone 1
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(1, 0));
+        // 1 material in zone 2
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(2, 0));
+        // 3 materials in zone 3
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(3, 0));
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(3, 1));
+        EXPECT_EQ(3, m_acc.num_spec_for_mat(3, 2));
+    }
+
+    CONDUIT_INFO("venn sparse_by_material sizes information");
+    {
+        const Node &mset = mesh_sbm["matsets/matset"];
+        const Node &sset = mesh_sbm["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, sset);
+
+        // you cannot ask a sbm matset for num mats for zone
+        EXPECT_THROW(m_acc.num_mats_for_zone(0), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_zone(1), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_zone(2), conduit::Error);
+        EXPECT_THROW(m_acc.num_mats_for_zone(3), conduit::Error);
+
+        EXPECT_EQ(3, m_acc.num_zones_for_mat(0));
+        EXPECT_EQ(1, m_acc.num_zones_for_mat(1));
+        EXPECT_EQ(1, m_acc.num_zones_for_mat(2));
+        EXPECT_EQ(1, m_acc.num_zones_for_mat(3));
+
+        // 3 zones for material 0
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(0, 0));
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(1, 0));
+        EXPECT_EQ(1, m_acc.num_spec_for_mat(2, 0));
+        // 1 zone for material 1
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(0, 1));
+        // 1 zone for material 2
+        EXPECT_EQ(2, m_acc.num_spec_for_mat(0, 2));
+        // 1 zone for material 3
+        EXPECT_EQ(3, m_acc.num_spec_for_mat(0, 3));
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
+{
+    const index_t nx = 2, ny = 2;
+    const float64 radius = 0.25;
+
+    Node mesh_full, mesh_sbe, mesh_sbm;
+    blueprint::mesh::examples::venn_specsets("full", nx, ny, radius, mesh_full);
+    blueprint::mesh::examples::venn_specsets("sparse_by_element", nx, ny, radius, mesh_sbe);
+    blueprint::mesh::examples::venn_specsets("sparse_by_material", nx, ny, radius, mesh_sbm);
+
+    CONDUIT_INFO("venn full data retrieval");
+    {
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* background */ {0, 0, 0, 0},
+            /* circle_a   */ {1, 1, 1, 1},
+            /* circle_b   */ {2, 2, 2, 2},
+            /* circle_c   */ {3, 3, 3, 3},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> vol_fracs_baseline = {
+            /* background */ {1.0, 1.0, 1.0, 0.0},
+            /* circle_a   */ {0.0, 0.0, 0.0, 0.333333333333333},
+            /* circle_b   */ {0.0, 0.0, 0.0, 0.333333333333333},
+            /* circle_c   */ {0.0, 0.0, 0.0, 0.333333333333333},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> mset_vals_baseline = {
+            /* background */ {0.0, 0.5, 0.5, 0.0},
+            /* circle_a   */ {0.0, 0.0, 0.0, 0.100000001490116},
+            /* circle_b   */ {0.0, 0.0, 0.0, 0.200000002980232},
+            /* circle_c   */ {0.0, 0.0, 0.0, 0.600000023841858},
+        };
+
+        // index [mat_idx][spec_idx][zone_idx]
+        const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
+            /* background  */ {
+            /*    bg_spec1 */    {1.0, 1.0, 1.0, 1.0},
+            },
+            /* circle_a    */ {
+            /*    a_spec1  */    {0.0, 0.5, 0.0, 0.5},
+            /*    a_spec2  */    {1.0, 0.5, 1.0, 0.5},
+            },
+            /* circle_b    */ {
+            /*    b_spec1  */    {0.0, 0.0, 0.5, 0.5},
+            /*    b_spec2  */    {1.0, 1.0, 0.5, 0.5},
+            },
+            /* circle_c    */ {
+            /*    c_spec1  */    {1.0, 0.75, 0.75, 0.5},
+            /*    c_spec2  */    {0.0, 0.1875, 0.1875, 0.375},
+            /*    c_spec3  */    {0.0, 0.0625, 0.0625, 0.125},
+            },
+        };
+
+        const Node &mset = mesh_full["matsets/matset"];
+        const Node &field = mesh_full["fields/importance"];
+        const Node &sset = mesh_full["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        // we iterate over zones
+        const index_t num_zones = m_acc.num_zones();
+        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        {
+            // we ask for the total number of materials
+            const index_t num_mats = m_acc.num_mats();
+            for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
+            {
+                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+
+                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
+                EXPECT_EQ(zone_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
+                {
+                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                }
+            }
+        }
+    }
+
+    CONDUIT_INFO("venn sparse_by_element data retrieval");
+    {
+        // index [zone_idx][mat_idx]
+        const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* zone 0 */ {0},
+            /* zone 1 */ {0},
+            /* zone 2 */ {0},
+            /* zone 3 */ {1, 2, 3},
+        };
+
+        // index [zone_idx][mat_idx]
+        const std::vector<std::vector<float64>> vol_fracs_baseline = {
+            /* zone 0 */ {1.0},
+            /* zone 1 */ {1.0},
+            /* zone 2 */ {1.0},
+            /* zone 3 */ {0.333333333333333, 0.333333333333333, 0.333333333333333},
+        };
+
+        // index [zone_idx][mat_idx]
+        const std::vector<std::vector<float64>> mset_vals_baseline = {
+            /* zone 0 */ {0.0},
+            /* zone 1 */ {0.5},
+            /* zone 2 */ {0.5},
+            /* zone 3 */ {0.100000001490116, 0.200000002980232, 0.600000023841858},
+        };
+
+        // index [zone_idx][mat_idx][spec_idx]
+        const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
+            /* zone 0        */ {
+            /*    background */     {1.0},
+            },
+            /* zone 1         */ {
+            /*    background  */    {1.0},
+            },
+            /* zone 2         */ {
+            /*    background  */    {1.0},
+            },
+            /* zone 3         */ {
+            /*    circle_a    */    {0.5, 0.5},
+            /*    circle_b    */    {0.5, 0.5},
+            /*    circle_c    */    {0.5, 0.375, 0.125},
+            },
+        };
+
+        const Node &mset = mesh_sbe["matsets/matset"];
+        const Node &field = mesh_sbe["fields/importance"];
+        const Node &sset = mesh_sbe["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        // we iterate over zones
+        const index_t num_zones = m_acc.num_zones();
+        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        {
+            // we ask for the number of materials in this zone
+            const index_t num_mats_for_zone = m_acc.num_mats_for_zone(zone_idx);
+            for (index_t mat_idx = 0; mat_idx < num_mats_for_zone; mat_idx ++)
+            {
+                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+
+                EXPECT_EQ(mat_ids_baseline[zone_idx][mat_idx], mat_id);
+                EXPECT_EQ(zone_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[zone_idx][mat_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[zone_idx][mat_idx], mset_val);
+
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
+                {
+                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+
+                    EXPECT_EQ(mf_vals_baseline[zone_idx][mat_idx][spec_idx], mf_val);
+                }
+            }
+        }
+    }
+
+    CONDUIT_INFO("venn sparse_by_material data retrieval");
+    {
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* background */ {0, 0, 0},
+            /* circle_a   */ {1},
+            /* circle_b   */ {2},
+            /* circle_c   */ {3},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<index_t>> elem_ids_baseline = {
+            /* background */ {0, 1, 2},
+            /* circle_a   */ {3},
+            /* circle_b   */ {3},
+            /* circle_c   */ {3},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> vol_fracs_baseline = {
+            /* background */ {1.0, 1.0, 1.0},
+            /* circle_a   */ {0.333333333333333},
+            /* circle_b   */ {0.333333333333333},
+            /* circle_c   */ {0.333333333333333},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> mset_vals_baseline = {
+            /* background */ {0.0, 0.5, 0.5},
+            /* circle_a   */ {0.100000001490116},
+            /* circle_b   */ {0.200000002980232},
+            /* circle_c   */ {0.600000023841858},
+        };
+
+        // index [mat_idx][spec_idx][zone_idx]
+        const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
+            /* background  */ {
+            /*    bg_spec1 */    {1.0, 1.0, 1.0},
+            },
+            /* circle_a    */ {
+            /*    a_spec1  */    {0.5},
+            /*    a_spec2  */    {0.5},
+            },
+            /* circle_b    */ {
+            /*    b_spec1  */    {0.5},
+            /*    b_spec2  */    {0.5},
+            },
+            /* circle_c    */ {
+            /*    c_spec1  */    {0.5},
+            /*    c_spec2  */    {0.375},
+            /*    c_spec3  */    {0.125},
+            },
+        };
+
+        const Node &mset = mesh_sbm["matsets/matset"];
+        const Node &field = mesh_sbm["fields/importance"];
+        const Node &sset = mesh_sbm["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        // we iterate over materials
+        const index_t num_mats = m_acc.num_mats();
+        for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
+        {
+            // we ask for the number of zones for this material
+            const index_t num_zones_for_mat = m_acc.num_zones_for_mat(mat_idx);
+            for (index_t zone_idx = 0; zone_idx < num_zones_for_mat; zone_idx ++)
+            {
+                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+
+                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
+                EXPECT_EQ(elem_ids_baseline[mat_idx][zone_idx], elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
+                {
+                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                }
+            }
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// the goal here is to test several things at one:
+// 1. random material ids
+// 2. material order is different between matset/field/specset
+// 3. a material map is included for all cases
+TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_special_cases)
+{
+    const index_t nx = 2, ny = 2;
+    const float64 radius = 0.25;
+
+    Node mesh_full, mesh_sbe, mesh_sbm;
+    blueprint::mesh::examples::venn_specsets("full", nx, ny, radius, mesh_full);
+    blueprint::mesh::examples::venn_specsets("sparse_by_element", nx, ny, radius, mesh_sbe);
+    blueprint::mesh::examples::venn_specsets("sparse_by_material", nx, ny, radius, mesh_sbm);
+
+    Node &material_map = mesh_sbe["matsets"]["matset"]["material_map"];
+
+    material_map["circle_a"].set(6);
+    material_map["circle_b"].set(2);
+    material_map["circle_c"].set(9);
+    material_map["background"].set(17);
+
+    // add material maps with strange material numbers to each matset
+    mesh_full["matsets"]["matset"]["material_map"].set(material_map);
+    mesh_sbm["matsets"]["matset"]["material_map"].set(material_map);
+
+    // update material ids for sbe matset
+    index_t_accessor sbe_mat_ids = mesh_sbe["matsets"]["matset"]["material_ids"].value();
+    sbe_mat_ids.set(0, 17);
+    sbe_mat_ids.set(1, 17);
+    sbe_mat_ids.set(2, 17);
+    sbe_mat_ids.set(3, 6);
+    sbe_mat_ids.set(4, 2);
+    sbe_mat_ids.set(5, 9);
+
+    // scramble material order in importance field for full matset mesh rep
+    Node full_importance_circle_b, full_importance_background;
+    full_importance_circle_b.set(mesh_full["fields"]["importance"]["matset_values"]["circle_b"]);
+    full_importance_background.set(mesh_full["fields"]["importance"]["matset_values"]["background"]);
+    mesh_full["fields"]["importance"]["matset_values"].remove_child("circle_b");
+    mesh_full["fields"]["importance"]["matset_values"].remove_child("background");
+    mesh_full["fields"]["importance"]["matset_values"]["background"].set(full_importance_background);
+    mesh_full["fields"]["importance"]["matset_values"]["circle_b"].set(full_importance_circle_b);
+
+    // scramble material order in importance field for sbm matset mesh rep
+    Node sbm_importance_circle_b, sbm_importance_background;
+    sbm_importance_circle_b.set(mesh_sbm["fields"]["importance"]["matset_values"]["circle_b"]);
+    sbm_importance_background.set(mesh_sbm["fields"]["importance"]["matset_values"]["background"]);
+    mesh_sbm["fields"]["importance"]["matset_values"].remove_child("circle_b");
+    mesh_sbm["fields"]["importance"]["matset_values"].remove_child("background");
+    mesh_sbm["fields"]["importance"]["matset_values"]["background"].set(sbm_importance_background);
+    mesh_sbm["fields"]["importance"]["matset_values"]["circle_b"].set(sbm_importance_circle_b);
+
+    // scramble material order in matset element ids for sbm matset mesh rep
+    Node sbm_element_ids_circle_a, sbm_element_ids_background;
+    sbm_element_ids_circle_a.set(mesh_sbm["matsets"]["matset"]["element_ids"]["circle_a"]);
+    sbm_element_ids_background.set(mesh_sbm["matsets"]["matset"]["element_ids"]["background"]);
+    mesh_sbm["matsets"]["matset"]["element_ids"].remove_child("circle_a");
+    mesh_sbm["matsets"]["matset"]["element_ids"].remove_child("background");
+    mesh_sbm["matsets"]["matset"]["element_ids"]["background"].set(sbm_element_ids_background);
+    mesh_sbm["matsets"]["matset"]["element_ids"]["circle_a"].set(sbm_element_ids_circle_a);
+
+    // scramble material order in specset for full matset mesh rep
+    Node full_specset_circle_a;
+    full_specset_circle_a.set(mesh_full["specsets"]["specset"]["matset_values"]["circle_a"]);
+    mesh_full["specsets"]["specset"]["matset_values"].remove_child("circle_a");
+    mesh_full["specsets"]["specset"]["matset_values"]["circle_a"].set(full_specset_circle_a);
+
+    // scramble material order in specset for sbm matset mesh rep
+    Node sbm_specset_circle_a;
+    sbm_specset_circle_a.set(mesh_sbm["specsets"]["specset"]["matset_values"]["circle_a"]);
+    mesh_sbm["specsets"]["specset"]["matset_values"].remove_child("circle_a");
+    mesh_sbm["specsets"]["specset"]["matset_values"]["circle_a"].set(sbm_specset_circle_a);
+
+    // scramble material order in specset for sbe matset mesh rep
+    Node sbe_specset_circle_b;
+    sbe_specset_circle_b.set(mesh_sbe["specsets"]["specset"]["species_names"]["circle_b"]);
+    mesh_sbe["specsets"]["specset"]["species_names"].remove_child("circle_b");
+    mesh_sbe["specsets"]["specset"]["species_names"]["circle_b"].set(sbe_specset_circle_b);
+
+    CONDUIT_INFO("venn full complicated data retrieval");
+    {
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* circle_a   */ {6, 6, 6, 6},
+            /* circle_b   */ {2, 2, 2, 2},
+            /* circle_c   */ {9, 9, 9, 9},
+            /* background */ {17, 17, 17, 17},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> vol_fracs_baseline = {
+            /* circle_a   */ {0.0, 0.0, 0.0, 0.333333333333333},
+            /* circle_b   */ {0.0, 0.0, 0.0, 0.333333333333333},
+            /* circle_c   */ {0.0, 0.0, 0.0, 0.333333333333333},
+            /* background */ {1.0, 1.0, 1.0, 0.0},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> mset_vals_baseline = {
+            /* circle_a   */ {0.0, 0.0, 0.0, 0.100000001490116},
+            /* circle_b   */ {0.0, 0.0, 0.0, 0.200000002980232},
+            /* circle_c   */ {0.0, 0.0, 0.0, 0.600000023841858},
+            /* background */ {0.0, 0.5, 0.5, 0.0},
+        };
+
+        // index [mat_idx][spec_idx][zone_idx]
+        const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
+            /* circle_a    */ {
+            /*    a_spec1  */    {0.0, 0.5, 0.0, 0.5},
+            /*    a_spec2  */    {1.0, 0.5, 1.0, 0.5},
+            },
+            /* circle_b    */ {
+            /*    b_spec1  */    {0.0, 0.0, 0.5, 0.5},
+            /*    b_spec2  */    {1.0, 1.0, 0.5, 0.5},
+            },
+            /* circle_c    */ {
+            /*    c_spec1  */    {1.0, 0.75, 0.75, 0.5},
+            /*    c_spec2  */    {0.0, 0.1875, 0.1875, 0.375},
+            /*    c_spec3  */    {0.0, 0.0625, 0.0625, 0.125},
+            },
+            /* background  */ {
+            /*    bg_spec1 */    {1.0, 1.0, 1.0, 1.0},
+            },
+        };
+
+        const Node &mset = mesh_full["matsets/matset"];
+        const Node &field = mesh_full["fields/importance"];
+        const Node &sset = mesh_full["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        // we iterate over zones
+        const index_t num_zones = m_acc.num_zones();
+        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        {
+            // we ask for the total number of materials
+            const index_t num_mats = m_acc.num_mats();
+            for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
+            {
+                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+
+                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
+                EXPECT_EQ(zone_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
+                {
+                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                }
+            }
+        }
+    }
+
+    CONDUIT_INFO("venn sparse_by_element complicated data retrieval");
+    {
+        // index [zone_idx][mat_idx]
+        const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* zone 0 */ {17},
+            /* zone 1 */ {17},
+            /* zone 2 */ {17},
+            /* zone 3 */ {6, 2, 9},
+        };
+
+        // index [zone_idx][mat_idx]
+        const std::vector<std::vector<float64>> vol_fracs_baseline = {
+            /* zone 0 */ {1.0},
+            /* zone 1 */ {1.0},
+            /* zone 2 */ {1.0},
+            /* zone 3 */ {0.333333333333333, 0.333333333333333, 0.333333333333333},
+        };
+
+        // index [zone_idx][mat_idx]
+        const std::vector<std::vector<float64>> mset_vals_baseline = {
+            /* zone 0 */ {0.0},
+            /* zone 1 */ {0.5},
+            /* zone 2 */ {0.5},
+            /* zone 3 */ {0.100000001490116, 0.200000002980232, 0.600000023841858},
+        };
+
+        // index [zone_idx][mat_idx][spec_idx]
+        const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
+            /* zone 0        */ {
+            /*    background */     {1.0},
+            },
+            /* zone 1         */ {
+            /*    background  */    {1.0},
+            },
+            /* zone 2         */ {
+            /*    background  */    {1.0},
+            },
+            /* zone 3         */ {
+            /*    circle_a    */    {0.5, 0.5},
+            /*    circle_b    */    {0.5, 0.5},
+            /*    circle_c    */    {0.5, 0.375, 0.125},
+            },
+        };
+
+        const Node &mset = mesh_sbe["matsets/matset"];
+        const Node &field = mesh_sbe["fields/importance"];
+        const Node &sset = mesh_sbe["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        // we iterate over zones
+        const index_t num_zones = m_acc.num_zones();
+        for (index_t zone_idx = 0; zone_idx < num_zones; zone_idx ++)
+        {
+            // we ask for the number of materials in this zone
+            const index_t num_mats_for_zone = m_acc.num_mats_for_zone(zone_idx);
+            for (index_t mat_idx = 0; mat_idx < num_mats_for_zone; mat_idx ++)
+            {
+                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+
+                EXPECT_EQ(mat_ids_baseline[zone_idx][mat_idx], mat_id);
+                EXPECT_EQ(zone_idx, elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[zone_idx][mat_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[zone_idx][mat_idx], mset_val);
+
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
+                {
+                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+
+                    EXPECT_EQ(mf_vals_baseline[zone_idx][mat_idx][spec_idx], mf_val);
+                }
+            }
+        }
+    }
+
+    CONDUIT_INFO("venn sparse_by_material complicated data retrieval");
+    {
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* circle_a   */ {6},
+            /* circle_b   */ {2},
+            /* circle_c   */ {9},
+            /* background */ {17, 17, 17},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<index_t>> elem_ids_baseline = {
+            /* circle_a   */ {3},
+            /* circle_b   */ {3},
+            /* circle_c   */ {3},
+            /* background */ {0, 1, 2},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> vol_fracs_baseline = {
+            /* circle_a   */ {0.333333333333333},
+            /* circle_b   */ {0.333333333333333},
+            /* circle_c   */ {0.333333333333333},
+            /* background */ {1.0, 1.0, 1.0},
+        };
+
+        // index [mat_idx][zone_idx]
+        const std::vector<std::vector<float64>> mset_vals_baseline = {
+            /* circle_a   */ {0.100000001490116},
+            /* circle_b   */ {0.200000002980232},
+            /* circle_c   */ {0.600000023841858},
+            /* background */ {0.0, 0.5, 0.5},
+        };
+
+        // index [mat_idx][spec_idx][zone_idx]
+        const std::vector<std::vector<std::vector<float64>>> mf_vals_baseline = {
+            /* circle_a    */ {
+            /*    a_spec1  */    {0.5},
+            /*    a_spec2  */    {0.5},
+            },
+            /* circle_b    */ {
+            /*    b_spec1  */    {0.5},
+            /*    b_spec2  */    {0.5},
+            },
+            /* circle_c    */ {
+            /*    c_spec1  */    {0.5},
+            /*    c_spec2  */    {0.375},
+            /*    c_spec3  */    {0.125},
+            },
+            /* background  */ {
+            /*    bg_spec1 */    {1.0, 1.0, 1.0},
+            },
+        };
+
+        const Node &mset = mesh_sbm["matsets/matset"];
+        const Node &field = mesh_sbm["fields/importance"];
+        const Node &sset = mesh_sbm["specsets/specset"];
+
+        MatsetAccessor m_acc = MatsetAccessor(mset, field, sset);
+
+        // we iterate over materials
+        const index_t num_mats = m_acc.num_mats();
+        for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
+        {
+            // we ask for the number of zones for this material
+            const index_t num_zones_for_mat = m_acc.num_zones_for_mat(mat_idx);
+            for (index_t zone_idx = 0; zone_idx < num_zones_for_mat; zone_idx ++)
+            {
+                const index_t mat_id = m_acc.get_mat_id(zone_idx, mat_idx);
+                const index_t elem_id = m_acc.get_elem_id(zone_idx, mat_idx);
+                const float64 vol_frac = m_acc.get_vol_frac(zone_idx, mat_idx);
+                const float64 mset_val = m_acc.get_mset_val(zone_idx, mat_idx);
+
+                EXPECT_EQ(mat_ids_baseline[mat_idx][zone_idx], mat_id);
+                EXPECT_EQ(elem_ids_baseline[mat_idx][zone_idx], elem_id);
+                EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][zone_idx], vol_frac);
+                EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][zone_idx], mset_val);
+
+                const index_t num_specs_for_mat = m_acc.num_spec_for_mat(zone_idx, mat_idx);
+                for (index_t spec_idx = 0; spec_idx < num_specs_for_mat; spec_idx ++)
+                {
+                    const float64 mf_val = m_acc.get_mass_frac(zone_idx, mat_idx, spec_idx);
+
+                    EXPECT_EQ(mf_vals_baseline[mat_idx][spec_idx][zone_idx], mf_val);
+                }
+            }
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_errors)
+{
+    const index_t nx = 2, ny = 2;
+    const float64 radius = 0.25;
+
+    Node mesh_full, mesh_sbe, mesh_sbm;
+    blueprint::mesh::examples::venn_specsets("full", nx, ny, radius, mesh_full);
+    blueprint::mesh::examples::venn_specsets("sparse_by_element", nx, ny, radius, mesh_sbe);
+    blueprint::mesh::examples::venn_specsets("sparse_by_material", nx, ny, radius, mesh_sbm);
+
+    CONDUIT_INFO("venn full data retrieval errors");
+    {
+        const Node &mset = mesh_full["matsets/matset"];
+        const Node &field = mesh_full["fields/importance"];
+        const Node &sset = mesh_full["specsets/specset"];
+
+        MatsetAccessor m_acc_only_matset = MatsetAccessor(mset);
+
+        EXPECT_NO_THROW(m_acc_only_matset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_vol_frac(0, 0));
+        EXPECT_THROW(m_acc_only_matset.get_mset_val(0, 0), conduit::Error);
+        EXPECT_THROW(m_acc_only_matset.get_mass_frac(0, 0, 0), conduit::Error);
+
+        MatsetAccessor m_acc_matset_and_field = MatsetAccessor(mset, field);
+
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_vol_frac(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mset_val(0, 0));
+        EXPECT_THROW(m_acc_matset_and_field.get_mass_frac(0, 0, 0), conduit::Error);
+
+        MatsetAccessor m_acc_matset_and_specset = MatsetAccessor(mset, sset);
+
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_vol_frac(0, 0));
+        EXPECT_THROW(m_acc_matset_and_specset.get_mset_val(0, 0), conduit::Error);
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mass_frac(0, 0, 0));
+
+        MatsetAccessor m_acc_matset_field_specset = MatsetAccessor(mset, field, sset);
+
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_vol_frac(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mset_val(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mass_frac(0, 0, 0));
+    }
+
+    CONDUIT_INFO("venn sparse_by_element data retrieval errors");
+    {
+        const Node &mset = mesh_sbe["matsets/matset"];
+        const Node &field = mesh_sbe["fields/importance"];
+        const Node &sset = mesh_sbe["specsets/specset"];
+
+        MatsetAccessor m_acc_only_matset = MatsetAccessor(mset);
+
+        EXPECT_NO_THROW(m_acc_only_matset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_vol_frac(0, 0));
+        EXPECT_THROW(m_acc_only_matset.get_mset_val(0, 0), conduit::Error);
+        EXPECT_THROW(m_acc_only_matset.get_mass_frac(0, 0, 0), conduit::Error);
+
+        MatsetAccessor m_acc_matset_and_field = MatsetAccessor(mset, field);
+
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_vol_frac(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mset_val(0, 0));
+        EXPECT_THROW(m_acc_matset_and_field.get_mass_frac(0, 0, 0), conduit::Error);
+
+        MatsetAccessor m_acc_matset_and_specset = MatsetAccessor(mset, sset);
+
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_vol_frac(0, 0));
+        EXPECT_THROW(m_acc_matset_and_specset.get_mset_val(0, 0), conduit::Error);
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mass_frac(0, 0, 0));
+
+        MatsetAccessor m_acc_matset_field_specset = MatsetAccessor(mset, field, sset);
+
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_vol_frac(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mset_val(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mass_frac(0, 0, 0));
+    }
+
+    CONDUIT_INFO("venn sparse_by_material data retrieval errors");
+    {
+        const Node &mset = mesh_sbm["matsets/matset"];
+        const Node &field = mesh_sbm["fields/importance"];
+        const Node &sset = mesh_sbm["specsets/specset"];
+
+        MatsetAccessor m_acc_only_matset = MatsetAccessor(mset);
+
+        EXPECT_NO_THROW(m_acc_only_matset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_vol_frac(0, 0));
+        EXPECT_THROW(m_acc_only_matset.get_mset_val(0, 0), conduit::Error);
+        EXPECT_THROW(m_acc_only_matset.get_mass_frac(0, 0, 0), conduit::Error);
+
+        MatsetAccessor m_acc_matset_and_field = MatsetAccessor(mset, field);
+
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_vol_frac(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mset_val(0, 0));
+        EXPECT_THROW(m_acc_matset_and_field.get_mass_frac(0, 0, 0), conduit::Error);
+
+        MatsetAccessor m_acc_matset_and_specset = MatsetAccessor(mset, sset);
+
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_vol_frac(0, 0));
+        EXPECT_THROW(m_acc_matset_and_specset.get_mset_val(0, 0), conduit::Error);
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mass_frac(0, 0, 0));
+
+        MatsetAccessor m_acc_matset_field_specset = MatsetAccessor(mset, field, sset);
+
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_elem_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_vol_frac(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mset_val(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mass_frac(0, 0, 0));
+    }
+}


### PR DESCRIPTION
Adds `MatsetAccessor` class that can be used for extracting material data. It mostly abstracts away the matset layout differences. It also extracts field and species data in the same manner. Examples of use are included in the data retrieval tests.

This partially addresses #1514 