### PR TITLE
Material set utilities 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 - Added `conduit::blueprint::mesh::matset::create_or_reuse_material_map()`, which will shallow copy or create a material map for the provided material set.
 - Added `conduit::blueprint::mesh::matset::create_or_copy_material_map()`, which will deep copy or create a material map for the provided material set
 - Added `conduit::blueprint::mesh::matset::renumber_material_ids()`, which renumbers material ids for a material set to be in the range 0 to N - 1, where N is the number of materials.
+- Added `conduit::blueprint::mesh::matset::count_materials_from_matset()`, which counts the number of materials in a given material set, taking into account the various matset layouts.
+- Added `conduit::blueprint::mesh::matset::count_materials_from_specset()`, which counts the number of materials in a given species set, taking into account the various specset layouts.
 
 ### Changed
 

--- a/scripts/build_conduit/build_conduit.sh
+++ b/scripts/build_conduit/build_conduit.sh
@@ -416,7 +416,7 @@ if ${build_pyvenv}; then
     echo "**** Creating Python Virtual Env"
     cd ${install_dir} && ${python_exe} -m venv python-venv
     ${venv_python_exe} -m pip install --upgrade pip
-    ${venv_python_exe} -m pip install wheel numpy sphinx sphinx_rtd_theme
+    ${venv_python_exe} -m pip install wheel numpy sphinx sphinx_rtd_theme setuptools
     if ${build_zfp}; then
         ${venv_python_exe} -m pip install cython setuptools
     fi

--- a/src/libs/blueprint/conduit_blueprint_mesh.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh.hpp
@@ -853,6 +853,8 @@ namespace matset
     //-------------------------------------------------------------------------
     index_t CONDUIT_BLUEPRINT_API count_zones_from_matset(const conduit::Node &matset);
     //-------------------------------------------------------------------------
+    index_t CONDUIT_BLUEPRINT_API count_materials_from_matset(const conduit::Node &matset);
+    //-------------------------------------------------------------------------
     bool CONDUIT_BLUEPRINT_API is_material_in_zone(const conduit::Node &matset,
                                                    const std::string &matname,
                                                    const index_t zone_id,
@@ -993,6 +995,9 @@ namespace specset
     //-------------------------------------------------------------------------
     void CONDUIT_BLUEPRINT_API get_material_names(const conduit::Node &specset,
                                                   std::vector<std::string> &matnames);
+
+    //-------------------------------------------------------------------------
+    index_t CONDUIT_BLUEPRINT_API count_materials_from_specset(const conduit::Node &specset);
     
     //-------------------------------------------------------------------------
     // Converts a blueprint specset to the silo style sparse mixed slot 

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -73,7 +73,7 @@ create_material_map(const conduit::Node &matset,
     // We must be multi-buffer, so we can assume we have a 
     // "volume_fractions" child that is an object.
     const std::vector<std::string> &matnames = matset["volume_fractions"].child_names();
-    int mat_id = 0;
+    index_t mat_id = 0;
     for (const auto &matname : matnames)
     {
         material_map[matname].set(mat_id);
@@ -1925,6 +1925,7 @@ create_reverse_material_map(const conduit::Node &src_material_map)
     }
     return reverse_matmap;
 }
+
 //-------------------------------------------------------------------------
 index_t 
 count_zones_from_matset(const conduit::Node &matset)
@@ -1935,31 +1936,88 @@ count_zones_from_matset(const conduit::Node &matset)
         CONDUIT_ERROR("blueprint::mesh::matset::count_zones_in_matset"
                       " passed matset node must be a valid matset tree.");
     }
