### PR TITLE
Tiled mesh fixes

### DIFF
--- a/src/libs/blueprint/conduit_blueprint_mesh_examples_tiled.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_examples_tiled.cpp
@@ -2350,14 +2350,17 @@ std::vector<Block> BlockSplitter::split(const Block &whole, IndexType nblocks) c
     std::cout << "  whole: " << whole << std::endl;
     std::cout << "  nblocks: " << nblocks << std::endl;
     std::cout << "  factors: " << f << std::endl;
+    std::cout << "  whole.size: " << whole.size() << std::endl;
 #endif
 
-    if(f.size() == 1 && f[0] == 1)
+    const auto wholeSize = whole.size();
+
+    if((f.size() == 1 && f[0] == 1) || wholeSize == 1)
     {
         // Single Block
         blocks.push_back(whole);
     }
-    else if(options.curveSplitting && whole.size() <= options.maximumSize)
+    else if(options.curveSplitting && wholeSize <= options.maximumSize)
     {
         // Hilbert curve splitting is enabled so do it.
         auto newblocks = split_hilbert(whole, nblocks);
@@ -3115,12 +3118,13 @@ TopDownTiler::generate(conduit::index_t nx, conduit::index_t ny, conduit::index_
 #ifdef CONDUIT_WRITE_BLOCKS
     std::vector<Block> writeBlocks;
 #endif
+    const bool threeD = nz > 0;
     if(m_selectedDomains.empty())
     {
         const bool multi = (blocks.size() > 1);
         for(size_t bi = 0; bi < blocks.size(); bi++)
         {
-            auto selectedBlock = neighbors(blocks, bi, dims[2] > 1);
+            auto selectedBlock = neighbors(blocks, bi, threeD);
             generateDomain(nx, ny, nz, multi ? res.append() : res, selectedBlock,
                            static_cast<IndexType>(bi), options);
 #ifdef CONDUIT_WRITE_BLOCKS
@@ -3133,7 +3137,7 @@ TopDownTiler::generate(conduit::index_t nx, conduit::index_t ny, conduit::index_
         const bool multi = (m_selectedDomains.size() > 1);
         for(const auto bi : m_selectedDomains)
         {
-            auto selectedBlock = neighbors(blocks, bi, dims[2] > 1);
+            auto selectedBlock = neighbors(blocks, bi, threeD);
             generateDomain(nx, ny, nz, multi ? res.append() : res, selectedBlock,
                            static_cast<IndexType>(bi), options);
 #ifdef CONDUIT_WRITE_BLOCKS

--- a/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
+++ b/src/libs/blueprint/conduit_blueprint_mesh_utils.cpp
@@ -2830,10 +2830,49 @@ topology::MeshInfoCollection::merge(const topology::MeshInfo &a, const topology:
     info.maxExtents[0] = std::max(a.maxExtents[0], b.maxExtents[0]);
     info.maxExtents[1] = std::max(a.maxExtents[1], b.maxExtents[1]);
     info.maxExtents[2] = std::max(a.maxExtents[2], b.maxExtents[2]);
-    info.minEdgeLength = std::min(a.minEdgeLength, b.minEdgeLength);
-    info.maxEdgeLength = std::max(a.maxEdgeLength, b.maxEdgeLength);
-    info.minDiagonalLength = std::min(a.minDiagonalLength, b.minDiagonalLength);
-    info.maxDiagonalLength = std::max(a.maxDiagonalLength, b.maxDiagonalLength);
+
+    auto choosyMin = [](float64 a, float64 b, float64 eps)
+    {
+        float64 v = eps;
+        if(a > eps && b > eps)
+        {
+            v = std::min(a, b);
+        }
+        else if(a > eps)
+        {
+            v = a;
+        }
+        else if(b > eps)
+        {
+            v = b;
+        }
+        return v;
+    };
+    auto choosyMax = [](float64 a, float64 b, float64 eps)
+    {
+        float64 v = eps;
+        if(a > eps && b > eps)
+        {
+            v = std::max(a, b);
+        }
+        else if(a > eps)
+        {
+            v = a;
+        }
+        else if(b > eps)
+        {
+            v = b;
+        }
+        return v;
+    };
+    // Use the "choosy" functions so we do not try to replace length values with zeroes
+    // when we merge in case some domains had 0 length edges (spherical to cartesian
+    // transformations might do that).
+    info.minEdgeLength = choosyMin(a.minEdgeLength, b.minEdgeLength, CONDUIT_EPSILON);
+    info.maxEdgeLength = choosyMax(a.maxEdgeLength, b.maxEdgeLength, CONDUIT_EPSILON);
+    info.minDiagonalLength = choosyMin(a.minDiagonalLength, b.minDiagonalLength, CONDUIT_EPSILON);
+    info.maxDiagonalLength = choosyMax(a.maxDiagonalLength, b.maxDiagonalLength, CONDUIT_EPSILON);
+
     return info;
 }
 
@@ -2861,6 +2900,10 @@ topology::Quantizer::Quantizer(const topology::MeshInfo &info) : meshInfo(info)
 {
     // Take the smaller of the lengths.
     length = static_cast<FloatValue>(std::min(meshInfo.minDiagonalLength, meshInfo.minEdgeLength));
+    // If the length is REALLY small, clamp it.
+    constexpr FloatValue minLength = std::numeric_limits<FloatValue>::epsilon() * FloatValue{10.};
+    length = std::max(length, minLength);
+
     offset = length / 2.;
 
     // Set some values derived from the MeshInfo.

--- a/src/tests/blueprint/t_blueprint_mpi_mesh_tiled.cpp
+++ b/src/tests/blueprint/t_blueprint_mpi_mesh_tiled.cpp
@@ -534,8 +534,6 @@ TEST(conduit_blueprint_mpi_mesh_utils, topdown_size_1_1_1)
 
   // There was a single domain so no adjsets.
   EXPECT_FALSE(res.has_path("adjsets"));
-
-  conduit::relay::io::blueprint::save_mesh(res, "tiled", "hdf5");
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/blueprint/t_blueprint_mpi_mesh_tiled.cpp
+++ b/src/tests/blueprint/t_blueprint_mpi_mesh_tiled.cpp
@@ -509,6 +509,36 @@ translate:
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mpi_mesh_utils, topdown_size_1_1_1)
+{
+  double extents[] = {0., 1., 0., 1., 0., 1.};
+  conduit::Node res, bopts;
+  bopts["meshname"] = "main";
+  bopts["datatype"] = "int32";
+  bopts["numDomains"] = 2;
+  bopts["extents"].set(extents, 6);
+  bopts["curveSplitting"] = 0;
+
+  // This makes a single tile due to 1, 1, 1 size.
+  conduit::blueprint::mesh::examples::tiled(1, 1, 1, res, bopts);
+
+  // See if that's what we got.
+  EXPECT_TRUE(res.has_path("coordsets/coords"));
+  EXPECT_EQ(res.fetch_existing("coordsets/coords/values/x").dtype().number_of_elements(), 66);
+  EXPECT_TRUE(res.has_path("topologies/main/elements/shape"));
+  EXPECT_EQ(res.fetch_existing("topologies/main/elements/shape").as_string(), "hex");
+  EXPECT_EQ(res.fetch_existing("topologies/main/elements/sizes").dtype().number_of_elements(), 24);
+  EXPECT_TRUE(res.has_path("topologies/boundary/elements/shape"));
+  EXPECT_EQ(res.fetch_existing("topologies/boundary/elements/shape").as_string(), "quad");
+  EXPECT_EQ(res.fetch_existing("topologies/boundary/elements/sizes").dtype().number_of_elements(), 64);
+
+  // There was a single domain so no adjsets.
+  EXPECT_FALSE(res.has_path("adjsets"));
+
+  conduit::relay::io::blueprint::save_mesh(res, "tiled", "hdf5");
+}
+
+//-----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
     int result = 0;


### PR DESCRIPTION
This PR fixes a problem generating a 1x1x1 tiled mesh.

* When 1x1x1 was requested with 2 domains, it caused infinite recursion when trying to split the tile block
* Fixed an issue with this mesh where the Z boundary faces were not being added
* Added a test for the 1x1x1 tile generation case
* Fixed an issue with merging 'MeshInfo` objects that might contain zero-length edge and diagonal lengths. This was causing a test to throw an exception from the quantizer. I think some domains had zero-length edges b/c of a spherical/polar coordinate transformation and then the merge caused those zero lengths to be used. Fixed now.