### PR TITLE
Matset Accessor: Add mat_order_id

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.cpp
@@ -52,6 +52,7 @@ namespace matset
 //---------------------------------------------------------------------------//
 MatsetAccessor::MatsetAccessor()
  : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_mat_order_id(&MatsetAccessor::get_error_mat_order_id),
    m_get_elem_id(&MatsetAccessor::get_error_elem_id),
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
@@ -66,6 +67,7 @@ MatsetAccessor::MatsetAccessor()
 //---------------------------------------------------------------------------//
 MatsetAccessor::MatsetAccessor(const Node &matset)
  : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_mat_order_id(&MatsetAccessor::get_error_mat_order_id),
    m_get_elem_id(&MatsetAccessor::get_error_elem_id),
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
@@ -81,6 +83,7 @@ MatsetAccessor::MatsetAccessor(const Node &matset)
 MatsetAccessor::MatsetAccessor(const Node &matset,
                                const Node &specset_or_field)
  : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_mat_order_id(&MatsetAccessor::get_error_mat_order_id),
    m_get_elem_id(&MatsetAccessor::get_error_elem_id),
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
@@ -108,6 +111,7 @@ MatsetAccessor::MatsetAccessor(const Node &matset,
                                const Node &field,
                                const Node &specset)
  : m_get_mat_id(&MatsetAccessor::get_error_mat_id),
+   m_get_mat_order_id(&MatsetAccessor::get_error_mat_order_id),
    m_get_elem_id(&MatsetAccessor::get_error_elem_id),
    m_get_vol_frac(&MatsetAccessor::get_error_vol_frac),
    m_get_mset_val(&MatsetAccessor::get_error_mset_val),