-    // full
-    if (is_element_dominant(matset) && is_multi_buffer(matset))
+
+    const bool element_dominant = is_element_dominant(matset);
+    const bool multi_buffer = is_multi_buffer(matset);
+
+    if (element_dominant)
     {
-        if (matset["volume_fractions"].number_of_children() > 0)
+        // venn full
+        if (multi_buffer)
         {
-            return matset["volume_fractions"][0].dtype().number_of_elements();
+            if (matset["volume_fractions"].number_of_children() > 0)
+            {
+                return matset["volume_fractions"][0].dtype().number_of_elements();
+            }
+            else
+            {
+                return 0;
+            }
         }
+        // venn sparse by element
         else
         {
-            return 0;
+            return matset["sizes"].dtype().number_of_elements();
         }
-    }
-    // sparse_by_element
-    else if (is_element_dominant(matset))
-    {
-        return matset["sizes"].dtype().number_of_elements();
-    }
-    // sparse_by_material
-    else if (is_material_dominant(matset))
-    {
-        return detail::determine_num_elems_in_multi_buffer_by_material(matset["element_ids"]);
     }
     else
     {
-        CONDUIT_ERROR("Unknown matset type.");
+        // venn sparse by material
+        if (multi_buffer)
+        {
+            return detail::determine_num_elems_in_multi_buffer_by_material(matset["element_ids"]);
+        }
+        // material-dominant uni-buffer
+        else
+        {
+            CONDUIT_ERROR("blueprint::mesh::matset::count_zones_in_matset() "
+                          "material-dominant uni-buffer material set is unsupported.");
+        }
+    }
+
+    return -1;
+}
+
+//-------------------------------------------------------------------------
+index_t 
+count_materials_from_matset(const conduit::Node &matset)
+{
+    // extra seat belt here
+    if (! matset.dtype().is_object())
+    {
+        CONDUIT_ERROR("blueprint::mesh::matset::count_materials_from_matset"
+                      " passed matset node must be a valid matset tree.");
+    }
+
+    const bool element_dominant = is_element_dominant(matset);
+    const bool multi_buffer = is_multi_buffer(matset);
+
+    if (element_dominant)
+    {
+        // venn full
+        if (multi_buffer)
+        {
+            return matset["volume_fractions"].number_of_children();
+        }
+        // venn sparse by element
+        else
+        {
+            return matset["material_map"].number_of_children();
+        }
+    }
+    else
+    {
+        // venn sparse by material
+        if (multi_buffer)
+        {
+            return matset["volume_fractions"].number_of_children();
+        }
+        // material-dominant uni-buffer
+        else
+        {
+            CONDUIT_ERROR("blueprint::mesh::matset::count_materials_from_matset() "
+                          "material-dominant uni-buffer material set is unsupported.");
+        }
     }
 
     return -1;

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_xforms.cpp
@@ -2226,7 +2226,7 @@ index_t
 get_num_species_for_material(const conduit::Node &specset,
                              const std::string &matname)
 {
-    if (blueprint::mesh::specset::is_multi_buffer(specset))
+    if (is_multi_buffer(specset))
     {
         if (specset["matset_values"].has_child(matname))
         {
@@ -2255,7 +2255,14 @@ void
 get_material_names(const conduit::Node &specset,
                    std::vector<std::string> &matnames)
 {
-    if (blueprint::mesh::specset::is_multi_buffer(specset))
+    // extra seat belt here
+    if (! specset.dtype().is_object())
+    {
+        CONDUIT_ERROR("blueprint::mesh::specset::get_material_names"
+                      " passed specset node must be a valid specset tree.");
+    }
+
+    if (is_multi_buffer(specset))
     {
         matnames = specset["matset_values"].child_names();
     }
@@ -2263,6 +2270,29 @@ get_material_names(const conduit::Node &specset,
     {
         matnames = specset["species_names"].child_names();
     }
+}
+
+//-------------------------------------------------------------------------
+index_t 
+count_materials_from_specset(const conduit::Node &specset)
+{
+    // extra seat belt here
+    if (! specset.dtype().is_object())
+    {
+        CONDUIT_ERROR("blueprint::mesh::specset::count_materials_from_specset"
+                      " passed specset node must be a valid specset tree.");
+    }
+
+    if (is_multi_buffer(specset))
+    {
+        return specset["matset_values"].number_of_children();
+    }
+    else
+    {
+        return specset["species_names"].number_of_children();
+    }
+
+    return -1;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -162,6 +162,40 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_count_materials_from_matset
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_count_materials_from_specset)
+{
+    const int nx = 4, ny = 4;
+    const double radius = 0.25;
+
+    CONDUIT_INFO("venn full count zones");
+    {
+        Node mesh;
+        blueprint::mesh::examples::venn_specsets("full", nx, ny, radius, mesh);
+        const Node &specset = mesh["specsets/specset"];
+
+        EXPECT_EQ(4, blueprint::mesh::specset::count_materials_from_specset(specset));
+    }
+
+    CONDUIT_INFO("venn sparse_by_material count zones");
+    {
+        Node mesh;
+        blueprint::mesh::examples::venn_specsets("sparse_by_material", nx, ny, radius, mesh);
+        const Node &specset = mesh["specsets/specset"];
+
+        EXPECT_EQ(4, blueprint::mesh::specset::count_materials_from_specset(specset));
+    }
+
+    CONDUIT_INFO("venn sparse_by_element count zones");
+    {
+        Node mesh;
+        blueprint::mesh::examples::venn_specsets("sparse_by_element", nx, ny, radius, mesh);
+        const Node &specset = mesh["specsets/specset"];
+
+        EXPECT_EQ(4, blueprint::mesh::specset::count_materials_from_specset(specset));
+    }
+}
+
+//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_is_material_in_zone)
 {
     const int nx = 2, ny = 2;

--- a/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_xforms.cpp
@@ -128,6 +128,40 @@ TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_count_zones_from_matset)
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_count_materials_from_matset)
+{
+    const int nx = 4, ny = 4;
+    const double radius = 0.25;
+
+    CONDUIT_INFO("venn full count zones");
+    {
+        Node mesh;
+        blueprint::mesh::examples::venn("full", nx, ny, radius, mesh);
+        const Node &mset = mesh["matsets/matset"];
+
+        EXPECT_EQ(4, blueprint::mesh::matset::count_materials_from_matset(mset));
+    }
+
+    CONDUIT_INFO("venn sparse_by_material count zones");
+    {
+        Node mesh;
+        blueprint::mesh::examples::venn("sparse_by_material", nx, ny, radius, mesh);
+        const Node &mset = mesh["matsets/matset"];
+
+        EXPECT_EQ(4, blueprint::mesh::matset::count_materials_from_matset(mset));
+    }
+
+    CONDUIT_INFO("venn sparse_by_element count zones");
+    {
+        Node mesh;
+        blueprint::mesh::examples::venn("sparse_by_element", nx, ny, radius, mesh);
+        const Node &mset = mesh["matsets/matset"];
+
+        EXPECT_EQ(4, blueprint::mesh::matset::count_materials_from_matset(mset));
+    }
+}
+
+//-----------------------------------------------------------------------------
 TEST(conduit_blueprint_mesh_matset_xforms, mesh_util_is_material_in_zone)
 {
     const int nx = 2, ny = 2;


### PR DESCRIPTION
adds `count_materials_from_matset()` and `count_materials_from_specset()`

reworks other matset helpers, using conduit data types and updating them to reflect the new reality of 4 matset layout types.