@@ -122,6 +126,7 @@ MatsetAccessor::MatsetAccessor(const Node &matset,
 //---------------------------------------------------------------------------//
 MatsetAccessor::MatsetAccessor(const MatsetAccessor &m_acc)
 : m_get_mat_id(m_acc.m_get_mat_id),
+  m_get_mat_order_id(m_acc.m_get_mat_order_id),
   m_get_elem_id(m_acc.m_get_elem_id),
   m_get_vol_frac(m_acc.m_get_vol_frac),
   m_get_mset_val(m_acc.m_get_mset_val),
@@ -145,6 +150,8 @@ MatsetAccessor::MatsetAccessor(const MatsetAccessor &m_acc)
   m_multi_mass_fracs(m_acc.m_multi_mass_fracs),
   m_sbm_elem_ids(m_acc.m_sbm_elem_ids),
   m_sbe_material_ids(m_acc.m_sbe_material_ids),
+  m_sbe_mat_order_ids(m_acc.m_sbe_mat_order_ids),
+  m_sbe_mat_order_ids_acc(m_acc.m_sbe_mat_order_ids_acc),
   m_sbe_vol_fracs(m_acc.m_sbe_vol_fracs),
   m_sbe_mset_vals(m_acc.m_sbe_mset_vals),
   m_sbe_o2m_idx(m_acc.m_sbe_o2m_idx),
@@ -159,6 +166,7 @@ MatsetAccessor::operator=(const MatsetAccessor &m_acc)
     if (this != &m_acc)
     {
         m_get_mat_id = m_acc.m_get_mat_id;
+        m_get_mat_order_id = m_acc.m_get_mat_order_id;
         m_get_elem_id = m_acc.m_get_elem_id;
         m_get_vol_frac = m_acc.m_get_vol_frac;
         m_get_mset_val = m_acc.m_get_mset_val;
@@ -182,6 +190,8 @@ MatsetAccessor::operator=(const MatsetAccessor &m_acc)
         m_multi_mass_fracs = m_acc.m_multi_mass_fracs;
         m_sbm_elem_ids = m_acc.m_sbm_elem_ids;
         m_sbe_material_ids = m_acc.m_sbe_material_ids;
+        m_sbe_mat_order_ids = m_acc.m_sbe_mat_order_ids;
+        m_sbe_mat_order_ids_acc = m_acc.m_sbe_mat_order_ids_acc;
         m_sbe_vol_fracs = m_acc.m_sbe_vol_fracs;
         m_sbe_mset_vals = m_acc.m_sbe_mset_vals;
         m_sbe_o2m_idx = m_acc.m_sbe_o2m_idx;
@@ -227,8 +237,8 @@ MatsetAccessor::init(const Node &matset,
         m_has_specset = true;
     }
 
-    m_is_uni_buffer       = blueprint::mesh::matset::is_uni_buffer(matset);
-    m_is_element_dominant = blueprint::mesh::matset::is_element_dominant(matset);
+    m_is_uni_buffer       = matset::is_uni_buffer(matset);
+    m_is_element_dominant = matset::is_element_dominant(matset);
 
     m_num_elems = count_zones_from_matset(matset);
     m_num_mats  = count_materials_from_matset(matset);
@@ -245,6 +255,28 @@ MatsetAccessor::init(const Node &matset,
             m_sbe_material_ids = matset["material_ids"].value();
             m_sbe_vol_fracs = matset["volume_fractions"].value();
             m_sbe_o2m_idx = o2mrelation::O2MIndex(matset);
+
+            //
+            // save material order ids
+            //
+            const index_t num_vol_fracs = matset["volume_fractions"].dtype().number_of_elements();
+            m_sbe_mat_order_ids.set(DataType::index_t(num_vol_fracs));
+            m_sbe_mat_order_ids_acc = m_sbe_mat_order_ids.value();
+            // create a map from material id to material order id
+            std::map<index_t, index_t> mat_id_to_order_id;
+            for (index_t mat_idx = 0; mat_idx < m_num_mats; mat_idx ++)
+            {
+                const index_t mat_id = material_map.child(mat_idx).to_index_t();
+                mat_id_to_order_id[mat_id] = mat_idx;
+            }
+            // now we can fill the mat order id array using the information we've collected
+            for (index_t vf_elem = 0; vf_elem < num_vol_fracs; vf_elem ++)
+            {
+                const index_t mat_id = m_sbe_material_ids[vf_elem];
+                const index_t mat_order_id = mat_id_to_order_id.at(mat_id);
+                m_sbe_mat_order_ids_acc.set(vf_elem, mat_order_id);
+            }
+
             if (nullptr != field)
             {
                 m_sbe_mset_vals = (*field)["matset_values"].value();
@@ -423,7 +455,6 @@ MatsetAccessor::init(const Node &matset,
                 // We pay a price at the start when creating these arrays, but we enable quick
                 // access of species mass fraction data.
 
-                const index_t num_vol_fracs = matset["volume_fractions"].dtype().number_of_elements();
                 m_nmatspec["nmatspec"].set(DataType::index_t(num_vol_fracs));
                 m_nmatspec_acc = m_nmatspec["nmatspec"].value();
                 m_nmatspec["nmatspec_offsets"].set(DataType::index_t(num_vol_fracs));
@@ -465,9 +496,10 @@ MatsetAccessor::init(const Node &matset,
             }
 
             // set our fetch methods
-            m_get_mat_id   = &MatsetAccessor::get_sbe_mat_id;
-            m_get_elem_id  = &MatsetAccessor::get_sbe_elem_id;
-            m_get_vol_frac = &MatsetAccessor::get_sbe_vol_frac;
+            m_get_mat_id       = &MatsetAccessor::get_sbe_mat_id;
+            m_get_mat_order_id = &MatsetAccessor::get_sbe_mat_order_id;
+            m_get_elem_id      = &MatsetAccessor::get_sbe_elem_id;
+            m_get_vol_frac     = &MatsetAccessor::get_sbe_vol_frac;
             if (nullptr != field)
             {
                 m_get_mset_val = &MatsetAccessor::get_sbe_mset_val;
@@ -571,9 +603,10 @@ MatsetAccessor::init(const Node &matset,
         // multi-buffer by element (full)
         if (m_is_element_dominant)
         {
-            m_get_mat_id   = &MatsetAccessor::get_full_mat_id;
-            m_get_elem_id  = &MatsetAccessor::get_full_elem_id;
-            m_get_vol_frac = &MatsetAccessor::get_full_vol_frac;
+            m_get_mat_id       = &MatsetAccessor::get_full_mat_id;
+            m_get_mat_order_id = &MatsetAccessor::get_full_mat_order_id;
+            m_get_elem_id      = &MatsetAccessor::get_full_elem_id;
+            m_get_vol_frac     = &MatsetAccessor::get_full_vol_frac;
             if (nullptr != field)
             {
                 m_get_mset_val = &MatsetAccessor::get_full_mset_val;
@@ -593,9 +626,10 @@ MatsetAccessor::init(const Node &matset,
                 m_sbm_elem_ids.push_back(matset["element_ids"][matname].value());
             }
 
-            m_get_mat_id   = &MatsetAccessor::get_sbm_mat_id;
-            m_get_elem_id  = &MatsetAccessor::get_sbm_elem_id;
-            m_get_vol_frac = &MatsetAccessor::get_sbm_vol_frac;
+            m_get_mat_id       = &MatsetAccessor::get_sbm_mat_id;
+            m_get_mat_order_id = &MatsetAccessor::get_sbm_mat_order_id;
+            m_get_elem_id      = &MatsetAccessor::get_sbm_elem_id;
+            m_get_vol_frac     = &MatsetAccessor::get_sbm_vol_frac;
             if (nullptr != field)
             {
                 m_get_mset_val = &MatsetAccessor::get_sbm_mset_val;
@@ -621,6 +655,14 @@ MatsetAccessor::get_full_mat_id(const index_t elem_idx, const index_t mat_idx) c
 {
     (void) elem_idx;
     return m_multi_mat_idx_map_acc[mat_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_full_mat_order_id(const index_t elem_idx, const index_t mat_idx) const
+{
+    (void) elem_idx;
+    return mat_idx;
 }
 
 //-----------------------------------------------------------------------------
@@ -674,6 +716,14 @@ MatsetAccessor::get_sbm_mat_id(const index_t elem_idx, const index_t mat_idx) co
 {
     (void) elem_idx;
     return m_multi_mat_idx_map_acc[mat_idx];
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_sbm_mat_order_id(const index_t elem_idx, const index_t mat_idx) const
+{
+    (void) elem_idx;
+    return mat_idx;
 }
 
 //-----------------------------------------------------------------------------
@@ -733,6 +783,14 @@ MatsetAccessor::get_sbe_mat_id(const index_t elem_idx, const index_t mat_idx) co
 {
     const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
     return m_sbe_material_ids[data_index];
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_sbe_mat_order_id(const index_t elem_idx, const index_t mat_idx) const
+{
+    const index_t data_index = m_sbe_o2m_idx.index(elem_idx, mat_idx);
+    return m_sbe_mat_order_ids_acc[data_index];
 }
 
 //-----------------------------------------------------------------------------
@@ -811,6 +869,16 @@ MatsetAccessor::get_error_mat_id(const index_t elem_idx, const index_t mat_idx) 
     (void) elem_idx;
     (void) mat_idx;
     CONDUIT_ERROR("Impossible to fetch mat_id from material set.");
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+index_t 
+MatsetAccessor::get_error_mat_order_id(const index_t elem_idx, const index_t mat_idx) const
+{
+    (void) elem_idx;
+    (void) mat_idx;
+    CONDUIT_ERROR("Impossible to fetch mat_order_id from material set.");
     return 0;
 }
 
@@ -920,5 +988,4 @@ MatsetAccessor::get_error_nspec_for_mat(const index_t elem_idx, const index_t ma
 //-----------------------------------------------------------------------------
 // -- end conduit:: --
 //-----------------------------------------------------------------------------
-
 

--- a/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.hpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_matset_accessor.hpp
@@ -70,6 +70,7 @@ public:
 /// MatsetAccessor Function pointer types
 //-----------------------------------------------------------------------------
 using GetMatIdPtr        = index_t (MatsetAccessor::*)(index_t, index_t) const;
+using GetMatOrderIdPtr   = index_t (MatsetAccessor::*)(index_t, index_t) const;
 using GetElemIdPtr       = index_t (MatsetAccessor::*)(index_t, index_t) const;
 using GetVolFracPtr      = float64 (MatsetAccessor::*)(index_t, index_t) const;
 using GetMsetValPtr      = float64 (MatsetAccessor::*)(index_t, index_t) const;
@@ -191,6 +192,13 @@ using GetNMatSpecPtr     = index_t (MatsetAccessor::*)(index_t, index_t) const;
     }
 
     inline
+    index_t     get_mat_order_id(const index_t elem_idx,
+                                 const index_t mat_idx) const
+    {
+        return (this->*m_get_mat_order_id)(elem_idx, mat_idx);
+    }
+
+    inline
     index_t     get_elem_id(const index_t elem_idx,
                             const index_t mat_idx) const
     {
@@ -246,6 +254,7 @@ private:
     // 0 <= mat_idx < num mats
     // 0 <= spec_idx < num species for material mat_idx
     index_t get_full_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_full_mat_order_id(const index_t elem_idx, const index_t mat_idx) const;
     index_t get_full_elem_id(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_full_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_full_mset_val(const index_t elem_idx, const index_t mat_idx) const;
@@ -265,6 +274,7 @@ private:
     // 0 <= mat_idx < num mats
     // 0 <= spec_idx < num species for material mat_idx
     index_t get_sbm_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_sbm_mat_order_id(const index_t elem_idx, const index_t mat_idx) const;
     index_t get_sbm_elem_id(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_sbm_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_sbm_mset_val(const index_t elem_idx, const index_t mat_idx) const;
@@ -278,10 +288,11 @@ private:
     index_t get_sbm_nspec_for_mat(const index_t elem_idx, const index_t mat_idx) const;
 
     // uni-buffer by element (sparse by element)
-    // 0 <= elem_idx < num element
+    // 0 <= elem_idx < num elements
     // 0 <= mat_idx < num mats for element elem_idx
     // 0 <= spec_idx < num species for material mat_idx in element elem_idx
     index_t get_sbe_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_sbe_mat_order_id(const index_t elem_idx, const index_t mat_idx) const;
     index_t get_sbe_elem_id(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_sbe_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_sbe_mset_val(const index_t elem_idx, const index_t mat_idx) const;
@@ -302,6 +313,7 @@ private:
     // of just a segfault. The field and specset access methods will only be
     // turned on if a field or a specset is provided.
     index_t get_error_mat_id(const index_t elem_idx, const index_t mat_idx) const;
+    index_t get_error_mat_order_id(const index_t elem_idx, const index_t mat_idx) const;
     index_t get_error_elem_id(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_error_vol_frac(const index_t elem_idx, const index_t mat_idx) const;
     float64 get_error_mset_val(const index_t elem_idx, const index_t mat_idx) const;
@@ -321,6 +333,7 @@ private:
     // function pointer members
     // these take us to implementations for each layout type
     GetMatIdPtr        m_get_mat_id;
+    GetMatOrderIdPtr   m_get_mat_order_id;
     GetElemIdPtr       m_get_elem_id;
     GetVolFracPtr      m_get_vol_frac;
     GetMsetValPtr      m_get_mset_val;
@@ -355,6 +368,8 @@ private:
 
     // uni-buffer element-dominant (sparse by element) members
     index_t_accessor m_sbe_material_ids;
+    Node m_sbe_mat_order_ids;
+    index_t_accessor m_sbe_mat_order_ids_acc;
     float64_accessor m_sbe_vol_fracs;
     float64_accessor m_sbe_mset_vals;
     o2mrelation::O2MIndex m_sbe_o2m_idx;

--- a/src/tests/blueprint/t_blueprint_mesh_matset_accessor.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_matset_accessor.cpp
@@ -274,6 +274,14 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
         };
 
         // index [mat_idx][elem_idx]
+        const std::vector<std::vector<index_t>> mat_order_ids_baseline = {
+            /* background */ {0, 0, 0, 0},
+            /* circle_a   */ {1, 1, 1, 1},
+            /* circle_b   */ {2, 2, 2, 2},
+            /* circle_c   */ {3, 3, 3, 3},
+        };
+
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
             /* background */ {1.0, 1.0, 1.0, 0.0},
             /* circle_a   */ {0.0, 0.0, 0.0, 0.333333333333333},
@@ -324,11 +332,13 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
             {
                 const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t mat_order_id = m_acc.get_mat_order_id(elem_idx, mat_idx);
                 const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
                 const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
                 const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
                 EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(mat_order_ids_baseline[mat_idx][elem_idx], mat_order_id);
                 EXPECT_EQ(elem_idx, elem_id);
                 EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
                 EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
@@ -352,6 +362,14 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             /* element 1 */ {0},
             /* element 2 */ {0},
             /* element 3 */ {1, 2, 3},
+        };
+
+        // index [elem_idx][mat_idx]
+        const std::vector<std::vector<index_t>> mat_order_ids_baseline = {
+            /* element 0 */ {3},
+            /* element 1 */ {3},
+            /* element 2 */ {3},
+            /* element 3 */ {0, 1, 2},
         };
 
         // index [elem_idx][mat_idx]
@@ -403,11 +421,13 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             for (index_t mat_idx = 0; mat_idx < num_mats_for_elem; mat_idx ++)
             {
                 const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t mat_order_id = m_acc.get_mat_order_id(elem_idx, mat_idx);
                 const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
                 const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
                 const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
                 EXPECT_EQ(mat_ids_baseline[elem_idx][mat_idx], mat_id);
+                EXPECT_EQ(mat_order_ids_baseline[elem_idx][mat_idx], mat_order_id);
                 EXPECT_EQ(elem_idx, elem_id);
                 EXPECT_FLOAT_EQ(vol_fracs_baseline[elem_idx][mat_idx], vol_frac);
                 EXPECT_FLOAT_EQ(mset_vals_baseline[elem_idx][mat_idx], mset_val);
@@ -427,6 +447,14 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
     {
         // index [mat_idx][elem_idx]
         const std::vector<std::vector<index_t>> mat_ids_baseline = {
+            /* background */ {0, 0, 0},
+            /* circle_a   */ {1},
+            /* circle_b   */ {2},
+            /* circle_c   */ {3},
+        };
+
+        // index [mat_idx][elem_idx]
+        const std::vector<std::vector<index_t>> mat_order_ids_baseline = {
             /* background */ {0, 0, 0},
             /* circle_a   */ {1},
             /* circle_b   */ {2},
@@ -492,11 +520,13 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval)
             for (index_t elem_idx = 0; elem_idx < num_elems_for_mat; elem_idx ++)
             {
                 const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t mat_order_id = m_acc.get_mat_order_id(elem_idx, mat_idx);
                 const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
                 const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
                 const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
                 EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(mat_order_ids_baseline[mat_idx][elem_idx], mat_order_id);
                 EXPECT_EQ(elem_ids_baseline[mat_idx][elem_idx], elem_id);
                 EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
                 EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
@@ -604,6 +634,14 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
         };
 
         // index [mat_idx][elem_idx]
+        const std::vector<std::vector<index_t>> mat_order_ids_baseline = {
+            /* circle_a   */ {0, 0, 0, 0},
+            /* circle_b   */ {1, 1, 1, 1},
+            /* circle_c   */ {2, 2, 2, 2},
+            /* background */ {3, 3, 3, 3},
+        };
+
+        // index [mat_idx][elem_idx]
         const std::vector<std::vector<float64>> vol_fracs_baseline = {
             /* circle_a   */ {0.0, 0.0, 0.0, 0.333333333333333},
             /* circle_b   */ {0.0, 0.0, 0.0, 0.333333333333333},
@@ -654,11 +692,13 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             for (index_t mat_idx = 0; mat_idx < num_mats; mat_idx ++)
             {
                 const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t mat_order_id = m_acc.get_mat_order_id(elem_idx, mat_idx);
                 const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
                 const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
                 const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
                 EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(mat_order_ids_baseline[mat_idx][elem_idx], mat_order_id);
                 EXPECT_EQ(elem_idx, elem_id);
                 EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
                 EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
@@ -682,6 +722,14 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* element 1 */ {17},
             /* element 2 */ {17},
             /* element 3 */ {6, 2, 9},
+        };
+
+        // index [elem_idx][mat_idx]
+        const std::vector<std::vector<index_t>> mat_order_ids_baseline = {
+            /* element 0 */ {3},
+            /* element 1 */ {3},
+            /* element 2 */ {3},
+            /* element 3 */ {0, 1, 2},
         };
 
         // index [elem_idx][mat_idx]
@@ -733,11 +781,13 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             for (index_t mat_idx = 0; mat_idx < num_mats_for_elem; mat_idx ++)
             {
                 const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t mat_order_id = m_acc.get_mat_order_id(elem_idx, mat_idx);
                 const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
                 const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
                 const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
                 EXPECT_EQ(mat_ids_baseline[elem_idx][mat_idx], mat_id);
+                EXPECT_EQ(mat_order_ids_baseline[elem_idx][mat_idx], mat_order_id);
                 EXPECT_EQ(elem_idx, elem_id);
                 EXPECT_FLOAT_EQ(vol_fracs_baseline[elem_idx][mat_idx], vol_frac);
                 EXPECT_FLOAT_EQ(mset_vals_baseline[elem_idx][mat_idx], mset_val);
@@ -761,6 +811,14 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             /* circle_b   */ {2},
             /* circle_c   */ {9},
             /* background */ {17, 17, 17},
+        };
+
+        // index [mat_idx][elem_idx]
+        const std::vector<std::vector<index_t>> mat_order_ids_baseline = {
+            /* circle_a   */ {0},
+            /* circle_b   */ {1},
+            /* circle_c   */ {2},
+            /* background */ {3, 3, 3},
         };
 
         // index [mat_idx][elem_idx]
@@ -822,11 +880,13 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_spec
             for (index_t elem_idx = 0; elem_idx < num_elems_for_mat; elem_idx ++)
             {
                 const index_t mat_id = m_acc.get_mat_id(elem_idx, mat_idx);
+                const index_t mat_order_id = m_acc.get_mat_order_id(elem_idx, mat_idx);
                 const index_t elem_id = m_acc.get_elem_id(elem_idx, mat_idx);
                 const float64 vol_frac = m_acc.get_vol_frac(elem_idx, mat_idx);
                 const float64 mset_val = m_acc.get_mset_val(elem_idx, mat_idx);
 
                 EXPECT_EQ(mat_ids_baseline[mat_idx][elem_idx], mat_id);
+                EXPECT_EQ(mat_order_ids_baseline[mat_idx][elem_idx], mat_order_id);
                 EXPECT_EQ(elem_ids_baseline[mat_idx][elem_idx], elem_id);
                 EXPECT_FLOAT_EQ(vol_fracs_baseline[mat_idx][elem_idx], vol_frac);
                 EXPECT_FLOAT_EQ(mset_vals_baseline[mat_idx][elem_idx], mset_val);
@@ -863,6 +923,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_only_matset = MatsetAccessor(mset);
 
         EXPECT_NO_THROW(m_acc_only_matset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_only_matset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_only_matset.get_vol_frac(0, 0));
         EXPECT_THROW(m_acc_only_matset.get_mset_val(0, 0), conduit::Error);
@@ -871,6 +932,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_and_field = MatsetAccessor(mset, field);
 
         EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_vol_frac(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_mset_val(0, 0));
@@ -879,6 +941,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_and_specset = MatsetAccessor(mset, sset);
 
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_vol_frac(0, 0));
         EXPECT_THROW(m_acc_matset_and_specset.get_mset_val(0, 0), conduit::Error);
@@ -887,6 +950,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_field_specset = MatsetAccessor(mset, field, sset);
 
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_vol_frac(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_mset_val(0, 0));
@@ -902,6 +966,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_only_matset = MatsetAccessor(mset);
 
         EXPECT_NO_THROW(m_acc_only_matset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_only_matset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_only_matset.get_vol_frac(0, 0));
         EXPECT_THROW(m_acc_only_matset.get_mset_val(0, 0), conduit::Error);
@@ -910,6 +975,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_and_field = MatsetAccessor(mset, field);
 
         EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_vol_frac(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_mset_val(0, 0));
@@ -918,6 +984,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_and_specset = MatsetAccessor(mset, sset);
 
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_vol_frac(0, 0));
         EXPECT_THROW(m_acc_matset_and_specset.get_mset_val(0, 0), conduit::Error);
@@ -926,6 +993,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_field_specset = MatsetAccessor(mset, field, sset);
 
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_vol_frac(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_mset_val(0, 0));
@@ -941,6 +1009,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_only_matset = MatsetAccessor(mset);
 
         EXPECT_NO_THROW(m_acc_only_matset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_only_matset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_only_matset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_only_matset.get_vol_frac(0, 0));
         EXPECT_THROW(m_acc_only_matset.get_mset_val(0, 0), conduit::Error);
@@ -949,6 +1018,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_and_field = MatsetAccessor(mset, field);
 
         EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_field.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_vol_frac(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_field.get_mset_val(0, 0));
@@ -957,6 +1027,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_and_specset = MatsetAccessor(mset, sset);
 
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_and_specset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_and_specset.get_vol_frac(0, 0));
         EXPECT_THROW(m_acc_matset_and_specset.get_mset_val(0, 0), conduit::Error);
@@ -965,6 +1036,7 @@ TEST(conduit_blueprint_mesh_matset_accessor, matset_accessor_data_retrieval_erro
         MatsetAccessor m_acc_matset_field_specset = MatsetAccessor(mset, field, sset);
 
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_id(0, 0));
+        EXPECT_NO_THROW(m_acc_matset_field_specset.get_mat_order_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_elem_id(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_vol_frac(0, 0));
         EXPECT_NO_THROW(m_acc_matset_field_specset.get_mset_val(0, 0));


### PR DESCRIPTION
mat_order_id is the true order the material associated with `mat_idx` appears in the material map.

for full matsets, `mat_order_id = mat_idx`
for sbm matsets, `mat_order_id = mat_idx`
for sbe matsets, `mat_order_id` may not necessarily equal `mat_idx`