### PR TITLE
Device Support: codex implements the strawman

### DIFF
--- a/src/libs/conduit/conduit_core.hpp
+++ b/src/libs/conduit/conduit_core.hpp
@@ -21,16 +21,7 @@
 // -- configure time defines -- 
 //-----------------------------------------------------------------------------
 #include "conduit_config.hpp"
-
-//-----------------------------------------------------------------------------
-// -- host + device annotation helper --
-//-----------------------------------------------------------------------------
-#if (defined(CONDUIT_USE_CUDA) && defined(__CUDACC__)) || \
-    (defined(CONDUIT_USE_HIP) && defined(__HIPCC__))
-#define CONDUIT_EXEC_HOST_DEVICE __host__ __device__
-#else
-#define CONDUIT_EXEC_HOST_DEVICE
-#endif
+#include "conduit_device_annotations.hpp"
 
 //-----------------------------------------------------------------------------
 // -- define proper lib exports for various platforms -- 

--- a/src/libs/conduit/conduit_core.hpp
+++ b/src/libs/conduit/conduit_core.hpp
@@ -23,6 +23,16 @@
 #include "conduit_config.hpp"
 
 //-----------------------------------------------------------------------------
+// -- host + device annotation helper --
+//-----------------------------------------------------------------------------
+#if (defined(CONDUIT_USE_CUDA) && defined(__CUDACC__)) || \
+    (defined(CONDUIT_USE_HIP) && defined(__HIPCC__))
+#define CONDUIT_EXEC_HOST_DEVICE __host__ __device__
+#else
+#define CONDUIT_EXEC_HOST_DEVICE
+#endif
+
+//-----------------------------------------------------------------------------
 // -- define proper lib exports for various platforms -- 
 //-----------------------------------------------------------------------------
 #include "conduit_exports.h"
@@ -80,4 +90,3 @@ void        CONDUIT_API about(Node &);
 //-----------------------------------------------------------------------------
 
 #endif
-

--- a/src/libs/conduit/conduit_core.hpp
+++ b/src/libs/conduit/conduit_core.hpp
@@ -21,7 +21,7 @@
 // -- configure time defines -- 
 //-----------------------------------------------------------------------------
 #include "conduit_config.hpp"
-#include "conduit_device_annotations.hpp"
+#include "conduit_execution_qualifiers.hpp"
 
 //-----------------------------------------------------------------------------
 // -- define proper lib exports for various platforms -- 

--- a/src/libs/conduit/conduit_data_accessor.cpp
+++ b/src/libs/conduit/conduit_data_accessor.cpp
@@ -50,20 +50,6 @@ DataAccessor<T>::DataAccessor()
 {}
 
 //---------------------------------------------------------------------------//
-template <typename T>
-DataAccessor<T>::DataAccessor(const DataAccessor<T> &accessor)
-: m_data(accessor.m_data),
-  m_dtype(accessor.m_dtype),
-  m_node_ptr(accessor.m_node_ptr),
-  m_other_ptr(accessor.m_other_ptr),
-  m_other_dtype(accessor.m_other_dtype),
-  m_do_i_own_it(accessor.m_do_i_own_it),
-  m_offset(accessor.m_offset),
-  m_stride(accessor.m_stride)
-{}
-
-
-//---------------------------------------------------------------------------//
 template <typename T> 
 DataAccessor<T>::DataAccessor(void *data, const DataType &dtype)
 : m_data(data),
@@ -141,24 +127,6 @@ DataAccessor<T>::DataAccessor(const Node *node)
   m_offset(node->dtype().offset()),
   m_stride(node->dtype().stride())
 {}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-DataAccessor<T>::~DataAccessor()
-{
-    if (m_do_i_own_it)
-    {
-        if (execution::DeviceMemory::is_device_ptr(m_other_ptr))
-        {
-            execution::DeviceMemory::deallocate(m_other_ptr);
-        }
-        else
-        {
-            execution::HostMemory::deallocate(m_other_ptr);
-        }
-    }
-}
-
 
 //---------------------------------------------------------------------------// 
 ///
@@ -251,135 +219,10 @@ DataAccessor<T>::count(T val) const
 }
 
 //---------------------------------------------------------------------------//
-template <typename T> 
-DataAccessor<T> &
-DataAccessor<T>::operator=(const DataAccessor<T> &accessor)
-{
-    if(this != &accessor)
-    {
-        m_data  = accessor.m_data;
-        m_dtype = accessor.m_dtype;
-        m_node_ptr = accessor.m_node_ptr;
-        m_other_ptr = accessor.m_other_ptr;
-        m_other_dtype = accessor.m_other_dtype;
-        m_do_i_own_it = accessor.m_do_i_own_it;
-        m_offset = accessor.m_offset;
-        m_stride = accessor.m_stride;
-    }
-    return *this;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-T
-DataAccessor<T>::element(index_t idx) const
-{
-    switch(dtype().id())
-    {
-        // ints
-        case DataType::INT8_ID:
-            return (T)(*(int8*)(element_ptr(idx)));
-        case DataType::INT16_ID: 
-            return (T)(*(int16*)(element_ptr(idx)));
-        case DataType::INT32_ID:
-            return (T)(*(int32*)(element_ptr(idx)));
-        case DataType::INT64_ID:
-            return (T)(*(int64*)(element_ptr(idx)));
-        // uints
-        case DataType::UINT8_ID:
-            return (T)(*(uint8*)(element_ptr(idx)));
-        case DataType::UINT16_ID:
-            return (T)(*(uint16*)(element_ptr(idx)));
-        case DataType::UINT32_ID:
-            return (T)(*(uint32*)(element_ptr(idx)));
-        case DataType::UINT64_ID:
-            return (T)(*(uint64*)(element_ptr(idx)));
-        // floats 
-        case DataType::FLOAT32_ID:
-            return (T)(*(float32*)(element_ptr(idx)));
-        case DataType::FLOAT64_ID:
-            return (T)(*(float64*)(element_ptr(idx)));
-    }
-
-    // error
-    CONDUIT_ERROR("DataAccessor does not support dtype: "
-                  << dtype().name());
-    return (T)0;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T>
-template <typename U>
-typename std::enable_if<!std::is_pointer<U>::value, void>::type
-DataAccessor<T>::set(index_t idx, T value)
-{
-    switch(dtype().id())
-    {
-        // ints
-        case DataType::INT8_ID:
-        {
-            (*(int8*)(element_ptr(idx))) = static_cast<int8>(value);
-            break;
-        }
-        case DataType::INT16_ID:
-        {
-            (*(int16*)(element_ptr(idx))) = static_cast<int16>(value);
-            break;
-        }
-        case DataType::INT32_ID:
-        {
-            (*(int32*)(element_ptr(idx))) = static_cast<int32>(value);
-            break;
-        }
-        case DataType::INT64_ID:
-        {
-            (*(int64*)(element_ptr(idx))) = static_cast<int64>(value);
-            break;
-        }
-        // uints
-        case DataType::UINT8_ID:
-        {
-            (*(uint8*)(element_ptr(idx))) = static_cast<uint8>(value);
-            break;
-        }
-        case DataType::UINT16_ID:
-        {
-            (*(uint16*)(element_ptr(idx))) = static_cast<uint16>(value);
-            break;
-        }
-        case DataType::UINT32_ID:
-        {
-            (*(uint32*)(element_ptr(idx))) = static_cast<uint32>(value);
-            break;
-        }
-        case DataType::UINT64_ID:
-        {
-            (*(uint64*)(element_ptr(idx))) = static_cast<uint64>(value);
-            break;
-        }
-        // floats
-        case DataType::FLOAT32_ID:
-        {
-            (*(float32*)(element_ptr(idx))) = static_cast<float32>(value);
-            break;
-        }
-        case DataType::FLOAT64_ID:
-        {
-            (*(float64*)(element_ptr(idx))) = static_cast<float64>(value);
-            break;
-        }
-        default:
-            // error
-            CONDUIT_ERROR("DataAccessor does not support dtype: "
-                          << dtype().name());
-    }
-}
-
-//---------------------------------------------------------------------------//
 template <typename T>
 template <typename U>
 typename std::enable_if<std::is_pointer<U>::value, void>::type
-DataAccessor<T>::set(const T* values, index_t num_elements)
+DataAccessor<T>::set(const T* values, index_t num_elements) const
 {
     switch(dtype().id())
     {
@@ -579,52 +422,6 @@ DataAccessor<T>::fill(T value)
                           << dtype().name());
     }
 }
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-const DataType &
-DataAccessor<T>::dtype() const
-{
-    if (nullptr != m_node_ptr)
-    {
-        return (m_data == m_node_ptr->data_ptr() ? orig_dtype() : other_dtype());
-    }
-    else
-    {
-        return m_dtype;
-    }
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-const DataType &
-DataAccessor<T>::orig_dtype() const
-{
-    if (nullptr != m_node_ptr)
-    {
-        return m_node_ptr->dtype();
-    }
-    else
-    {
-        return m_dtype;
-    }
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-const DataType &
-DataAccessor<T>::other_dtype() const
-{
-    if (nullptr != m_node_ptr)
-    {
-        return m_other_dtype;
-    }
-    else
-    {
-        return m_dtype;
-    }
-}
-
 
 //---------------------------------------------------------------------------//
 template <typename T>

--- a/src/libs/conduit/conduit_data_accessor.cpp
+++ b/src/libs/conduit/conduit_data_accessor.cpp
@@ -40,6 +40,7 @@ namespace conduit
 template <typename T> 
 DataAccessor<T>::DataAccessor()
 : m_data(nullptr),
+  m_orig_data_ptr(nullptr),
   m_dtype(DataType::empty()),
   m_node_ptr(nullptr),
   m_other_ptr(nullptr),
@@ -53,6 +54,7 @@ DataAccessor<T>::DataAccessor()
 template <typename T> 
 DataAccessor<T>::DataAccessor(void *data, const DataType &dtype)
 : m_data(data),
+  m_orig_data_ptr(data),
   m_dtype(dtype),
   m_node_ptr(nullptr),
   m_other_ptr(nullptr),
@@ -67,6 +69,7 @@ DataAccessor<T>::DataAccessor(void *data, const DataType &dtype)
 template <typename T> 
 DataAccessor<T>::DataAccessor(const void *data, const DataType &dtype)
 : m_data(const_cast<void*>(data)),
+  m_orig_data_ptr(const_cast<void*>(data)),
   m_dtype(dtype),
   m_node_ptr(nullptr),
   m_other_ptr(nullptr),
@@ -80,6 +83,7 @@ DataAccessor<T>::DataAccessor(const void *data, const DataType &dtype)
 template <typename T> 
 DataAccessor<T>::DataAccessor(Node &node)
 : m_data(node.data_ptr()),
+  m_orig_data_ptr(node.data_ptr()),
   m_dtype(node.dtype()),
   m_node_ptr(&node),
   m_other_ptr(nullptr),
@@ -93,6 +97,7 @@ DataAccessor<T>::DataAccessor(Node &node)
 template <typename T> 
 DataAccessor<T>::DataAccessor(const Node &node)
 : m_data(const_cast<void*>(node.data_ptr())),
+  m_orig_data_ptr(const_cast<void*>(node.data_ptr())),
   m_dtype(node.dtype()),
   m_node_ptr(const_cast<Node*>(&node)),
   m_other_ptr(nullptr),
@@ -106,6 +111,7 @@ DataAccessor<T>::DataAccessor(const Node &node)
 template <typename T> 
 DataAccessor<T>::DataAccessor(Node *node)
 : m_data(node->data_ptr()),
+  m_orig_data_ptr(node->data_ptr()),
   m_dtype(node->dtype()), 
   m_node_ptr(node),
   m_other_ptr(nullptr),
@@ -119,6 +125,7 @@ DataAccessor<T>::DataAccessor(Node *node)
 template <typename T> 
 DataAccessor<T>::DataAccessor(const Node *node)
 : m_data(const_cast<void*>(node->data_ptr())),
+  m_orig_data_ptr(const_cast<void*>(node->data_ptr())),
   m_dtype(node->dtype()), 
   m_node_ptr(const_cast<Node*>(node)),
   m_other_ptr(nullptr),
@@ -613,6 +620,10 @@ DataAccessor<T>::assume()
         m_node_ptr->reset();
         m_node_ptr->schema_ptr()->set(dtype());
         m_node_ptr->set_data_ptr(m_data);
+
+        // the assumed data is now the accessor's new original backing storage
+        m_orig_data_ptr = m_data;
+        m_dtype = other_dtype();
 
         // we no longer own the data since we have given it to node
         m_other_ptr = nullptr;

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -68,6 +68,11 @@ public:
 //-----------------------------------------------------------------------------
         /// Default constructor
         DataAccessor();
+        ///
+        /// This copy constructor must remain inline in the header because a
+        /// DataAccessor is commonly captured by value into device lambdas.
+        /// Device compilation needs to see the copy operation.
+        ///
         /// Copy constructor
         CONDUIT_EXEC_HOST_DEVICE DataAccessor(const DataAccessor<T> &accessor)
         : m_data(accessor.m_data),
@@ -92,6 +97,11 @@ public:
         DataAccessor(Node *node);
         /// Access a const pointer to node data according to node dtype description.
         DataAccessor(const Node *node);
+        ///
+        /// This destructor must remain inline in the header because accessors
+        /// may be materialized during device compilation. The device path is a
+        /// no-op while the host path preserves ownership cleanup.
+        ///
         /// Destructor.
         CONDUIT_EXEC_HOST_DEVICE ~DataAccessor()
         {
@@ -121,6 +131,11 @@ public:
     /// counts number of occurrences of given value
     index_t         count(T value) const;
 
+    ///
+    /// This assignment operator must remain inline in the header because
+    /// accessors may be copied and assigned while preparing captures for
+    /// device lambdas.
+    ///
     /// Assignment operator
     CONDUIT_EXEC_HOST_DEVICE DataAccessor<T> &operator=(const DataAccessor<T> &accessor)
     {
@@ -142,6 +157,12 @@ public:
 //-----------------------------------------------------------------------------
 // Data and Info Access
 //-----------------------------------------------------------------------------
+    ///
+    /// These inline methods form the minimal device-usable slice of
+    /// DataAccessor. Kernels use them to read values, write values, and walk
+    /// array layout, so device compilation must see the definitions here in
+    /// the header.
+    ///
     CONDUIT_EXEC_HOST_DEVICE T operator[](index_t idx) const
                     {return element(idx);}
 
@@ -269,6 +290,11 @@ public:
     CONDUIT_EXEC_HOST_DEVICE index_t number_of_elements() const
                         {return dtype().number_of_elements();}
 
+    ///
+    /// dtype metadata is cached in the accessor so device code can choose
+    /// between the original and migrated layout without dereferencing Node.
+    /// This logic must stay inline in the header for device compilation.
+    ///
     CONDUIT_EXEC_HOST_DEVICE const DataType &dtype() const
     {
         if (nullptr != m_node_ptr)
@@ -283,6 +309,10 @@ public:
         }
     }
 
+    ///
+    /// These accessors are part of the cached dtype metadata used by device
+    /// code, so they must remain inline in the header alongside dtype().
+    ///
     CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const
                     { return m_dtype; }
 

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -310,7 +310,7 @@ public:
     }
 
     ///
-    /// These accessors are part of the cached dtype metadata used by device
+    /// These methods are part of the cached dtype metadata used by device
     /// code, so they must remain inline in the header alongside dtype().
     ///
     CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -270,15 +270,15 @@ public:
     CONDUIT_EXEC_HOST_DEVICE const DataType &dtype() const
     {
         return (nullptr != m_other_ptr && m_data == m_other_ptr)
-               ? m_other_dtype
-               : m_dtype;
+               ? other_dtype()
+               : orig_dtype();
     }
 
     CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const
                     { return m_dtype; }
 
     CONDUIT_EXEC_HOST_DEVICE const DataType &other_dtype() const
-                    { return nullptr != m_other_ptr ? m_other_dtype : m_dtype; }
+                    { return nullptr != m_node_ptr ? m_other_dtype : m_dtype; }
 
 //-----------------------------------------------------------------------------
 // Data movement

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -15,6 +15,7 @@
 //-----------------------------------------------------------------------------
 // -- conduit  includes -- 
 //-----------------------------------------------------------------------------
+#include "conduit_device_annotations.hpp"
 #include "conduit_core.hpp"
 #include "conduit_data_type.hpp"
 #include "conduit_memory_manager.hpp"

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -95,7 +95,7 @@ public:
         /// Destructor.
         CONDUIT_EXEC_HOST_DEVICE ~DataAccessor()
         {
-#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+#if !defined(CONDUIT_EXEC_DEVICE_COMPILE)
             if (m_do_i_own_it)
             {
                 if (execution::DeviceMemory::is_device_ptr(m_other_ptr))
@@ -171,7 +171,7 @@ public:
                 return (T)(*(float64*)(element_ptr(idx)));
             default:
             {
-#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+#if !defined(CONDUIT_EXEC_DEVICE_COMPILE)
                 CONDUIT_ERROR("DataAccessor does not support dtype: "
                               << dtype().name());
 #endif
@@ -242,7 +242,7 @@ public:
             }
             default:
             {
-#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+#if !defined(CONDUIT_EXEC_DEVICE_COMPILE)
                 CONDUIT_ERROR("DataAccessor does not support dtype: "
                               << dtype().name());
 #endif

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -271,9 +271,16 @@ public:
 
     CONDUIT_EXEC_HOST_DEVICE const DataType &dtype() const
     {
-        return (m_data == m_orig_data_ptr)
-               ? orig_dtype()
-               : other_dtype();
+        if (nullptr != m_node_ptr)
+        {
+            return (m_data == m_orig_data_ptr)
+                   ? orig_dtype()
+                   : other_dtype();
+        }
+        else
+        {
+            return m_dtype;
+        }
     }
 
     CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -15,7 +15,7 @@
 //-----------------------------------------------------------------------------
 // -- conduit  includes -- 
 //-----------------------------------------------------------------------------
-#include "conduit_device_annotations.hpp"
+#include "conduit_execution_qualifiers.hpp"
 #include "conduit_core.hpp"
 #include "conduit_data_type.hpp"
 #include "conduit_memory_manager.hpp"

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -71,6 +71,7 @@ public:
         /// Copy constructor
         CONDUIT_EXEC_HOST_DEVICE DataAccessor(const DataAccessor<T> &accessor)
         : m_data(accessor.m_data),
+          m_orig_data_ptr(accessor.m_orig_data_ptr),
           m_dtype(accessor.m_dtype),
           m_node_ptr(accessor.m_node_ptr),
           m_other_ptr(accessor.m_other_ptr),
@@ -126,6 +127,7 @@ public:
         if(this != &accessor)
         {
             m_data  = accessor.m_data;
+            m_orig_data_ptr = accessor.m_orig_data_ptr;
             m_dtype = accessor.m_dtype;
             m_node_ptr = accessor.m_node_ptr;
             m_other_ptr = accessor.m_other_ptr;
@@ -269,9 +271,9 @@ public:
 
     CONDUIT_EXEC_HOST_DEVICE const DataType &dtype() const
     {
-        return (nullptr != m_other_ptr && m_data == m_other_ptr)
-               ? other_dtype()
-               : orig_dtype();
+        return (m_data == m_orig_data_ptr)
+               ? orig_dtype()
+               : other_dtype();
     }
 
     CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const
@@ -367,6 +369,8 @@ private:
 //-----------------------------------------------------------------------------
     /// holds data (always external, never allocated)
     void           *m_data;
+    /// holds original wrapped data pointer
+    void           *m_orig_data_ptr;
     /// holds data description
     DataType        m_dtype;
 

--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -17,7 +17,10 @@
 //-----------------------------------------------------------------------------
 #include "conduit_core.hpp"
 #include "conduit_data_type.hpp"
+#include "conduit_memory_manager.hpp"
 #include "conduit_utils.hpp"
+
+#include <type_traits>
 
 
 //-----------------------------------------------------------------------------
@@ -65,7 +68,16 @@ public:
         /// Default constructor
         DataAccessor();
         /// Copy constructor
-        DataAccessor(const DataAccessor<T> &accessor);
+        CONDUIT_EXEC_HOST_DEVICE DataAccessor(const DataAccessor<T> &accessor)
+        : m_data(accessor.m_data),
+          m_dtype(accessor.m_dtype),
+          m_node_ptr(accessor.m_node_ptr),
+          m_other_ptr(accessor.m_other_ptr),
+          m_other_dtype(accessor.m_other_dtype),
+          m_do_i_own_it(false),
+          m_offset(accessor.m_offset),
+          m_stride(accessor.m_stride)
+        {}
         /// Access a pointer to raw data according to dtype description.
         DataAccessor(void *data, const DataType &dtype);
         /// Access a const pointer to raw data according to dtype description.
@@ -79,7 +91,22 @@ public:
         /// Access a const pointer to node data according to node dtype description.
         DataAccessor(const Node *node);
         /// Destructor.
-        ~DataAccessor();
+        CONDUIT_EXEC_HOST_DEVICE ~DataAccessor()
+        {
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+            if (m_do_i_own_it)
+            {
+                if (execution::DeviceMemory::is_device_ptr(m_other_ptr))
+                {
+                    execution::DeviceMemory::deallocate(m_other_ptr);
+                }
+                else
+                {
+                    execution::HostMemory::deallocate(m_other_ptr);
+                }
+            }
+#endif
+        }
 
     ///
     /// Summary Stats Helpers
@@ -93,26 +120,136 @@ public:
     index_t         count(T value) const;
 
     /// Assignment operator
-    DataAccessor<T>   &operator=(const DataAccessor<T> &accessor);
+    CONDUIT_EXEC_HOST_DEVICE DataAccessor<T> &operator=(const DataAccessor<T> &accessor)
+    {
+        if(this != &accessor)
+        {
+            m_data  = accessor.m_data;
+            m_dtype = accessor.m_dtype;
+            m_node_ptr = accessor.m_node_ptr;
+            m_other_ptr = accessor.m_other_ptr;
+            m_other_dtype = accessor.m_other_dtype;
+            m_do_i_own_it = false;
+            m_offset = accessor.m_offset;
+            m_stride = accessor.m_stride;
+        }
+        return *this;
+    }
 
 //-----------------------------------------------------------------------------
 // Data and Info Access
 //-----------------------------------------------------------------------------
-    T              operator[](index_t idx) const
+    CONDUIT_EXEC_HOST_DEVICE T operator[](index_t idx) const
                     {return element(idx);}
 
-    T              element(index_t idx) const;
+    CONDUIT_EXEC_HOST_DEVICE T element(index_t idx) const
+    {
+        switch(dtype().id())
+        {
+            case DataType::INT8_ID:
+                return (T)(*(int8*)(element_ptr(idx)));
+            case DataType::INT16_ID:
+                return (T)(*(int16*)(element_ptr(idx)));
+            case DataType::INT32_ID:
+                return (T)(*(int32*)(element_ptr(idx)));
+            case DataType::INT64_ID:
+                return (T)(*(int64*)(element_ptr(idx)));
+            case DataType::UINT8_ID:
+                return (T)(*(uint8*)(element_ptr(idx)));
+            case DataType::UINT16_ID:
+                return (T)(*(uint16*)(element_ptr(idx)));
+            case DataType::UINT32_ID:
+                return (T)(*(uint32*)(element_ptr(idx)));
+            case DataType::UINT64_ID:
+                return (T)(*(uint64*)(element_ptr(idx)));
+            case DataType::FLOAT32_ID:
+                return (T)(*(float32*)(element_ptr(idx)));
+            case DataType::FLOAT64_ID:
+                return (T)(*(float64*)(element_ptr(idx)));
+            default:
+            {
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+                CONDUIT_ERROR("DataAccessor does not support dtype: "
+                              << dtype().name());
+#endif
+                return (T)0;
+            }
+        }
+    }
 
     // Without the SFINAE features, the compiler doesn't know which of the two
     // set methods to call. We need to restrict them based on if the type is a 
     // pointer or not so that it is unambiguous which method should be called.
     template <typename U = T>
+    CONDUIT_EXEC_HOST_DEVICE
     typename std::enable_if<!std::is_pointer<U>::value, void>::type
-                    set(index_t idx, T value);
+                    set(index_t idx, T value) const
+    {
+        switch(dtype().id())
+        {
+            case DataType::INT8_ID:
+            {
+                (*(int8*)(element_ptr(idx))) = static_cast<int8>(value);
+                break;
+            }
+            case DataType::INT16_ID:
+            {
+                (*(int16*)(element_ptr(idx))) = static_cast<int16>(value);
+                break;
+            }
+            case DataType::INT32_ID:
+            {
+                (*(int32*)(element_ptr(idx))) = static_cast<int32>(value);
+                break;
+            }
+            case DataType::INT64_ID:
+            {
+                (*(int64*)(element_ptr(idx))) = static_cast<int64>(value);
+                break;
+            }
+            case DataType::UINT8_ID:
+            {
+                (*(uint8*)(element_ptr(idx))) = static_cast<uint8>(value);
+                break;
+            }
+            case DataType::UINT16_ID:
+            {
+                (*(uint16*)(element_ptr(idx))) = static_cast<uint16>(value);
+                break;
+            }
+            case DataType::UINT32_ID:
+            {
+                (*(uint32*)(element_ptr(idx))) = static_cast<uint32>(value);
+                break;
+            }
+            case DataType::UINT64_ID:
+            {
+                (*(uint64*)(element_ptr(idx))) = static_cast<uint64>(value);
+                break;
+            }
+            case DataType::FLOAT32_ID:
+            {
+                (*(float32*)(element_ptr(idx))) = static_cast<float32>(value);
+                break;
+            }
+            case DataType::FLOAT64_ID:
+            {
+                (*(float64*)(element_ptr(idx))) = static_cast<float64>(value);
+                break;
+            }
+            default:
+            {
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+                CONDUIT_ERROR("DataAccessor does not support dtype: "
+                              << dtype().name());
+#endif
+            }
+        }
+    }
 
     template <typename U = T>
     typename std::enable_if<std::is_pointer<U>::value, void>::type
-                    set(const T* values, index_t num_elements);
+                    set(const T* values, index_t num_elements) const;
 
     // void            set(const std::vector<typename std::remove_pointer<T>::type> &values)
     //                     { set(values.data(), values.size()); }
@@ -120,20 +257,27 @@ public:
 
     void            fill(T value);
 
-    const void     *element_ptr(index_t idx) const
+    CONDUIT_EXEC_HOST_DEVICE const void *element_ptr(index_t idx) const
                     {
                          return static_cast<const char*>(m_data) +
                                   dtype().element_index(idx);
                     }
 
-    index_t         number_of_elements() const 
+    CONDUIT_EXEC_HOST_DEVICE index_t number_of_elements() const
                         {return dtype().number_of_elements();}
 
-    const DataType &dtype()    const;
+    CONDUIT_EXEC_HOST_DEVICE const DataType &dtype() const
+    {
+        return (nullptr != m_other_ptr && m_data == m_other_ptr)
+               ? m_other_dtype
+               : m_dtype;
+    }
 
-    const DataType &orig_dtype() const;
+    CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const
+                    { return m_dtype; }
 
-    const DataType &other_dtype() const;
+    CONDUIT_EXEC_HOST_DEVICE const DataType &other_dtype() const
+                    { return nullptr != m_other_ptr ? m_other_dtype : m_dtype; }
 
 //-----------------------------------------------------------------------------
 // Data movement

--- a/src/libs/conduit/conduit_data_array.cpp
+++ b/src/libs/conduit/conduit_data_array.cpp
@@ -46,6 +46,7 @@ namespace conduit
 template <typename T> 
 DataArray<T>::DataArray()
 : m_data(nullptr),
+  m_orig_data_ptr(nullptr),
   m_dtype(DataType::empty()),
   m_node_ptr(nullptr),
   m_other_ptr(nullptr),
@@ -56,23 +57,10 @@ DataArray<T>::DataArray()
 {}
 
 //---------------------------------------------------------------------------//
-template <typename T>
-DataArray<T>::DataArray(const DataArray<T> &array)
-: m_data(array.m_data),
-  m_dtype(array.m_dtype),
-  m_node_ptr(array.m_node_ptr),
-  m_other_ptr(array.m_other_ptr),
-  m_other_dtype(array.m_other_dtype),
-  m_do_i_own_it(array.m_do_i_own_it),
-  m_offset(array.m_offset),
-  m_stride(array.m_stride)
-{}
-
-
-//---------------------------------------------------------------------------//
 template <typename T> 
 DataArray<T>::DataArray(void *data, const DataType &dtype)
 : m_data(data),
+  m_orig_data_ptr(data),
   m_dtype(dtype),
   m_node_ptr(nullptr),
   m_other_ptr(nullptr),
@@ -87,6 +75,7 @@ DataArray<T>::DataArray(void *data, const DataType &dtype)
 template <typename T> 
 DataArray<T>::DataArray(const void *data, const DataType &dtype)
 : m_data(const_cast<void*>(data)),
+  m_orig_data_ptr(const_cast<void*>(data)),
   m_dtype(dtype),
   m_node_ptr(nullptr),
   m_other_ptr(nullptr),
@@ -100,6 +89,7 @@ DataArray<T>::DataArray(const void *data, const DataType &dtype)
 template <typename T> 
 DataArray<T>::DataArray(Node &node)
 : m_data(node.data_ptr()),
+  m_orig_data_ptr(node.data_ptr()),
   m_dtype(node.dtype()),
   m_node_ptr(&node),
   m_other_ptr(nullptr),
@@ -113,6 +103,7 @@ DataArray<T>::DataArray(Node &node)
 template <typename T> 
 DataArray<T>::DataArray(const Node &node)
 : m_data(const_cast<void*>(node.data_ptr())),
+  m_orig_data_ptr(const_cast<void*>(node.data_ptr())),
   m_dtype(node.dtype()),
   m_node_ptr(const_cast<Node*>(&node)),
   m_other_ptr(nullptr),
@@ -126,6 +117,7 @@ DataArray<T>::DataArray(const Node &node)
 template <typename T> 
 DataArray<T>::DataArray(Node *node)
 : m_data(node->data_ptr()),
+  m_orig_data_ptr(node->data_ptr()),
   m_dtype(node->dtype()), 
   m_node_ptr(node),
   m_other_ptr(nullptr),
@@ -139,6 +131,7 @@ DataArray<T>::DataArray(Node *node)
 template <typename T> 
 DataArray<T>::DataArray(const Node *node)
 : m_data(const_cast<void*>(node->data_ptr())),
+  m_orig_data_ptr(const_cast<void*>(node->data_ptr())),
   m_dtype(node->dtype()), 
   m_node_ptr(const_cast<Node*>(node)),
   m_other_ptr(nullptr),
@@ -147,103 +140,6 @@ DataArray<T>::DataArray(const Node *node)
   m_offset(node->dtype().offset()),
   m_stride(node->dtype().stride())
 {}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-DataArray<T>::~DataArray()
-{
-    if (m_do_i_own_it)
-    {
-        if (execution::DeviceMemory::is_device_ptr(m_other_ptr))
-        {
-            execution::DeviceMemory::deallocate(m_other_ptr);
-        }
-        else
-        {
-            execution::HostMemory::deallocate(m_other_ptr);
-        }
-    }
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-DataArray<T> &
-DataArray<T>::operator=(const DataArray<T> &array)
-{
-    if(this != &array)
-    {
-        m_node_ptr = array.m_node_ptr;
-        m_other_ptr = array.m_other_ptr;
-        m_other_dtype = array.m_other_dtype;
-        m_do_i_own_it = array.m_do_i_own_it;
-        m_data = array.m_data;
-        m_dtype = array.m_dtype;
-        m_offset = array.m_offset;
-        m_stride = array.m_stride;
-    }
-    return *this;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-T &
-DataArray<T>::element(index_t idx)
-{ 
-    return (*(T*)(element_ptr(idx)));
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-T &             
-DataArray<T>::element(index_t idx) const 
-{ 
-    return (*(T*)(element_ptr(idx)));
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-const DataType &
-DataArray<T>::dtype() const
-{
-    if (nullptr != m_node_ptr)
-    {
-        return (m_data == m_node_ptr->data_ptr() ? orig_dtype() : other_dtype());
-    }
-    else
-    {
-        return m_dtype;
-    }
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-const DataType &
-DataArray<T>::orig_dtype() const
-{
-    if (nullptr != m_node_ptr)
-    {
-        return m_node_ptr->dtype();
-    }
-    else
-    {
-        return m_dtype;
-    }
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-const DataType &
-DataArray<T>::other_dtype() const
-{
-    if (nullptr != m_node_ptr)
-    {
-        return m_other_dtype;
-    }
-    else
-    {
-        return m_dtype;
-    }
-}
 
 //---------------------------------------------------------------------------//
 template <typename T> 
@@ -864,6 +760,10 @@ DataArray<T>::assume()
         m_node_ptr->schema_ptr()->set(dtype());
         m_node_ptr->set_data_ptr(m_data);
 
+        // the assumed data is now the array's new original backing storage
+        m_orig_data_ptr = m_data;
+        m_dtype = other_dtype();
+
         // we no longer own the data since we have given it to node
         m_other_ptr = nullptr;
         m_do_i_own_it = false;
@@ -1041,94 +941,6 @@ DataArray<T>::to_yaml_stream(std::ostream &os) const
 //---------------------------------------------------------------------------//
 // DataArray::set() signed integers single element
 //---------------------------------------------------------------------------//
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, int8 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, int16 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, int32 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, int64 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-// DataArray::set() unsigned integers single element
-//---------------------------------------------------------------------------//
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, uint8 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, uint16 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, uint32 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, uint64 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-// DataArray::set() floating point single element
-//---------------------------------------------------------------------------//
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, float32 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
-
-//---------------------------------------------------------------------------//
-template <typename T> 
-void
-DataArray<T>::set(index_t ele_idx, float64 value)
-{ 
-    this->element(ele_idx) = (T)value;
-}
 
 //---------------------------------------------------------------------------//
 template <typename T> 

--- a/src/libs/conduit/conduit_data_array.hpp
+++ b/src/libs/conduit/conduit_data_array.hpp
@@ -16,8 +16,10 @@
 //-----------------------------------------------------------------------------
 // -- conduit  includes -- 
 //-----------------------------------------------------------------------------
+#include "conduit_execution_qualifiers.hpp"
 #include "conduit_core.hpp"
 #include "conduit_data_type.hpp"
+#include "conduit_memory_manager.hpp"
 #include "conduit_utils.hpp"
 
 //-----------------------------------------------------------------------------
@@ -64,8 +66,23 @@ public:
 //-----------------------------------------------------------------------------
         /// default constructor
         DataArray();
+        ///
+        /// This copy constructor must remain inline in the header because a
+        /// DataArray is commonly captured by value into device lambdas.
+        /// Device compilation needs to see the copy operation.
+        ///
         /// copy constructor
-        DataArray(const DataArray<T> &array);
+        CONDUIT_EXEC_HOST_DEVICE DataArray(const DataArray<T> &array)
+        : m_data(array.m_data),
+          m_orig_data_ptr(array.m_orig_data_ptr),
+          m_dtype(array.m_dtype),
+          m_node_ptr(array.m_node_ptr),
+          m_other_ptr(array.m_other_ptr),
+          m_other_dtype(array.m_other_dtype),
+          m_do_i_own_it(false),
+          m_offset(array.m_offset),
+          m_stride(array.m_stride)
+        {}
         /// Access a pointer to raw data according to dtype description.
         DataArray(void *data, const DataType &dtype);
         /// Access a const pointer to raw data according to dtype description.
@@ -78,46 +95,117 @@ public:
         DataArray(Node *node);
         /// Access a const pointer to node data according to node dtype description.
         DataArray(const Node *node);
+        ///
+        /// This destructor must remain inline in the header because arrays may
+        /// be materialized during device compilation. The device path is a
+        /// no-op while the host path preserves ownership cleanup.
+        ///
         /// Destructor
-       ~DataArray();
+        CONDUIT_EXEC_HOST_DEVICE ~DataArray()
+        {
+#if !defined(CONDUIT_EXEC_DEVICE_COMPILE)
+            if (m_do_i_own_it)
+            {
+                if (execution::DeviceMemory::is_device_ptr(m_other_ptr))
+                {
+                    execution::DeviceMemory::deallocate(m_other_ptr);
+                }
+                else
+                {
+                    execution::HostMemory::deallocate(m_other_ptr);
+                }
+            }
+#endif
+        }
 
+    ///
+    /// This assignment operator must remain inline in the header because
+    /// arrays may be copied and assigned while preparing captures for device
+    /// lambdas.
+    ///
     /// Assignment operator
-    DataArray<T>   &operator=(const DataArray<T> &array);
+    CONDUIT_EXEC_HOST_DEVICE DataArray<T> &operator=(const DataArray<T> &array)
+    {
+        if(this != &array)
+        {
+            m_data = array.m_data;
+            m_orig_data_ptr = array.m_orig_data_ptr;
+            m_dtype = array.m_dtype;
+            m_node_ptr = array.m_node_ptr;
+            m_other_ptr = array.m_other_ptr;
+            m_other_dtype = array.m_other_dtype;
+            m_do_i_own_it = false;
+            m_offset = array.m_offset;
+            m_stride = array.m_stride;
+        }
+        return *this;
+    }
 
 //-----------------------------------------------------------------------------
 // Data and Info Access
 //-----------------------------------------------------------------------------
     typedef T ElementType;
 
-    T              &operator[](index_t idx)
+    ///
+    /// These inline methods form the minimal device-usable slice of
+    /// DataArray. Kernels use them to read values, write values, and walk
+    /// array layout, so device compilation must see the definitions here in
+    /// the header.
+    ///
+    CONDUIT_EXEC_HOST_DEVICE T &operator[](index_t idx)
                     {return element(idx);}
-    T              &operator[](index_t idx) const
+    CONDUIT_EXEC_HOST_DEVICE T &operator[](index_t idx) const
                     {return element(idx);}
     
-    T              &element(index_t idx);
-    T              &element(index_t idx) const;
+    CONDUIT_EXEC_HOST_DEVICE T &element(index_t idx)
+                    {return (*(T*)(element_ptr(idx)));}
+    CONDUIT_EXEC_HOST_DEVICE T &element(index_t idx) const
+                    {return (*(T*)(element_ptr(idx)));}
 
-    void           *element_ptr(index_t idx)
+    CONDUIT_EXEC_HOST_DEVICE void *element_ptr(index_t idx)
                     {
                         return static_cast<char*>(m_data) +
                             dtype().element_index(idx);
                     };
 
-    const void     *element_ptr(index_t idx) const 
+    CONDUIT_EXEC_HOST_DEVICE const void *element_ptr(index_t idx) const
                     {
                          return static_cast<char*>(m_data) +
                             dtype().element_index(idx);
                     };
 
-    index_t         number_of_elements() const 
+    CONDUIT_EXEC_HOST_DEVICE index_t number_of_elements() const
                         {return dtype().number_of_elements();}
-    const DataType &dtype()    const;
+    ///
+    /// dtype metadata is cached in the array so device code can choose
+    /// between the original and migrated layout without dereferencing Node.
+    /// This logic must stay inline in the header for device compilation.
+    ///
+    CONDUIT_EXEC_HOST_DEVICE const DataType &dtype() const
+    {
+        if (nullptr != m_node_ptr)
+        {
+            return (m_data == m_orig_data_ptr)
+                   ? orig_dtype()
+                   : other_dtype();
+        }
+        else
+        {
+            return m_dtype;
+        }
+    }
 
-    const DataType &orig_dtype() const;
+    ///
+    /// These methods are part of the cached dtype metadata used by device
+    /// code, so they must remain inline in the header alongside dtype().
+    ///
+    CONDUIT_EXEC_HOST_DEVICE const DataType &orig_dtype() const
+                    { return m_dtype; }
 
-    const DataType &other_dtype() const;
+    CONDUIT_EXEC_HOST_DEVICE const DataType &other_dtype() const
+                    { return nullptr != m_node_ptr ? m_other_dtype : m_dtype; }
     
-    void           *data_ptr() const 
+    CONDUIT_EXEC_HOST_DEVICE void *data_ptr() const
                         { return m_data;}
 
     bool            compatible(const DataArray<T> &array) const;
@@ -154,20 +242,30 @@ public:
 // Setters
 //-----------------------------------------------------------------------------
     /// signed integer single element
-    void            set(index_t elem_idx, int8  value);
-    void            set(index_t elem_idx, int16 value);
-    void            set(index_t elem_idx, int32 value);
-    void            set(index_t elem_idx, int64 value);
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, int8  value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, int16 value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, int32 value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, int64 value) const
+                    { this->element(elem_idx) = (T)value; }
 
     // unsigned integer single element
-    void            set(index_t elem_idx, uint8  value);
-    void            set(index_t elem_idx, uint16 value);
-    void            set(index_t elem_idx, uint32 value);
-    void            set(index_t elem_idx, uint64 value);
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, uint8  value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, uint16 value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, uint32 value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, uint64 value) const
+                    { this->element(elem_idx) = (T)value; }
 
     /// floating point single element
-    void            set(index_t elem_idx, float32 value);
-    void            set(index_t elem_idx, float64 value);
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, float32 value) const
+                    { this->element(elem_idx) = (T)value; }
+    CONDUIT_EXEC_HOST_DEVICE void set(index_t elem_idx, float64 value) const
+                    { this->element(elem_idx) = (T)value; }
 
     /// signed integer arrays
     void            set(const int8  *values, index_t num_elements);
@@ -427,6 +525,9 @@ private:
 //-----------------------------------------------------------------------------
     /// holds data (always external, never allocated)
     void           *m_data;
+    /// caches the original backing pointer so device code can reason about
+    /// migrated state without dereferencing Node.
+    void           *m_orig_data_ptr;
     /// holds data description
     DataType        m_dtype;
 

--- a/src/libs/conduit/conduit_data_type.cpp
+++ b/src/libs/conduit/conduit_data_type.cpp
@@ -488,41 +488,6 @@ DataType::c_long_double(conduit::index_t num_elements,
 //-----------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------//
-DataType::DataType()
-: m_id(DataType::EMPTY_ID),
-  m_num_ele(0),
-  m_offset(0),
-  m_stride(0),
-  m_ele_bytes(0),
-  m_endianness(Endianness::DEFAULT_ID)
-{}
-
-//---------------------------------------------------------------------------// 
-DataType::DataType(const DataType& value)
-: m_id(value.m_id),
-  m_num_ele(value.m_num_ele),
-  m_offset(value.m_offset),
-  m_stride(value.m_stride),
-  m_ele_bytes(value.m_ele_bytes),
-  m_endianness(value.m_endianness)
-{}
-
-
-//---------------------------------------------------------------------------// 
-DataType& DataType::operator=(const DataType& value)
-{
-  m_id = value.m_id;
-  m_num_ele = value.m_num_ele;
-  m_offset = value.m_offset;
-  m_stride = value.m_stride;
-  m_ele_bytes = value.m_ele_bytes;
-  m_endianness = value.m_endianness;
-
-  return *this;
-}
-
-
-//---------------------------------------------------------------------------//
 DataType::DataType(conduit::index_t id, conduit::index_t num_elements)
 : m_id(id),
   m_num_ele(num_elements),
@@ -545,27 +510,6 @@ DataType::DataType(const std::string &dtype_name,
   m_stride(stride),
   m_ele_bytes(element_bytes),
   m_endianness(endianness)
-{}
-
-//---------------------------------------------------------------------------// 
-DataType::DataType(conduit::index_t dtype_id,
-                   conduit::index_t num_elements,
-                   conduit::index_t offset,
-                   conduit::index_t stride,
-                   conduit::index_t element_bytes,
-                   conduit::index_t endianness)
-                
-: m_id(dtype_id),
-  m_num_ele(num_elements),
-  m_offset(offset),
-  m_stride(stride),
-  m_ele_bytes(element_bytes),
-  m_endianness(endianness)
-{}
-
-
-//---------------------------------------------------------------------------//
-DataType::~DataType()
 {}
 
 //---------------------------------------------------------------------------//
@@ -1032,22 +976,6 @@ DataType::endianness_matches_machine() const
                     Endianness::machine_is_big_endian()) ||
              (m_endianness == Endianness::LITTLE_ID && 
                     Endianness::machine_is_little_endian()) );
-}
-
-//---------------------------------------------------------------------------// 
-conduit::index_t
-DataType::element_index(conduit::index_t idx) const
-{
-    /// TODO: This will be an expensive check, placed this in 
-    /// to help us ferret out some places were we are creating default 
-    /// datatypes that have stride == 0.
-
-    if(idx > 0 && m_stride == 0)
-    {
-        CONDUIT_WARN("Node index calculation with with stride = 0");
-    }
-    
-    return m_offset + m_stride * idx;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -21,7 +21,7 @@
 //-----------------------------------------------------------------------------
 // -- conduit library includes -- 
 //-----------------------------------------------------------------------------
-#include "conduit_device_annotations.hpp"
+#include "conduit_execution_qualifiers.hpp"
 #include "conduit_core.hpp"
 #include "conduit_endianness.hpp"
 #include "conduit_utils.hpp"

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -21,6 +21,7 @@
 //-----------------------------------------------------------------------------
 // -- conduit library includes -- 
 //-----------------------------------------------------------------------------
+#include "conduit_device_annotations.hpp"
 #include "conduit_core.hpp"
 #include "conduit_endianness.hpp"
 #include "conduit_utils.hpp"

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -323,11 +323,35 @@ public:
 //-----------------------------------------------------------------------------
 
     /// standard constructor
-    DataType();
+    CONDUIT_EXEC_HOST_DEVICE DataType()
+    : m_id(DataType::EMPTY_ID),
+      m_num_ele(0),
+      m_offset(0),
+      m_stride(0),
+      m_ele_bytes(0),
+      m_endianness(Endianness::DEFAULT_ID)
+    {}
     /// copy constructor
-    DataType(const DataType& type);
+    CONDUIT_EXEC_HOST_DEVICE DataType(const DataType& type)
+    : m_id(type.m_id),
+      m_num_ele(type.m_num_ele),
+      m_offset(type.m_offset),
+      m_stride(type.m_stride),
+      m_ele_bytes(type.m_ele_bytes),
+      m_endianness(type.m_endianness)
+    {}
     /// Assignment operator
-    DataType& operator=(const DataType& type);
+    CONDUIT_EXEC_HOST_DEVICE DataType& operator=(const DataType& type)
+    {
+        m_id = type.m_id;
+        m_num_ele = type.m_num_ele;
+        m_offset = type.m_offset;
+        m_stride = type.m_stride;
+        m_ele_bytes = type.m_ele_bytes;
+        m_endianness = type.m_endianness;
+
+        return *this;
+    }
     /// construct simplest dtype for given type id
     explicit DataType(conduit::index_t id,
                       conduit::index_t num_elements=0);
@@ -341,15 +365,22 @@ public:
              conduit::index_t endianness);
 
     /// construct from full details, given a data type id
-    DataType(conduit::index_t dtype_id,
-             conduit::index_t num_elements,
-             conduit::index_t offset,
-             conduit::index_t stride,
-             conduit::index_t element_bytes,
-             conduit::index_t endianness);
+    CONDUIT_EXEC_HOST_DEVICE DataType(conduit::index_t dtype_id,
+                                      conduit::index_t num_elements,
+                                      conduit::index_t offset,
+                                      conduit::index_t stride,
+                                      conduit::index_t element_bytes,
+                                      conduit::index_t endianness)
+    : m_id(dtype_id),
+      m_num_ele(num_elements),
+      m_offset(offset),
+      m_stride(stride),
+      m_ele_bytes(element_bytes),
+      m_endianness(endianness)
+    {}
 
     /// destructor
-   ~DataType();
+   CONDUIT_EXEC_HOST_DEVICE ~DataType() = default;
 
    /// return a data type to the default (empty) state
    void  reset();
@@ -390,15 +421,21 @@ public:
 //-----------------------------------------------------------------------------
 // Getters and info methods.
 //-----------------------------------------------------------------------------
-    conduit::index_t     id()    const { return m_id;}
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t id() const { return m_id;}
     std::string name()  const { return id_to_name(m_id);}
 
-    conduit::index_t     number_of_elements()  const { return m_num_ele;}
-    conduit::index_t     offset()              const { return m_offset;}
-    conduit::index_t     stride()              const { return m_stride;}
-    conduit::index_t     element_bytes()       const { return m_ele_bytes;}
-    conduit::index_t     endianness()          const { return m_endianness;}
-    conduit::index_t     element_index(conduit::index_t idx) const;
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t number_of_elements() const
+                    { return m_num_ele; }
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t offset() const
+                    { return m_offset; }
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t stride() const
+                    { return m_stride; }
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t element_bytes() const
+                    { return m_ele_bytes; }
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t endianness() const
+                    { return m_endianness; }
+    CONDUIT_EXEC_HOST_DEVICE conduit::index_t element_index(conduit::index_t idx) const
+                    { return m_offset + m_stride * idx; }
 
     /// strided bytes = stride() * (number_of_elements() -1) + element_bytes()
     conduit::index_t     strided_bytes() const;

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -438,7 +438,7 @@ public:
                     { return m_endianness; }
     CONDUIT_EXEC_HOST_DEVICE conduit::index_t element_index(conduit::index_t idx) const
                     {
-#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+#if !defined(CONDUIT_EXEC_DEVICE_COMPILE)
                         if(idx > 0 && m_stride == 0)
                         {
                             CONDUIT_WARN("Node index calculation with with stride = 0");

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -23,6 +23,7 @@
 //-----------------------------------------------------------------------------
 #include "conduit_core.hpp"
 #include "conduit_endianness.hpp"
+#include "conduit_utils.hpp"
 
 //-----------------------------------------------------------------------------
 // -- begin conduit:: --
@@ -435,7 +436,15 @@ public:
     CONDUIT_EXEC_HOST_DEVICE conduit::index_t endianness() const
                     { return m_endianness; }
     CONDUIT_EXEC_HOST_DEVICE conduit::index_t element_index(conduit::index_t idx) const
-                    { return m_offset + m_stride * idx; }
+                    {
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
+                        if(idx > 0 && m_stride == 0)
+                        {
+                            CONDUIT_WARN("Node index calculation with with stride = 0");
+                        }
+#endif
+                        return m_offset + m_stride * idx;
+                    }
 
     /// strided bytes = stride() * (number_of_elements() -1) + element_bytes()
     conduit::index_t     strided_bytes() const;

--- a/src/libs/conduit/conduit_data_type.hpp
+++ b/src/libs/conduit/conduit_data_type.hpp
@@ -324,6 +324,11 @@ public:
 // Construction and Destruction
 //-----------------------------------------------------------------------------
 
+    ///
+    /// These simple constructors and assignment operators must remain inline
+    /// in the header because DataAccessor carries DataType metadata into
+    /// device lambdas by value.
+    ///
     /// standard constructor
     CONDUIT_EXEC_HOST_DEVICE DataType()
     : m_id(DataType::EMPTY_ID),
@@ -423,6 +428,11 @@ public:
 //-----------------------------------------------------------------------------
 // Getters and info methods.
 //-----------------------------------------------------------------------------
+    ///
+    /// These metadata accessors must remain inline in the header because the
+    /// device-usable slice of DataAccessor queries them while executing inside
+    /// device lambdas.
+    ///
     CONDUIT_EXEC_HOST_DEVICE conduit::index_t id() const { return m_id;}
     std::string name()  const { return id_to_name(m_id);}
 
@@ -436,6 +446,11 @@ public:
                     { return m_ele_bytes; }
     CONDUIT_EXEC_HOST_DEVICE conduit::index_t endianness() const
                     { return m_endianness; }
+    ///
+    /// element_index() is part of the address calculation path used from
+    /// device lambdas, so it must remain inline in the header. The warning is
+    /// kept host-only because device code cannot emit Conduit diagnostics.
+    ///
     CONDUIT_EXEC_HOST_DEVICE conduit::index_t element_index(conduit::index_t idx) const
                     {
 #if !defined(CONDUIT_EXEC_DEVICE_COMPILE)

--- a/src/libs/conduit/conduit_device_annotations.hpp
+++ b/src/libs/conduit/conduit_device_annotations.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_device_annotations.hpp
+///
+//-----------------------------------------------------------------------------
+
+#ifndef CONDUIT_DEVICE_ANNOTATIONS_HPP
+#define CONDUIT_DEVICE_ANNOTATIONS_HPP
+
+#include "conduit_config.hpp"
+
+//-----------------------------------------------------------------------------
+// -- host + device annotation helper --
+//-----------------------------------------------------------------------------
+#if (defined(CONDUIT_USE_CUDA) && defined(__CUDACC__)) || \
+    (defined(CONDUIT_USE_HIP) && defined(__HIPCC__))
+#define CONDUIT_EXEC_HOST_DEVICE __host__ __device__
+#else
+#define CONDUIT_EXEC_HOST_DEVICE
+#endif
+
+#endif

--- a/src/libs/conduit/conduit_execution_qualifiers.hpp
+++ b/src/libs/conduit/conduit_execution_qualifiers.hpp
@@ -4,12 +4,12 @@
 
 //-----------------------------------------------------------------------------
 ///
-/// file: conduit_device_annotations.hpp
+/// file: conduit_execution_qualifiers.hpp
 ///
 //-----------------------------------------------------------------------------
 
-#ifndef CONDUIT_DEVICE_ANNOTATIONS_HPP
-#define CONDUIT_DEVICE_ANNOTATIONS_HPP
+#ifndef CONDUIT_EXECUTION_QUALIFIERS_HPP
+#define CONDUIT_EXECUTION_QUALIFIERS_HPP
 
 #include "conduit_config.hpp"
 

--- a/src/libs/conduit/conduit_execution_qualifiers.hpp
+++ b/src/libs/conduit/conduit_execution_qualifiers.hpp
@@ -23,4 +23,11 @@
 #define CONDUIT_EXEC_HOST_DEVICE
 #endif
 
+//-----------------------------------------------------------------------------
+// -- device compilation helper --
+//-----------------------------------------------------------------------------
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define CONDUIT_EXEC_DEVICE_COMPILE
+#endif
+
 #endif

--- a/src/libs/conduit/conduit_memory_manager.cpp
+++ b/src/libs/conduit/conduit_memory_manager.cpp
@@ -214,7 +214,7 @@ DeviceMemory::is_device_ptr(const void *ptr, bool &is_gpu, bool &is_unified)
 
     // clear last error so other error checking does
     // not pick it up
-    hipError_t error = hipGetLastError();
+    (void)hipGetLastError();
     is_gpu = (perr == hipSuccess) &&
              (atts.TYPE_ATTR == hipMemoryTypeDevice ||
               atts.TYPE_ATTR ==  hipMemoryTypeUnified );
@@ -246,7 +246,7 @@ DeviceMemory::is_device_ptr(const void *ptr)
     const hipError_t perr = hipPointerGetAttributes(&atts, ptr);
     // clear last error so other error checking does
     // not pick it up
-    hipError_t error = hipGetLastError();
+    (void)hipGetLastError();
     return perr == hipSuccess &&
                 (atts.TYPE_ATTR == hipMemoryTypeDevice ||
                  atts.TYPE_ATTR == hipMemoryTypeUnified);
@@ -273,7 +273,11 @@ MagicMemory::set(void * ptr, int value, size_t num )
 #if defined(CONDUIT_USE_CUDA)
         cudaMemset(ptr,value,num);
 #elif defined(CONDUIT_USE_HIP)
-        hipMemset(ptr,value,num);
+        const hipError_t err = hipMemset(ptr,value,num);
+        if (err != hipSuccess)
+        {
+            CONDUIT_ERROR("hipMemset failed: " << hipGetErrorName(err));
+        }
 #endif
     }
     else
@@ -297,7 +301,13 @@ MagicMemory::copy(void * destination, const void * source, size_t num)
 #if defined(CONDUIT_USE_CUDA)
         cudaMemcpy(destination, source, num, cudaMemcpyDeviceToDevice);
 #elif defined(CONDUIT_USE_HIP)
-        hipMemcpy(destination, source, num, hipMemcpyDeviceToDevice);
+        const hipError_t err =
+            hipMemcpy(destination, source, num, hipMemcpyDeviceToDevice);
+        if (err != hipSuccess)
+        {
+            CONDUIT_ERROR("hipMemcpy device-to-device failed: "
+                          << hipGetErrorName(err));
+        }
 #endif
     }
     else if (src_is_gpu && !dst_is_gpu)
@@ -305,7 +315,13 @@ MagicMemory::copy(void * destination, const void * source, size_t num)
 #if defined(CONDUIT_USE_CUDA)
         cudaMemcpy(destination, source, num, cudaMemcpyDeviceToHost);
 #elif defined(CONDUIT_USE_HIP)
-        hipMemcpy(destination, source, num, hipMemcpyDeviceToHost);
+        const hipError_t err =
+            hipMemcpy(destination, source, num, hipMemcpyDeviceToHost);
+        if (err != hipSuccess)
+        {
+            CONDUIT_ERROR("hipMemcpy device-to-host failed: "
+                          << hipGetErrorName(err));
+        }
 #endif
     }
     else if (!src_is_gpu && dst_is_gpu)
@@ -313,7 +329,13 @@ MagicMemory::copy(void * destination, const void * source, size_t num)
 #if defined(CONDUIT_USE_CUDA)
         cudaMemcpy(destination, source, num, cudaMemcpyHostToDevice);
 #elif defined(CONDUIT_USE_HIP)
-        hipMemcpy(destination, source, num, hipMemcpyHostToDevice);
+        const hipError_t err =
+            hipMemcpy(destination, source, num, hipMemcpyHostToDevice);
+        if (err != hipSuccess)
+        {
+            CONDUIT_ERROR("hipMemcpy host-to-device failed: "
+                          << hipGetErrorName(err));
+        }
 #endif
     }
     else

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -522,6 +522,8 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -547,6 +549,8 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -571,6 +575,8 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -596,6 +602,8 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -620,6 +628,8 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -663,6 +673,8 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -691,6 +703,8 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -719,6 +733,8 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -747,6 +763,8 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -774,6 +792,8 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -818,6 +838,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -844,6 +866,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -870,6 +894,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -896,6 +922,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -921,6 +949,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -964,6 +994,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -990,6 +1022,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -1016,6 +1050,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -1042,6 +1078,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);
@@ -1068,6 +1106,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
         float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
         EXPECT_EQ(result_acc[0], 2.0);

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -382,13 +382,6 @@ TEST(conduit_execution, for_all_and_dispatch)
 }
 
 //-----------------------------------------------------------------------------
-enum StrawmanStartSpace
-{
-    STRAWMAN_START_ON_HOST,
-    STRAWMAN_START_ON_DEVICE
-};
-
-//-----------------------------------------------------------------------------
 float64 *
 strawman_make_device_buffer(const float64 *host_vals, index_t num_vals)
 {
@@ -400,77 +393,53 @@ strawman_make_device_buffer(const float64 *host_vals, index_t num_vals)
     return device_ptr;
 }
 
-//-----------------------------------------------------------------------------
-void
-strawman_cleanup_node(Node &node,
-                      StrawmanStartSpace src_start_space,
-                      StrawmanStartSpace des_start_space,
-                      float64 *src_device_ptr,
-                      float64 *des_device_ptr)
-{
-    node.reset();
-
-    if (src_start_space == STRAWMAN_START_ON_DEVICE)
-    {
-        execution::DeviceMemory::deallocate(src_device_ptr);
-    }
-
-    if (des_start_space == STRAWMAN_START_ON_DEVICE)
-    {
-        execution::DeviceMemory::deallocate(des_device_ptr);
-    }
-}
-
-//-----------------------------------------------------------------------------
 void
 strawman_run_policy_and_sync(Node &node,
                              ExecutionPolicy policy,
                              const bool expect_src_device_backed_result,
                              const bool expect_des_device_backed_result)
 {
+    // DataAccessors wrap node leaf data.
+    float64_accessor acc_src(node["src"]);
+    float64_accessor acc_des(node["des"]);
+
+    // Ask the accessors to move their data to the memory space occupied
+    // by the requested execution policy if their data is not already
+    // there.
+    acc_src.use_with(policy);
+    acc_des.use_with(policy);
+
+    // Our forall will execute in the memory space selected by the
+    // requested ExecutionPolicy.
+    index_t size = acc_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
     {
-        // DataAccessors wrap node leaf data.
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
+        const float64 val = 2.0 * acc_src[idx];
+        acc_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-        // Ask the accessors to move their data to the memory space occupied
-        // by the requested execution policy if their data is not already
-        // there.
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
+    // Sync values to node["des"].
+    // This is a no op if node["des"] was originally in the same memory
+    // space as the requested execution policy.
+    acc_des.sync();
 
-        // Our forall will execute in the memory space selected by the
-        // requested ExecutionPolicy.
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
+    if (expect_src_device_backed_result)
+    {
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+    }
+    else
+    {
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+    }
 
-        // Sync values to node["des"].
-        // This is a no op if node["des"] was originally in the same memory
-        // space as the requested execution policy.
-        acc_des.sync();
-
-        if (expect_src_device_backed_result)
-        {
-            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-        }
-        else
-        {
-            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-        }
-
-        if (expect_des_device_backed_result)
-        {
-            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-        }
-        else
-        {
-            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-        }
+    if (expect_des_device_backed_result)
+    {
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+    }
+    else
+    {
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
     }
 }
 
@@ -481,48 +450,46 @@ strawman_run_policy_and_assume(Node &node,
                                const bool expect_src_device_backed_result,
                                const bool expect_des_device_backed_result)
 {
+    // DataAccessors wrap node leaf data.
+    float64_accessor acc_src(node["src"]);
+    float64_accessor acc_des(node["des"]);
+
+    // Ask the accessors to move their data to the memory space occupied
+    // by the requested execution policy if their data is not already
+    // there.
+    acc_src.use_with(policy);
+    acc_des.use_with(policy);
+
+    // Our forall will execute in the memory space selected by the
+    // requested ExecutionPolicy.
+    index_t size = acc_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
     {
-        // DataAccessors wrap node leaf data.
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
+        const float64 val = 2.0 * acc_src[idx];
+        acc_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-        // Ask the accessors to move their data to the memory space occupied
-        // by the requested execution policy if their data is not already
-        // there.
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
+    // node["des"] takes ownership of the data in the active execution
+    // space. This is a no op if node["des"] was already in that space.
+    acc_des.assume();
 
-        // Our forall will execute in the memory space selected by the
-        // requested ExecutionPolicy.
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
+    if (expect_src_device_backed_result)
+    {
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+    }
+    else
+    {
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+    }
 
-        // node["des"] takes ownership of the data in the active execution
-        // space. This is a no op if node["des"] was already in that space.
-        acc_des.assume();
-
-        if (expect_src_device_backed_result)
-        {
-            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-        }
-        else
-        {
-            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-        }
-
-        if (expect_des_device_backed_result)
-        {
-            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-        }
-        else
-        {
-            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-        }
+    if (expect_des_device_backed_result)
+    {
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+    }
+    else
+    {
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
     }
 }
 
@@ -533,59 +500,57 @@ strawman_run_where_src_is(Node &node,
                           const bool expect_src_device_backed_result,
                           const bool expect_des_device_backed_result)
 {
+    // DataAccessors wrap node leaf data.
+    float64_accessor acc_src(node["src"]);
+    float64_accessor acc_des(node["des"]);
+
+    // Use the location of the source data.
+    ExecutionPolicy policy = acc_src.active_space();
+    if (expect_device_policy)
     {
-        // DataAccessors wrap node leaf data.
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
+        EXPECT_TRUE(policy.is_device_policy());
+    }
+    else
+    {
+        EXPECT_TRUE(policy.is_host_policy());
+    }
 
-        // Use the location of the source data.
-        ExecutionPolicy policy = acc_src.active_space();
-        if (expect_device_policy)
-        {
-            EXPECT_TRUE(policy.is_device_policy());
-        }
-        else
-        {
-            EXPECT_TRUE(policy.is_host_policy());
-        }
+    // Ask the accessors to move their data to the memory space occupied
+    // by node["src"] if their data is not already there.
+    acc_src.use_with(policy);
+    acc_des.use_with(policy);
 
-        // Ask the accessors to move their data to the memory space occupied
-        // by node["src"] if their data is not already there.
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
+    // Our forall will execute on the memory space occupied by node["src"]
+    // because it was passed an ExecutionPolicy for that space.
+    index_t size = acc_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * acc_src[idx];
+        acc_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-        // Our forall will execute on the memory space occupied by node["src"]
-        // because it was passed an ExecutionPolicy for that space.
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
+    // Sync values to node["des"].
+    // This is a no op if node["des"] was originally in the same memory
+    // space as node["src"].
+    acc_des.sync();
 
-        // Sync values to node["des"].
-        // This is a no op if node["des"] was originally in the same memory
-        // space as node["src"].
-        acc_des.sync();
+    if (expect_src_device_backed_result)
+    {
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+    }
+    else
+    {
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+    }
 
-        if (expect_src_device_backed_result)
-        {
-            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-        }
-        else
-        {
-            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-        }
-
-        if (expect_des_device_backed_result)
-        {
-            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-        }
-        else
-        {
-            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-        }
+    if (expect_des_device_backed_result)
+    {
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+    }
+    else
+    {
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
     }
 }
 
@@ -623,11 +588,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
     }
 
     if (ExecutionPolicy::is_device_enabled())
@@ -643,11 +604,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
     }
 
     // Run with an explicit host execution policy and call assume().
@@ -662,11 +619,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
     }
 
     if (ExecutionPolicy::is_device_enabled())
@@ -682,11 +635,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
     }
 
     // Use the location of node["src"] to choose where to execute.
@@ -701,11 +650,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_where_src_is(node, false, false, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
     }
 }
 
@@ -735,11 +680,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Run with an explicit device execution policy.
@@ -756,11 +699,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Run with an explicit host execution policy and call assume().
@@ -777,11 +718,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Run with an explicit device execution policy and call assume().
@@ -798,11 +737,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Use the location of node["src"] to choose where to execute.
@@ -819,11 +756,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_where_src_is(node, true, true, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 }
 
@@ -852,11 +787,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Run with an explicit device execution policy.
@@ -872,11 +804,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Run with an explicit host execution policy and call assume().
@@ -892,11 +821,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Run with an explicit device execution policy and call assume().
@@ -912,11 +838,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Use the location of node["src"] to choose where to execute.
@@ -932,11 +855,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_where_src_is(node, false, false, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_HOST,
-                              STRAWMAN_START_ON_DEVICE,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 }
 
@@ -965,11 +885,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
     }
 
     // Run with an explicit device execution policy.
@@ -985,11 +902,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
     }
 
     // Run with an explicit host execution policy and call assume().
@@ -1005,11 +919,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
     }
 
     // Run with an explicit device execution policy and call assume().
@@ -1025,11 +936,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
     }
 
     // Use the location of node["src"] to choose where to execute.
@@ -1045,11 +953,8 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["des"].set(des_vals, 4);
         strawman_run_where_src_is(node, true, true, false);
         strawman_expect_doubled_des(node);
-        strawman_cleanup_node(node,
-                              STRAWMAN_START_ON_DEVICE,
-                              STRAWMAN_START_ON_HOST,
-                              src_device_ptr,
-                              des_device_ptr);
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
     }
 }
 

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -382,315 +382,731 @@ TEST(conduit_execution, for_all_and_dispatch)
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_execution, strawman)
+enum StrawmanStartSpace
 {
-    conduit_device_prepare();
+    STRAWMAN_START_ON_HOST,
+    STRAWMAN_START_ON_DEVICE
+};
 
-    auto setup_host_backed_node = [](Node &node)
+//-----------------------------------------------------------------------------
+void
+strawman_setup_node(Node &node,
+                    StrawmanStartSpace src_start_space,
+                    StrawmanStartSpace des_start_space,
+                    float64 *&src_device_ptr,
+                    float64 *&des_device_ptr)
+{
+    float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+
+    if (src_start_space == STRAWMAN_START_ON_DEVICE)
     {
-        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-
-        node["src"].set(src_vals, 4);
-        node["des"].set(des_vals, 4);
-    };
-
-    auto setup_device_backed_node = [](Node &node,
-                                       float64 *&src_device_ptr,
-                                       float64 *&des_device_ptr)
-    {
-        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-
         src_device_ptr = static_cast<float64*>(
             execution::DeviceMemory::allocate(sizeof(float64) * 4));
-        des_device_ptr = static_cast<float64*>(
-            execution::DeviceMemory::allocate(sizeof(float64) * 4));
-
         conduit::execution::MagicMemory::copy(src_device_ptr,
                                               &src_vals[0],
                                               sizeof(float64) * 4);
+        node["src"].set_external(src_device_ptr, 4);
+    }
+    else
+    {
+        node["src"].set(src_vals, 4);
+    }
+
+    if (des_start_space == STRAWMAN_START_ON_DEVICE)
+    {
+        des_device_ptr = static_cast<float64*>(
+            execution::DeviceMemory::allocate(sizeof(float64) * 4));
         conduit::execution::MagicMemory::copy(des_device_ptr,
                                               &des_vals[0],
                                               sizeof(float64) * 4);
-
-        node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-    };
-
-    auto run_policy_and_sync = [&](ExecutionPolicy policy,
-                                   const bool start_on_device)
+    }
+    else
     {
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
-        Node node;
+        node["des"].set(des_vals, 4);
+    }
+}
 
-        if (start_on_device)
+//-----------------------------------------------------------------------------
+void
+strawman_cleanup_node(Node &node,
+                      StrawmanStartSpace src_start_space,
+                      StrawmanStartSpace des_start_space,
+                      float64 *src_device_ptr,
+                      float64 *des_device_ptr)
+{
+    node.reset();
+
+    if (src_start_space == STRAWMAN_START_ON_DEVICE)
+    {
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+
+    if (des_start_space == STRAWMAN_START_ON_DEVICE)
+    {
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void
+strawman_run_policy_and_sync(Node &node,
+                             ExecutionPolicy policy,
+                             const bool expect_src_device_backed_result,
+                             const bool expect_des_device_backed_result)
+{
+    {
+        // DataAccessors wrap node leaf data.
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
+
+        // Ask the accessors to move their data to the memory space occupied
+        // by the requested execution policy if their data is not already
+        // there.
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
+
+        // Our forall will execute in the memory space selected by the
+        // requested ExecutionPolicy.
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
         {
-            setup_device_backed_node(node, src_device_ptr, des_device_ptr);
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+        // Sync values to node["des"].
+        // This is a no op if node["des"] was originally in the same memory
+        // space as the requested execution policy.
+        acc_des.sync();
+
+        if (expect_src_device_backed_result)
+        {
+            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         }
         else
         {
-            setup_host_backed_node(node);
+            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         }
 
+        if (expect_des_device_backed_result)
         {
-            // DataAccessors wrap node leaf data.
-            float64_accessor acc_src(node["src"]);
-            float64_accessor acc_des(node["des"]);
-
-            // Ask the accessors to move their data to the memory space occupied
-            // by the requested execution policy if their data is not already
-            // there.
-            acc_src.use_with(policy);
-            acc_des.use_with(policy);
-
-            // Our forall will execute in the memory space selected by the
-            // requested ExecutionPolicy.
-            index_t size = acc_src.number_of_elements();
-            conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-            {
-                const float64 val = 2.0 * acc_src[idx];
-                acc_des.set(idx, val);
-            });
-            CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-            // Sync values to node["des"].
-            // This is a no op if node["des"] was originally in the same memory
-            // space as the requested execution policy.
-            acc_des.sync();
-
-            if (start_on_device)
-            {
-                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-            }
-            else
-            {
-                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-            }
-        }
-
-        float64_accessor result_acc(node["des"]);
-        // Verification runs on the host, so use a host execution policy
-        // in case node["des"] still owns device-backed data here.
-        result_acc.use_with(ExecutionPolicy::host());
-        EXPECT_EQ(result_acc.number_of_elements(), 4);
-        EXPECT_EQ(result_acc[0], 2.0);
-        EXPECT_EQ(result_acc[1], 4.0);
-        EXPECT_EQ(result_acc[2], 6.0);
-        EXPECT_EQ(result_acc[3], 8.0);
-
-        if (start_on_device)
-        {
-            execution::DeviceMemory::deallocate(src_device_ptr);
-            execution::DeviceMemory::deallocate(des_device_ptr);
-        }
-    };
-
-    auto run_policy_and_assume = [&](ExecutionPolicy policy,
-                                     const bool start_on_device)
-    {
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
-        Node node;
-
-        if (start_on_device)
-        {
-            setup_device_backed_node(node, src_device_ptr, des_device_ptr);
+            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
         else
         {
-            setup_host_backed_node(node);
+            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
+    }
 
-        {
-            // DataAccessors wrap node leaf data.
-            float64_accessor acc_src(node["src"]);
-            float64_accessor acc_des(node["des"]);
+    float64_accessor result_acc(node["des"]);
+    // Verification runs on the host, so use a host execution policy
+    // in case node["des"] still owns device-backed data here.
+    result_acc.use_with(ExecutionPolicy::host());
+    EXPECT_EQ(result_acc.number_of_elements(), 4);
+    EXPECT_EQ(result_acc[0], 2.0);
+    EXPECT_EQ(result_acc[1], 4.0);
+    EXPECT_EQ(result_acc[2], 6.0);
+    EXPECT_EQ(result_acc[3], 8.0);
+}
 
-            // Ask the accessors to move their data to the memory space occupied
-            // by the requested execution policy if their data is not already
-            // there.
-            acc_src.use_with(policy);
-            acc_des.use_with(policy);
-
-            // Our forall will execute in the memory space selected by the
-            // requested ExecutionPolicy.
-            index_t size = acc_src.number_of_elements();
-            conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-            {
-                const float64 val = 2.0 * acc_src[idx];
-                acc_des.set(idx, val);
-            });
-            CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-            // node["des"] takes ownership of the data in the active execution
-            // space. This is a no op if node["des"] was already in that space.
-            acc_des.assume();
-
-            if (policy.is_device_policy())
-            {
-                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-            }
-            else
-            {
-                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-            }
-        }
-
-        float64_accessor result_acc(node["des"]);
-        // Verification runs on the host, so use a host execution policy
-        // in case node["des"] still owns device-backed data here.
-        result_acc.use_with(ExecutionPolicy::host());
-        EXPECT_EQ(result_acc.number_of_elements(), 4);
-        EXPECT_EQ(result_acc[0], 2.0);
-        EXPECT_EQ(result_acc[1], 4.0);
-        EXPECT_EQ(result_acc[2], 6.0);
-        EXPECT_EQ(result_acc[3], 8.0);
-
-        if (start_on_device)
-        {
-            execution::DeviceMemory::deallocate(src_device_ptr);
-
-            // If we started on the device and ran on the host, assume()
-            // adopted a new host buffer for node["des"], so the original
-            // external device destination allocation still needs cleanup.
-            if (policy.is_host_policy())
-            {
-                execution::DeviceMemory::deallocate(des_device_ptr);
-            }
-        }
-    };
-
-    auto run_where_src_is = [&](const bool start_on_device)
+//-----------------------------------------------------------------------------
+void
+strawman_run_policy_and_assume(Node &node,
+                               ExecutionPolicy policy,
+                               const bool expect_src_device_backed_result,
+                               const bool expect_des_device_backed_result)
+{
     {
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
-        Node node;
+        // DataAccessors wrap node leaf data.
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
 
-        if (start_on_device)
+        // Ask the accessors to move their data to the memory space occupied
+        // by the requested execution policy if their data is not already
+        // there.
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
+
+        // Our forall will execute in the memory space selected by the
+        // requested ExecutionPolicy.
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
         {
-            setup_device_backed_node(node, src_device_ptr, des_device_ptr);
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+        // node["des"] takes ownership of the data in the active execution
+        // space. This is a no op if node["des"] was already in that space.
+        acc_des.assume();
+
+        if (expect_src_device_backed_result)
+        {
+            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         }
         else
         {
-            setup_host_backed_node(node);
+            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         }
 
+        if (expect_des_device_backed_result)
         {
-            // DataAccessors wrap node leaf data.
-            float64_accessor acc_src(node["src"]);
-            float64_accessor acc_des(node["des"]);
-
-            // Use the location of the source data.
-            ExecutionPolicy policy = acc_src.active_space();
-            if (start_on_device)
-            {
-                EXPECT_TRUE(policy.is_device_policy());
-            }
-            else
-            {
-                EXPECT_TRUE(policy.is_host_policy());
-            }
-
-            // Ask the accessors to move their data to the memory space occupied
-            // by node["src"] if their data is not already there.
-            acc_src.use_with(policy);
-            acc_des.use_with(policy);
-
-            // Our forall will execute on the memory space occupied by node["src"]
-            // because it was passed an ExecutionPolicy for that space.
-            index_t size = acc_src.number_of_elements();
-            conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-            {
-                const float64 val = 2.0 * acc_src[idx];
-                acc_des.set(idx, val);
-            });
-            CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-            // Sync values to node["des"].
-            // This is a no op if node["des"] was originally in the same memory
-            // space as node["src"].
-            acc_des.sync();
-
-            if (start_on_device)
-            {
-                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-            }
-            else
-            {
-                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-            }
+            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
-
-        float64_accessor result_acc(node["des"]);
-        // Verification runs on the host, so use a host execution policy
-        // in case node["des"] still owns device-backed data here.
-        result_acc.use_with(ExecutionPolicy::host());
-        EXPECT_EQ(result_acc.number_of_elements(), 4);
-        EXPECT_EQ(result_acc[0], 2.0);
-        EXPECT_EQ(result_acc[1], 4.0);
-        EXPECT_EQ(result_acc[2], 6.0);
-        EXPECT_EQ(result_acc[3], 8.0);
-
-        if (start_on_device)
+        else
         {
-            execution::DeviceMemory::deallocate(src_device_ptr);
-            execution::DeviceMemory::deallocate(des_device_ptr);
+            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
-    };
+    }
 
-    //-----------------------------------------------------------------------------
-    // run on host
-    //-----------------------------------------------------------------------------
-    run_policy_and_sync(ExecutionPolicy::host(), false);
+    float64_accessor result_acc(node["des"]);
+    // Verification runs on the host, so use a host execution policy
+    // in case node["des"] still owns device-backed data here.
+    result_acc.use_with(ExecutionPolicy::host());
+    EXPECT_EQ(result_acc.number_of_elements(), 4);
+    EXPECT_EQ(result_acc[0], 2.0);
+    EXPECT_EQ(result_acc[1], 4.0);
+    EXPECT_EQ(result_acc[2], 6.0);
+    EXPECT_EQ(result_acc[3], 8.0);
+}
+
+//-----------------------------------------------------------------------------
+void
+strawman_run_where_src_is(Node &node,
+                          const bool expect_device_policy,
+                          const bool expect_src_device_backed_result,
+                          const bool expect_des_device_backed_result)
+{
+    {
+        // DataAccessors wrap node leaf data.
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
+
+        // Use the location of the source data.
+        ExecutionPolicy policy = acc_src.active_space();
+        if (expect_device_policy)
+        {
+            EXPECT_TRUE(policy.is_device_policy());
+        }
+        else
+        {
+            EXPECT_TRUE(policy.is_host_policy());
+        }
+
+        // Ask the accessors to move their data to the memory space occupied
+        // by node["src"] if their data is not already there.
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
+
+        // Our forall will execute on the memory space occupied by node["src"]
+        // because it was passed an ExecutionPolicy for that space.
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+        {
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+        // Sync values to node["des"].
+        // This is a no op if node["des"] was originally in the same memory
+        // space as node["src"].
+        acc_des.sync();
+
+        if (expect_src_device_backed_result)
+        {
+            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        }
+        else
+        {
+            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        }
+
+        if (expect_des_device_backed_result)
+        {
+            EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+        }
+        else
+        {
+            EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+        }
+    }
+
+    float64_accessor result_acc(node["des"]);
+    // Verification runs on the host, so use a host execution policy
+    // in case node["des"] still owns device-backed data here.
+    result_acc.use_with(ExecutionPolicy::host());
+    EXPECT_EQ(result_acc.number_of_elements(), 4);
+    EXPECT_EQ(result_acc[0], 2.0);
+    EXPECT_EQ(result_acc[1], 4.0);
+    EXPECT_EQ(result_acc[2], 6.0);
+    EXPECT_EQ(result_acc[3], 8.0);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, strawman_src_host_des_host)
+{
+    conduit_device_prepare();
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to the memory space where it started.
+    {
+        std::cout << "sync policy=host src_start=host des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
 
     if (ExecutionPolicy::is_device_enabled())
     {
-        run_policy_and_sync(ExecutionPolicy::host(), true);
+        // Run with an explicit device execution policy.
+        // node["des"] is synced back to the memory space where it started.
+        std::cout << "sync policy=device src_start=host des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
     }
 
-    //-----------------------------------------------------------------------------
-    // run on device
-    //-----------------------------------------------------------------------------
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "assume policy=host src_start=host des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
     if (ExecutionPolicy::is_device_enabled())
     {
-        run_policy_and_sync(ExecutionPolicy::device(), false);
-        run_policy_and_sync(ExecutionPolicy::device(), true);
+        // Run with an explicit device execution policy and call assume().
+        // node["des"] keeps the device-backed result buffer.
+        std::cout << "assume policy=device src_start=host des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
     }
 
-    //-----------------------------------------------------------------------------
-    // run on host and leave the result on the host
-    //-----------------------------------------------------------------------------
-    run_policy_and_assume(ExecutionPolicy::host(), false);
-
-    if (ExecutionPolicy::is_device_enabled())
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to the memory space where it started.
     {
-        run_policy_and_assume(ExecutionPolicy::host(), true);
-    }
+        std::cout << "active_space src_start=host des_start=host" << std::endl;
 
-    //-----------------------------------------------------------------------------
-    // run on device and leave the result on the device
-    //-----------------------------------------------------------------------------
-    if (ExecutionPolicy::is_device_enabled())
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_where_src_is(node, false, false, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, strawman_src_device_des_device)
+{
+    conduit_device_prepare();
+
+    if (!ExecutionPolicy::is_device_enabled())
     {
-        run_policy_and_assume(ExecutionPolicy::device(), false);
-        run_policy_and_assume(ExecutionPolicy::device(), true);
+        return;
     }
 
-    //-----------------------------------------------------------------------------
-    // run wherever the source data is
-    //-----------------------------------------------------------------------------
-    run_where_src_is(false);
-
-    if (ExecutionPolicy::is_device_enabled())
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to the memory space where it started.
     {
-        run_where_src_is(true);
+        std::cout << "sync policy=host src_start=device des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
     }
+
+    // Run with an explicit device execution policy.
+    // node["des"] is synced back to the memory space where it started.
+    {
+        std::cout << "sync policy=device src_start=device des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "assume policy=host src_start=device des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy and call assume().
+    // node["des"] keeps the device-backed result buffer.
+    {
+        std::cout << "assume policy=device src_start=device des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to the memory space where it started.
+    {
+        std::cout << "active_space src_start=device des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_where_src_is(node, true, true, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, strawman_src_host_des_device)
+{
+    conduit_device_prepare();
+
+    if (!ExecutionPolicy::is_device_enabled())
+    {
+        return;
+    }
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to the memory space where it started.
+    {
+        std::cout << "sync policy=host src_start=host des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy.
+    // node["des"] is synced back to the memory space where it started.
+    {
+        std::cout << "sync policy=device src_start=host des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "assume policy=host src_start=host des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy and call assume().
+    // node["des"] keeps the device-backed result buffer.
+    {
+        std::cout << "assume policy=device src_start=host des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to the memory space where it started.
+    {
+        std::cout << "active_space src_start=host des_start=device" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_HOST,
+                            STRAWMAN_START_ON_DEVICE,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_where_src_is(node, false, false, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_HOST,
+                              STRAWMAN_START_ON_DEVICE,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, strawman_src_device_des_host)
+{
+    conduit_device_prepare();
+
+    if (!ExecutionPolicy::is_device_enabled())
+    {
+        return;
+    }
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to the memory space where it started.
+    {
+        std::cout << "sync policy=host src_start=device des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy.
+    // node["des"] is synced back to the memory space where it started.
+    {
+        std::cout << "sync policy=device src_start=device des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "assume policy=host src_start=device des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy and call assume().
+    // node["des"] keeps the device-backed result buffer.
+    {
+        std::cout << "assume policy=device src_start=device des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to the memory space where it started.
+    {
+        std::cout << "active_space src_start=device des_start=host" << std::endl;
+
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+        Node node;
+        strawman_setup_node(node,
+                            STRAWMAN_START_ON_DEVICE,
+                            STRAWMAN_START_ON_HOST,
+                            src_device_ptr,
+                            des_device_ptr);
+        strawman_run_where_src_is(node, true, true, false);
+        strawman_cleanup_node(node,
+                              STRAWMAN_START_ON_DEVICE,
+                              STRAWMAN_START_ON_HOST,
+                              src_device_ptr,
+                              des_device_ptr);
+    }
+}
 
     // // TODO are there other cases in the notes?
     // //------------------------------------------------------
@@ -902,4 +1318,3 @@ TEST(conduit_execution, strawman)
     //     //  same memory space as node["src"])
     //     acc_des.sync(node["des"]); 
     // }
-}

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -396,9 +396,7 @@ strawman_make_device_buffer(const float64 *host_vals, index_t num_vals)
 //-----------------------------------------------------------------------------
 void
 strawman_run_policy_and_sync(Node &node,
-                             ExecutionPolicy policy,
-                             const bool expect_src_device_backed_result,
-                             const bool expect_des_device_backed_result)
+                             ExecutionPolicy policy)
 {
     // DataAccessors wrap node leaf data.
     float64_accessor acc_src(node["src"]);
@@ -425,31 +423,12 @@ strawman_run_policy_and_sync(Node &node,
     // space as the requested execution policy.
     acc_des.sync();
 
-    if (expect_src_device_backed_result)
-    {
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-    }
-    else
-    {
-        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-    }
-
-    if (expect_des_device_backed_result)
-    {
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-    }
-    else
-    {
-        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-    }
 }
 
 //-----------------------------------------------------------------------------
 void
 strawman_run_policy_and_assume(Node &node,
-                               ExecutionPolicy policy,
-                               const bool expect_src_device_backed_result,
-                               const bool expect_des_device_backed_result)
+                               ExecutionPolicy policy)
 {
     // DataAccessors wrap node leaf data.
     float64_accessor acc_src(node["src"]);
@@ -475,31 +454,12 @@ strawman_run_policy_and_assume(Node &node,
     // space. This is a no op if node["des"] was already in that space.
     acc_des.assume();
 
-    if (expect_src_device_backed_result)
-    {
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-    }
-    else
-    {
-        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-    }
-
-    if (expect_des_device_backed_result)
-    {
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-    }
-    else
-    {
-        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-    }
 }
 
 //-----------------------------------------------------------------------------
 void
 strawman_run_where_src_is(Node &node,
-                          const bool expect_device_policy,
-                          const bool expect_src_device_backed_result,
-                          const bool expect_des_device_backed_result)
+                          const bool expect_device_policy)
 {
     // DataAccessors wrap node leaf data.
     float64_accessor acc_src(node["src"]);
@@ -536,23 +496,6 @@ strawman_run_where_src_is(Node &node,
     // space as node["src"].
     acc_des.sync();
 
-    if (expect_src_device_backed_result)
-    {
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-    }
-    else
-    {
-        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
-    }
-
-    if (expect_des_device_backed_result)
-    {
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-    }
-    else
-    {
-        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-    }
 }
 
 //-----------------------------------------------------------------------------
@@ -572,7 +515,9 @@ TEST(conduit_execution, strawman_src_host_des_host)
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, false);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -594,7 +539,9 @@ TEST(conduit_execution, strawman_src_host_des_host)
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, false);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -615,7 +562,9 @@ TEST(conduit_execution, strawman_src_host_des_host)
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -637,7 +586,9 @@ TEST(conduit_execution, strawman_src_host_des_host)
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -658,7 +609,9 @@ TEST(conduit_execution, strawman_src_host_des_host)
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_where_src_is(node, false, false, false);
+        strawman_run_where_src_is(node, false);
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -694,7 +647,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, true);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -719,7 +674,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, true);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -744,7 +701,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -769,7 +728,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -793,7 +754,9 @@ TEST(conduit_execution, strawman_src_device_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_where_src_is(node, true, true, true);
+        strawman_run_where_src_is(node, true);
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -830,7 +793,9 @@ TEST(conduit_execution, strawman_src_host_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, true);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -853,7 +818,9 @@ TEST(conduit_execution, strawman_src_host_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, true);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -876,7 +843,9 @@ TEST(conduit_execution, strawman_src_host_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -899,7 +868,9 @@ TEST(conduit_execution, strawman_src_host_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -921,7 +892,9 @@ TEST(conduit_execution, strawman_src_host_des_device)
         des_device_ptr = strawman_make_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_where_src_is(node, false, false, true);
+        strawman_run_where_src_is(node, false);
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -957,7 +930,9 @@ TEST(conduit_execution, strawman_src_device_des_host)
         src_device_ptr = strawman_make_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, false);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -980,7 +955,9 @@ TEST(conduit_execution, strawman_src_device_des_host)
         src_device_ptr = strawman_make_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, false);
+        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -1003,7 +980,9 @@ TEST(conduit_execution, strawman_src_device_des_host)
         src_device_ptr = strawman_make_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -1026,7 +1005,9 @@ TEST(conduit_execution, strawman_src_device_des_host)
         src_device_ptr = strawman_make_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
+        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -1049,7 +1030,9 @@ TEST(conduit_execution, strawman_src_device_des_host)
         src_device_ptr = strawman_make_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_where_src_is(node, true, true, false);
+        strawman_run_where_src_is(node, true);
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -89,8 +89,8 @@ make_float64_device_buffer(const float64 *host_vals, index_t num_vals)
 
 //-----------------------------------------------------------------------------
 void
-run_policy_and_sync(Node &node,
-                    ExecutionPolicy policy)
+run_data_accessor_policy_and_sync(Node &node,
+                                  ExecutionPolicy policy)
 {
     // DataAccessors wrap node leaf data.
     float64_accessor acc_src(node["src"]);
@@ -120,8 +120,8 @@ run_policy_and_sync(Node &node,
 
 //-----------------------------------------------------------------------------
 void
-run_policy_and_assume(Node &node,
-                      ExecutionPolicy policy)
+run_data_accessor_policy_and_assume(Node &node,
+                                    ExecutionPolicy policy)
 {
     // DataAccessors wrap node leaf data.
     float64_accessor acc_src(node["src"]);
@@ -150,8 +150,8 @@ run_policy_and_assume(Node &node,
 
 //-----------------------------------------------------------------------------
 void
-run_using_active_space(Node &node,
-                       const bool expect_device_policy)
+run_data_accessor_using_active_space(Node &node,
+                                     const bool expect_device_policy)
 {
     // DataAccessors wrap node leaf data.
     float64_accessor acc_src(node["src"]);
@@ -187,6 +187,108 @@ run_using_active_space(Node &node,
     // This is a no op if node["des"] was originally in the same memory
     // space as node["src"].
     acc_des.sync();
+}
+
+//-----------------------------------------------------------------------------
+void
+run_data_array_policy_and_sync(Node &node,
+                               ExecutionPolicy policy)
+{
+    // DataArrays wrap node leaf data directly.
+    float64_array arr_src(node["src"]);
+    float64_array arr_des(node["des"]);
+
+    // Ask the arrays to move their data to the memory space occupied
+    // by the requested execution policy if their data is not already
+    // there.
+    arr_src.use_with(policy);
+    arr_des.use_with(policy);
+
+    // Our forall will execute in the memory space selected by the
+    // requested ExecutionPolicy.
+    index_t size = arr_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [arr_src, arr_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * arr_src[idx];
+        arr_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+    // Sync values to node["des"].
+    // This is a no op if node["des"] was originally in the same memory
+    // space as the requested execution policy.
+    arr_des.sync();
+}
+
+//-----------------------------------------------------------------------------
+void
+run_data_array_policy_and_assume(Node &node,
+                                 ExecutionPolicy policy)
+{
+    // DataArrays wrap node leaf data directly.
+    float64_array arr_src(node["src"]);
+    float64_array arr_des(node["des"]);
+
+    // Ask the arrays to move their data to the memory space occupied
+    // by the requested execution policy if their data is not already
+    // there.
+    arr_src.use_with(policy);
+    arr_des.use_with(policy);
+
+    // Our forall will execute in the memory space selected by the
+    // requested ExecutionPolicy.
+    index_t size = arr_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [arr_src, arr_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * arr_src[idx];
+        arr_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+    // node["des"] takes ownership of the data in the active execution
+    // space. This is a no op if node["des"] was already in that space.
+    arr_des.assume();
+}
+
+//-----------------------------------------------------------------------------
+void
+run_data_array_using_active_space(Node &node,
+                                  const bool expect_device_policy)
+{
+    // DataArrays wrap node leaf data directly.
+    float64_array arr_src(node["src"]);
+    float64_array arr_des(node["des"]);
+
+    // Use the location of the source data.
+    ExecutionPolicy policy = arr_src.active_space();
+    if (expect_device_policy)
+    {
+        EXPECT_TRUE(policy.is_device_policy());
+    }
+    else
+    {
+        EXPECT_TRUE(policy.is_host_policy());
+    }
+
+    // Ask the arrays to move their data to the memory space occupied
+    // by node["src"] if their data is not already there.
+    arr_src.use_with(policy);
+    arr_des.use_with(policy);
+
+    // Our forall will execute on the memory space occupied by node["src"]
+    // because it was passed an ExecutionPolicy for that space.
+    index_t size = arr_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [arr_src, arr_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * arr_src[idx];
+        arr_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+    // Sync values to node["des"].
+    // This is a no op if node["des"] was originally in the same memory
+    // space as node["src"].
+    arr_des.sync();
 }
 
 // TODO someday we want allocator to make sense for nodes when we are done with them
@@ -498,11 +600,11 @@ TEST(conduit_execution, for_all_and_dispatch)
 }
 
 //-----------------------------------------------------------------------------
-// Test the strawman execution paths when both node["src"] and node["des"]
-// start in host memory. The covered cases are explicit host `sync`, explicit
-// device `sync`, explicit host `assume`, explicit device `assume`, and
-// `active_space` dispatch from host-backed source data.
-TEST(conduit_execution, strawman_src_host_des_host)
+// Test the DataAccessor strawman execution paths when both node["src"] and
+// node["des"] start in host memory. The covered cases are explicit host
+// `sync`, explicit device `sync`, explicit host `assume`, explicit device
+// `assume`, and `active_space` dispatch from host-backed source data.
+TEST(conduit_execution, strawman_data_accessor_src_host_des_host)
 {
     conduit_device_prepare();
     const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
@@ -511,13 +613,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
     // Run with an explicit host execution policy.
     // node["des"] is synced back to host memory.
     {
-        std::cout << "sync policy=host src_start=host des_start=host" << std::endl;
+        std::cout << "data_accessor sync policy=host src_start=host des_start=host" << std::endl;
 
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -538,13 +640,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
     {
         // Run with an explicit device execution policy.
         // node["des"] is synced back to host memory.
-        std::cout << "sync policy=device src_start=host des_start=host" << std::endl;
+        std::cout << "data_accessor sync policy=device src_start=host des_start=host" << std::endl;
 
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -564,13 +666,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
     // Run with an explicit host execution policy and call assume().
     // node["des"] keeps the host-backed result buffer.
     {
-        std::cout << "assume policy=host src_start=host des_start=host" << std::endl;
+        std::cout << "data_accessor assume policy=host src_start=host des_start=host" << std::endl;
 
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -591,13 +693,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
     {
         // Run with an explicit device execution policy and call assume().
         // node["des"] keeps the device-backed result buffer.
-        std::cout << "assume policy=device src_start=host des_start=host" << std::endl;
+        std::cout << "data_accessor assume policy=device src_start=host des_start=host" << std::endl;
 
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -617,13 +719,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
     // Use the location of node["src"] to choose where to execute.
     // node["des"] is then synced back to host memory.
     {
-        std::cout << "active_space src_start=host des_start=host" << std::endl;
+        std::cout << "data_accessor active_space src_start=host des_start=host" << std::endl;
 
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
-        run_using_active_space(node, false);
+        run_data_accessor_using_active_space(node, false);
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -642,11 +744,11 @@ TEST(conduit_execution, strawman_src_host_des_host)
 }
 
 //-----------------------------------------------------------------------------
-// Test the strawman execution paths when both node["src"] and node["des"]
-// start in device memory. The covered cases are explicit host `sync`,
-// explicit device `sync`, explicit host `assume`, explicit device `assume`,
-// and `active_space` dispatch from device-backed source data.
-TEST(conduit_execution, strawman_src_device_des_device)
+// Test the DataAccessor strawman execution paths when both node["src"] and
+// node["des"] start in device memory. The covered cases are explicit host
+// `sync`, explicit device `sync`, explicit host `assume`, explicit device
+// `assume`, and `active_space` dispatch from device-backed source data.
+TEST(conduit_execution, strawman_data_accessor_src_device_des_device)
 {
     conduit_device_prepare();
     const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
@@ -660,7 +762,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     // Run with an explicit host execution policy.
     // node["des"] is synced back to device memory.
     {
-        std::cout << "sync policy=host src_start=device des_start=device" << std::endl;
+        std::cout << "data_accessor sync policy=host src_start=device des_start=device" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
@@ -668,7 +770,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -690,7 +792,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     // Run with an explicit device execution policy.
     // node["des"] is synced back to device memory.
     {
-        std::cout << "sync policy=device src_start=device des_start=device" << std::endl;
+        std::cout << "data_accessor sync policy=device src_start=device des_start=device" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
@@ -698,7 +800,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -720,7 +822,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     // Run with an explicit host execution policy and call assume().
     // node["des"] keeps the host-backed result buffer.
     {
-        std::cout << "assume policy=host src_start=device des_start=device" << std::endl;
+        std::cout << "data_accessor assume policy=host src_start=device des_start=device" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
@@ -728,7 +830,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -750,7 +852,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     // Run with an explicit device execution policy and call assume().
     // node["des"] keeps the device-backed result buffer.
     {
-        std::cout << "assume policy=device src_start=device des_start=device" << std::endl;
+        std::cout << "data_accessor assume policy=device src_start=device des_start=device" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
@@ -758,7 +860,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -779,7 +881,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     // Use the location of node["src"] to choose where to execute.
     // node["des"] is then synced back to device memory.
     {
-        std::cout << "active_space src_start=device des_start=device" << std::endl;
+        std::cout << "data_accessor active_space src_start=device des_start=device" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
@@ -787,7 +889,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_using_active_space(node, true);
+        run_data_accessor_using_active_space(node, true);
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -808,11 +910,12 @@ TEST(conduit_execution, strawman_src_device_des_device)
 }
 
 //-----------------------------------------------------------------------------
-// Test the strawman execution paths when node["src"] starts in host memory
-// and node["des"] starts in device memory. The covered cases are explicit
-// host `sync`, explicit device `sync`, explicit host `assume`, explicit
-// device `assume`, and `active_space` dispatch from host-backed source data.
-TEST(conduit_execution, strawman_src_host_des_device)
+// Test the DataAccessor strawman execution paths when node["src"] starts in
+// host memory and node["des"] starts in device memory. The covered cases are
+// explicit host `sync`, explicit device `sync`, explicit host `assume`,
+// explicit device `assume`, and `active_space` dispatch from host-backed
+// source data.
+TEST(conduit_execution, strawman_data_accessor_src_host_des_device)
 {
     conduit_device_prepare();
     const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
@@ -826,14 +929,14 @@ TEST(conduit_execution, strawman_src_host_des_device)
     // Run with an explicit host execution policy.
     // node["des"] is synced back to device memory.
     {
-        std::cout << "sync policy=host src_start=host des_start=device" << std::endl;
+        std::cout << "data_accessor sync policy=host src_start=host des_start=device" << std::endl;
 
         Node node;
         float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -854,14 +957,14 @@ TEST(conduit_execution, strawman_src_host_des_device)
     // Run with an explicit device execution policy.
     // node["des"] is synced back to device memory.
     {
-        std::cout << "sync policy=device src_start=host des_start=device" << std::endl;
+        std::cout << "data_accessor sync policy=device src_start=host des_start=device" << std::endl;
 
         Node node;
         float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -882,14 +985,14 @@ TEST(conduit_execution, strawman_src_host_des_device)
     // Run with an explicit host execution policy and call assume().
     // node["des"] keeps the host-backed result buffer.
     {
-        std::cout << "assume policy=host src_start=host des_start=device" << std::endl;
+        std::cout << "data_accessor assume policy=host src_start=host des_start=device" << std::endl;
 
         Node node;
         float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -910,14 +1013,14 @@ TEST(conduit_execution, strawman_src_host_des_device)
     // Run with an explicit device execution policy and call assume().
     // node["des"] keeps the device-backed result buffer.
     {
-        std::cout << "assume policy=device src_start=host des_start=device" << std::endl;
+        std::cout << "data_accessor assume policy=device src_start=host des_start=device" << std::endl;
 
         Node node;
         float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -937,14 +1040,14 @@ TEST(conduit_execution, strawman_src_host_des_device)
     // Use the location of node["src"] to choose where to execute.
     // node["des"] is then synced back to device memory.
     {
-        std::cout << "active_space src_start=host des_start=device" << std::endl;
+        std::cout << "data_accessor active_space src_start=host des_start=device" << std::endl;
 
         Node node;
         float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
 
-        run_using_active_space(node, false);
+        run_data_accessor_using_active_space(node, false);
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -964,11 +1067,12 @@ TEST(conduit_execution, strawman_src_host_des_device)
 }
 
 //-----------------------------------------------------------------------------
-// Test the strawman execution paths when node["src"] starts in device memory
-// and node["des"] starts in host memory. The covered cases are explicit
-// host `sync`, explicit device `sync`, explicit host `assume`, explicit
-// device `assume`, and `active_space` dispatch from device-backed source data.
-TEST(conduit_execution, strawman_src_device_des_host)
+// Test the DataAccessor strawman execution paths when node["src"] starts in
+// device memory and node["des"] starts in host memory. The covered cases are
+// explicit host `sync`, explicit device `sync`, explicit host `assume`,
+// explicit device `assume`, and `active_space` dispatch from device-backed
+// source data.
+TEST(conduit_execution, strawman_data_accessor_src_device_des_host)
 {
     conduit_device_prepare();
     const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
@@ -982,14 +1086,14 @@ TEST(conduit_execution, strawman_src_device_des_host)
     // Run with an explicit host execution policy.
     // node["des"] is synced back to host memory.
     {
-        std::cout << "sync policy=host src_start=device des_start=host" << std::endl;
+        std::cout << "data_accessor sync policy=host src_start=device des_start=host" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -1010,14 +1114,14 @@ TEST(conduit_execution, strawman_src_device_des_host)
     // Run with an explicit device execution policy.
     // node["des"] is synced back to host memory.
     {
-        std::cout << "sync policy=device src_start=device des_start=host" << std::endl;
+        std::cout << "data_accessor sync policy=device src_start=device des_start=host" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_sync(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -1038,14 +1142,14 @@ TEST(conduit_execution, strawman_src_device_des_host)
     // Run with an explicit host execution policy and call assume().
     // node["des"] keeps the host-backed result buffer.
     {
-        std::cout << "assume policy=host src_start=device des_start=host" << std::endl;
+        std::cout << "data_accessor assume policy=host src_start=device des_start=host" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::host());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -1066,14 +1170,14 @@ TEST(conduit_execution, strawman_src_device_des_host)
     // Run with an explicit device execution policy and call assume().
     // node["des"] keeps the device-backed result buffer.
     {
-        std::cout << "assume policy=device src_start=device des_start=host" << std::endl;
+        std::cout << "data_accessor assume policy=device src_start=device des_start=host" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
 
-        run_policy_and_assume(node, ExecutionPolicy::device());
+        run_data_accessor_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -1094,14 +1198,14 @@ TEST(conduit_execution, strawman_src_device_des_host)
     // Use the location of node["src"] to choose where to execute.
     // node["des"] is then synced back to host memory.
     {
-        std::cout << "active_space src_start=device des_start=host" << std::endl;
+        std::cout << "data_accessor active_space src_start=device des_start=host" << std::endl;
 
         Node node;
         float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
 
-        run_using_active_space(node, true);
+        run_data_accessor_using_active_space(node, true);
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -1114,6 +1218,631 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Test the DataArray strawman execution paths when both node["src"] and
+// node["des"] start in host memory. The covered cases are explicit host
+// `sync`, explicit device `sync`, explicit host `assume`, explicit device
+// `assume`, and `active_space` dispatch from host-backed source data.
+TEST(conduit_execution, strawman_data_array_src_host_des_host)
+{
+    conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to host memory.
+    {
+        std::cout << "data_array sync policy=host src_start=host des_start=host" << std::endl;
+
+        Node node;
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+    }
+
+    if (ExecutionPolicy::is_device_enabled())
+    {
+        // Run with an explicit device execution policy.
+        // node["des"] is synced back to host memory.
+        std::cout << "data_array sync policy=device src_start=host des_start=host" << std::endl;
+
+        Node node;
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "data_array assume policy=host src_start=host des_start=host" << std::endl;
+
+        Node node;
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+    }
+
+    if (ExecutionPolicy::is_device_enabled())
+    {
+        // Run with an explicit device execution policy and call assume().
+        // node["des"] keeps the device-backed result buffer.
+        std::cout << "data_array assume policy=device src_start=host des_start=host" << std::endl;
+
+        Node node;
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to host memory.
+    {
+        std::cout << "data_array active_space src_start=host des_start=host" << std::endl;
+
+        Node node;
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_using_active_space(node, false);
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Test the DataArray strawman execution paths when both node["src"] and
+// node["des"] start in device memory. The covered cases are explicit host
+// `sync`, explicit device `sync`, explicit host `assume`, explicit device
+// `assume`, and `active_space` dispatch from device-backed source data.
+TEST(conduit_execution, strawman_data_array_src_device_des_device)
+{
+    conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+
+    if (!ExecutionPolicy::is_device_enabled())
+    {
+        return;
+    }
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to device memory.
+    {
+        std::cout << "data_array sync policy=host src_start=device des_start=device" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy.
+    // node["des"] is synced back to device memory.
+    {
+        std::cout << "data_array sync policy=device src_start=device des_start=device" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "data_array assume policy=host src_start=device des_start=device" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy and call assume().
+    // node["des"] keeps the device-backed result buffer.
+    {
+        std::cout << "data_array assume policy=device src_start=device des_start=device" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to device memory.
+    {
+        std::cout << "data_array active_space src_start=device des_start=device" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_using_active_space(node, true);
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Test the DataArray strawman execution paths when node["src"] starts in host
+// memory and node["des"] starts in device memory. The covered cases are
+// explicit host `sync`, explicit device `sync`, explicit host `assume`,
+// explicit device `assume`, and `active_space` dispatch from host-backed
+// source data.
+TEST(conduit_execution, strawman_data_array_src_host_des_device)
+{
+    conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+
+    if (!ExecutionPolicy::is_device_enabled())
+    {
+        return;
+    }
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to device memory.
+    {
+        std::cout << "data_array sync policy=host src_start=host des_start=device" << std::endl;
+
+        Node node;
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy.
+    // node["des"] is synced back to device memory.
+    {
+        std::cout << "data_array sync policy=device src_start=host des_start=device" << std::endl;
+
+        Node node;
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "data_array assume policy=host src_start=host des_start=device" << std::endl;
+
+        Node node;
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+
+    // Run with an explicit device execution policy and call assume().
+    // node["des"] keeps the device-backed result buffer.
+    {
+        std::cout << "data_array assume policy=device src_start=host des_start=device" << std::endl;
+
+        Node node;
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to device memory.
+    {
+        std::cout << "data_array active_space src_start=host des_start=device" << std::endl;
+
+        Node node;
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
+
+        run_data_array_using_active_space(node, false);
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(des_device_ptr);
+    }
+}
+
+//-----------------------------------------------------------------------------
+// Test the DataArray strawman execution paths when node["src"] starts in
+// device memory and node["des"] starts in host memory. The covered cases are
+// explicit host `sync`, explicit device `sync`, explicit host `assume`,
+// explicit device `assume`, and `active_space` dispatch from device-backed
+// source data.
+TEST(conduit_execution, strawman_data_array_src_device_des_host)
+{
+    conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+
+    if (!ExecutionPolicy::is_device_enabled())
+    {
+        return;
+    }
+
+    // Run with an explicit host execution policy.
+    // node["des"] is synced back to host memory.
+    {
+        std::cout << "data_array sync policy=host src_start=device des_start=host" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+
+    // Run with an explicit device execution policy.
+    // node["des"] is synced back to host memory.
+    {
+        std::cout << "data_array sync policy=device src_start=device des_start=host" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_sync(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+
+    // Run with an explicit host execution policy and call assume().
+    // node["des"] keeps the host-backed result buffer.
+    {
+        std::cout << "data_array assume policy=host src_start=device des_start=host" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::host());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+
+    // Run with an explicit device execution policy and call assume().
+    // node["des"] keeps the device-backed result buffer.
+    {
+        std::cout << "data_array assume policy=device src_start=device des_start=host" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_policy_and_assume(node, ExecutionPolicy::device());
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
+
+        node.reset();
+        execution::DeviceMemory::deallocate(src_device_ptr);
+    }
+
+    // Use the location of node["src"] to choose where to execute.
+    // node["des"] is then synced back to host memory.
+    {
+        std::cout << "data_array active_space src_start=device des_start=host" << std::endl;
+
+        Node node;
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
+
+        run_data_array_using_active_space(node, true);
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+        EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
+        float64_array result_array(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_array.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_array.number_of_elements(), 4);
+        EXPECT_EQ(result_array[0], 2.0);
+        EXPECT_EQ(result_array[1], 4.0);
+        EXPECT_EQ(result_array[2], 6.0);
+        EXPECT_EQ(result_array[3], 8.0);
 
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -77,8 +77,6 @@ conduit_device_prepare()
 
 // TODO someday we want allocator to make sense for nodes when we are done with them
 
-// TODO turn the strawman into tests?
-
 //---------------------------------------------------------------------------//
 // example functor 
 //---------------------------------------------------------------------------//
@@ -389,43 +387,6 @@ TEST(conduit_execution, strawman)
     conduit_device_prepare();
 
     //-----------------------------------------------------------------------------
-    // run wherever the source data is
-    //-----------------------------------------------------------------------------
-    {
-        Node node;
-        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-        node["src"].set(src_vals, 4);
-        node["des"].set(des_vals, 4);
-
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
-
-        ExecutionPolicy policy = acc_src.active_space();
-        EXPECT_TRUE(policy.is_host_policy());
-
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
-
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-        acc_des.sync();
-
-        float64_accessor verify(node["des"]);
-        EXPECT_EQ(verify.number_of_elements(), 4);
-        EXPECT_EQ(verify[0], 2.0);
-        EXPECT_EQ(verify[1], 4.0);
-        EXPECT_EQ(verify[2], 6.0);
-        EXPECT_EQ(verify[3], 8.0);
-    }
-
-    //-----------------------------------------------------------------------------
     // run on device
     //-----------------------------------------------------------------------------
     if (ExecutionPolicy::is_device_enabled())
@@ -436,14 +397,19 @@ TEST(conduit_execution, strawman)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
+        // DataAccessors wrap node leaf data.
         float64_accessor acc_src(node["src"]);
         float64_accessor acc_des(node["des"]);
 
         ExecutionPolicy policy = ExecutionPolicy::device();
 
+        // Ask the accessors to move their data to the device if their data is
+        // not already there.
         acc_src.use_with(policy);
         acc_des.use_with(policy);
 
+        // Our forall will execute on the device because it was passed a device
+        // ExecutionPolicy.
         index_t size = acc_src.number_of_elements();
         conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
         {
@@ -452,6 +418,8 @@ TEST(conduit_execution, strawman)
         });
         CONDUIT_DEVICE_ERROR_CHECK(policy);
 
+        // Sync values to node["des"].
+        // This is a no op if node["des"] was originally device memory.
         acc_des.sync();
 
         float64_accessor verify(node["des"]);
@@ -473,14 +441,19 @@ TEST(conduit_execution, strawman)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
 
+        // DataAccessors wrap node leaf data.
         float64_accessor acc_src(node["src"]);
         float64_accessor acc_des(node["des"]);
 
         ExecutionPolicy policy = ExecutionPolicy::device();
 
+        // Ask the accessors to move their data to the device if their data is
+        // not already there.
         acc_src.use_with(policy);
         acc_des.use_with(policy);
 
+        // Our forall will execute on the device because it was passed a device
+        // ExecutionPolicy.
         index_t size = acc_src.number_of_elements();
         conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
         {
@@ -489,6 +462,8 @@ TEST(conduit_execution, strawman)
         });
         CONDUIT_DEVICE_ERROR_CHECK(policy);
 
+        // node["des"] takes ownership of the data on the device.
+        // This is a no op if node["des"] was originally device memory.
         acc_des.assume();
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
@@ -500,4 +475,261 @@ TEST(conduit_execution, strawman)
         EXPECT_EQ(verify[2], 6.0);
         EXPECT_EQ(verify[3], 8.0);
     }
+
+    //-----------------------------------------------------------------------------
+    // run wherever the source data is
+    //-----------------------------------------------------------------------------
+    {
+        Node node;
+        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+
+        // DataAccessors wrap node leaf data.
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
+
+        // Use the location of the source data.
+        ExecutionPolicy policy = acc_src.active_space();
+        EXPECT_TRUE(policy.is_host_policy());
+
+        // Ask the accessors to move their data to the memory space occupied by
+        // node["src"] if their data is not already there.
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
+
+        // Our forall will execute on the memory space occupied by node["src"]
+        // because it was passed an ExecutionPolicy for that space.
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+        {
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+        // Sync values to node["des"].
+        // This is a no op if node["des"] was originally in the same memory
+        // space as node["src"].
+        acc_des.sync();
+
+        float64_accessor verify(node["des"]);
+        EXPECT_EQ(verify.number_of_elements(), 4);
+        EXPECT_EQ(verify[0], 2.0);
+        EXPECT_EQ(verify[1], 4.0);
+        EXPECT_EQ(verify[2], 6.0);
+        EXPECT_EQ(verify[3], 8.0);
+    }
+
+    // // TODO are there other cases in the notes?
+    // //------------------------------------------------------
+    // // forall cases
+    // //------------------------------------------------------
+
+    // //------------------------------------------------------
+    // // run on device
+    // //------------------------------------------------------
+    // if (ExecutionPolicy::is_device_enabled())
+    // {
+    //     Node node;
+    //     std::vector<int64> data_src = {0, 1, 2, 3};
+    //     node["src"].set(data_src);
+    //     std::vector<int64> data_des = {0, 0, 0, 0};
+    //     node["src"].set(data_des);
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+
+    //     acc_src.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+    //     {
+    //         const float64 val = 2.0 * acc_src[idx];
+    //         acc_des.set(idx,val);
+    //     });
+    //     CONDUIT_DEVICE_ERROR_CHECK();
+
+    //     // sync values to node["des"]
+    //     // (no op if node["des"] was originally device memory)
+    //     acc_des.sync();
+    // }
+
+    // //------------------------------------------------------
+    // // run on device, 
+    // // result stays on device and is owned by node["des"],
+    // // even if not on the device before hand
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+
+    //     acc_src.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+    //     {
+    //         const float64 val = 2.0 * acc_src[idx];
+    //         acc_des.set(idx,val);
+    //     });
+    //     CONDUIT_DEVICE_ERROR_CHECK();
+
+    //     // move results to be owned by node["des"]
+    //     // (no op if node["des"] was originally device memory)
+    //     acc_des.move(node["des"]); 
+    // }
+
+    // //------------------------------------------------------
+    // // run where the src data is
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = acc_src.active_space().execution_policy();
+    //     acc_des.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+    //     {
+    //         const float64 val = 2.0 * acc_src[idx];
+    //         acc_des.set(idx,val);
+    //     });
+    //     CONDUIT_DEVICE_ERROR_CHECK();
+
+    //     // sync values to node["des"], 
+    //     // (no op if node["des"] was originally in 
+    //     //  same memory space as node["src"] )
+    //     acc_des.sync(node["des"]); 
+    // }
+
+    // //------------------------------------------------------
+    // // more complex cases
+    // //------------------------------------------------------
+
+    // //------------------------------------------------------
+    // // complex run on device 
+    // // double lambda forwarding concrete template tag
+    // // for use in lambda
+    // //
+    // // ( requires c++ 20 b/c of templated lambda)
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+    //     acc_des.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     index_t min_loc = -1;
+    //     float64 min_val = 0;
+
+    //     dispatch(policy, [&] <typename Exec>(Exec &exec)
+    //     {
+    //         float64 identity = std::numeric_limits<float64>::max();
+    //         using for_policy    = typename Exec::for_policy;
+    //         using reduce_policy = typename Exec::reduce_policy;
+
+    //         ReduceMinLoc<reduce_policy,float64> reducer(identity,-1);
+
+    //         forall<for_policy>(0, size, [=] EXEC_LAMBDA (int i)
+    //         {
+    //             const float64 val = 2.0 * acc_src[idx];
+    //             reducer.minloc(val,i);
+    //             acc_des.set(idx,val);
+    //         });
+    //         CONDUIT_DEVICE_ERROR_CHECK();
+
+    //         min_val = reducer.get();
+    //         min_loc = reducer.getLoc();
+    //     });
+
+    //     // sync values to node["des"], 
+    //     // (no op if node["des"] was originally in
+    //     //  same memory space as node["src"] )
+    //     acc_des.sync(node["des"]); 
+    // }
+
+    // //------------------------------------------------------
+    // // complex run on device using functor
+    // // (functor implementation)
+    // //------------------------------------------------------
+    // struct ExecFunctor
+    // {
+    //     float64 min_val;
+    //     index_t min_loc;
+
+    //     ExecutionAccessor<float64> acc_src;
+    //     ExecutionAccessor<float64> acc_des;
+
+    //     template<typename Exec>
+    //     void operator()(Exec &exec)
+    //     {
+    //         float64 identity = std::numeric_limits<float64>::max();
+    //         using for_policy    = typename Exec::for_policy;
+    //         using reduce_policy = typename Exec::reduce_policy;
+
+    //         ReduceMinLoc<reduce_policy,float64> reducer(identity, -1);
+
+    //         forall<for_policy>(0, size, [=] (int i)
+    //         {
+    //             const float64 val = 2.0 * acc_src[idx];
+    //             reducer.minloc(val,i);
+    //             acc_des.set(idx,val);
+    //         });
+    //         CONDUIT_DEVICE_ERROR_CHECK();
+
+    //         min_val = reducer.get();
+    //         min_loc = reducer.getLoc();
+    //     }
+    // };
+
+    // //------------------------------------------------------
+    // // complex run on device using functor 
+    // // (functor dispatch)
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+    //     acc_des.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     ExecFunctor f();
+
+    //     // init functor
+    //     f.acc_src = acc_src;
+    //     f.acc_des = acc_des;
+
+    //     dispatch(policy,f);
+
+    //     // get results stored in functor
+    //     float64 min_val = f.min_val;
+    //     index_t min_loc = f.min_loc;
+
+    //     // sync values to node["des"], 
+    //     // (no op if node["des"] was originally in
+    //     //  same memory space as node["src"])
+    //     acc_des.sync(node["des"]); 
+    // }
 }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -386,214 +386,116 @@ TEST(conduit_execution, for_all_and_dispatch)
 //-----------------------------------------------------------------------------
 TEST(conduit_execution, strawman)
 {
-    // // TODO are there other cases in the notes?
-    // //------------------------------------------------------
-    // // forall cases
-    // //------------------------------------------------------
+    conduit_device_prepare();
 
-    // //------------------------------------------------------
-    // // run on device
-    // //------------------------------------------------------
-    // if (ExecutionPolicy::is_device_enabled())
-    // {
-    //     Node node;
-    //     std::vector<int64> data_src = {0, 1, 2, 3};
-    //     node["src"].set(data_src);
-    //     std::vector<int64> data_des = {0, 0, 0, 0};
-    //     node["src"].set(data_des);
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
+    //-----------------------------------------------------------------------------
+    auto verify_doubled_values = [](float64_accessor &acc)
+    {
+        EXPECT_EQ(acc.number_of_elements(), 4);
+        EXPECT_EQ(acc[0], 2.0);
+        EXPECT_EQ(acc[1], 4.0);
+        EXPECT_EQ(acc[2], 6.0);
+        EXPECT_EQ(acc[3], 8.0);
+    };
 
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
+    //-----------------------------------------------------------------------------
+    // run wherever the source data is
+    //-----------------------------------------------------------------------------
+    {
+        Node node;
+        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
 
-    //     acc_src.use_with(policy);
-    //     acc_des.use_with(policy);
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
 
-    //     index_t size = acc_src.number_of_elements();
+        ExecutionPolicy policy = acc_src.active_space();
+        EXPECT_TRUE(policy.is_host_policy());
 
-    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-    //     {
-    //         const float64 val = 2.0 * acc_src[idx];
-    //         acc_des.set(idx,val);
-    //     });
-    //     CONDUIT_DEVICE_ERROR_CHECK();
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
 
-    //     // sync values to node["des"]
-    //     // (no op if node["des"] was originally device memory)
-    //     acc_des.sync();
-    // }
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+        {
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-    // //------------------------------------------------------
-    // // run on device, 
-    // // result stays on device and is owned by node["des"],
-    // // even if not on the device before hand
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
+        acc_des.sync();
 
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
+        float64_accessor verify(node["des"]);
+        verify_doubled_values(verify);
+    }
 
-    //     acc_src.use_with(policy);
-    //     acc_des.use_with(policy);
+    //-----------------------------------------------------------------------------
+    // run on device
+    //-----------------------------------------------------------------------------
+    if (ExecutionPolicy::is_device_enabled())
+    {
+        Node node;
+        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
 
-    //     index_t size = acc_src.number_of_elements();
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
 
-    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-    //     {
-    //         const float64 val = 2.0 * acc_src[idx];
-    //         acc_des.set(idx,val);
-    //     });
-    //     CONDUIT_DEVICE_ERROR_CHECK();
+        ExecutionPolicy policy = ExecutionPolicy::device();
 
-    //     // move results to be owned by node["des"]
-    //     // (no op if node["des"] was originally device memory)
-    //     acc_des.move(node["des"]); 
-    // }
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
 
-    // //------------------------------------------------------
-    // // run where the src data is
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+        {
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-    //     ExecutionPolicy policy = acc_src.active_space().execution_policy();
-    //     acc_des.use_with(policy);
-    //     acc_des.use_with(policy);
+        acc_des.sync();
 
-    //     index_t size = acc_src.number_of_elements();
+        float64_accessor verify(node["des"]);
+        verify_doubled_values(verify);
+    }
 
-    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-    //     {
-    //         const float64 val = 2.0 * acc_src[idx];
-    //         acc_des.set(idx,val);
-    //     });
-    //     CONDUIT_DEVICE_ERROR_CHECK();
+    //-----------------------------------------------------------------------------
+    // run on device and leave the result on the device
+    //-----------------------------------------------------------------------------
+    if (ExecutionPolicy::is_device_enabled())
+    {
+        Node node;
+        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
 
-    //     // sync values to node["des"], 
-    //     // (no op if node["des"] was originally in 
-    //     //  same memory space as node["src"] )
-    //     acc_des.sync(node["des"]); 
-    // }
+        float64_accessor acc_src(node["src"]);
+        float64_accessor acc_des(node["des"]);
 
-    // //------------------------------------------------------
-    // // more complex cases
-    // //------------------------------------------------------
+        ExecutionPolicy policy = ExecutionPolicy::device();
 
-    // //------------------------------------------------------
-    // // complex run on device 
-    // // double lambda forwarding concrete template tag
-    // // for use in lambda
-    // //
-    // // ( requires c++ 20 b/c of templated lambda)
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
+        acc_src.use_with(policy);
+        acc_des.use_with(policy);
 
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
-    //     acc_des.use_with(policy);
-    //     acc_des.use_with(policy);
+        index_t size = acc_src.number_of_elements();
+        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+        {
+            const float64 val = 2.0 * acc_src[idx];
+            acc_des.set(idx, val);
+        });
+        CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-    //     index_t size = acc_src.number_of_elements();
+        acc_des.assume();
+        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
 
-    //     index_t min_loc = -1;
-    //     float64 min_val = 0;
-
-    //     dispatch(policy, [&] <typename Exec>(Exec &exec)
-    //     {
-    //         float64 identity = std::numeric_limits<float64>::max();
-    //         using for_policy    = typename Exec::for_policy;
-    //         using reduce_policy = typename Exec::reduce_policy;
-
-    //         ReduceMinLoc<reduce_policy,float64> reducer(identity,-1);
-
-    //         forall<for_policy>(0, size, [=] EXEC_LAMBDA (int i)
-    //         {
-    //             const float64 val = 2.0 * acc_src[idx];
-    //             reducer.minloc(val,i);
-    //             acc_des.set(idx,val);
-    //         });
-    //         CONDUIT_DEVICE_ERROR_CHECK();
-
-    //         min_val = reducer.get();
-    //         min_loc = reducer.getLoc();
-    //     });
-
-    //     // sync values to node["des"], 
-    //     // (no op if node["des"] was originally in
-    //     //  same memory space as node["src"] )
-    //     acc_des.sync(node["des"]); 
-    // }
-
-    // //------------------------------------------------------
-    // // complex run on device using functor
-    // // (functor implementation)
-    // //------------------------------------------------------
-    // struct ExecFunctor
-    // {
-    //     float64 min_val;
-    //     index_t min_loc;
-
-    //     ExecutionAccessor<float64> acc_src;
-    //     ExecutionAccessor<float64> acc_des;
-
-    //     template<typename Exec>
-    //     void operator()(Exec &exec)
-    //     {
-    //         float64 identity = std::numeric_limits<float64>::max();
-    //         using for_policy    = typename Exec::for_policy;
-    //         using reduce_policy = typename Exec::reduce_policy;
-
-    //         ReduceMinLoc<reduce_policy,float64> reducer(identity, -1);
-
-    //         forall<for_policy>(0, size, [=] (int i)
-    //         {
-    //             const float64 val = 2.0 * acc_src[idx];
-    //             reducer.minloc(val,i);
-    //             acc_des.set(idx,val);
-    //         });
-    //         CONDUIT_DEVICE_ERROR_CHECK();
-
-    //         min_val = reducer.get();
-    //         min_loc = reducer.getLoc();
-    //     }
-    // };
-
-    // //------------------------------------------------------
-    // // complex run on device using functor 
-    // // (functor dispatch)
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
-
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
-    //     acc_des.use_with(policy);
-    //     acc_des.use_with(policy);
-
-    //     index_t size = acc_src.number_of_elements();
-
-    //     ExecFunctor f();
-
-    //     // init functor
-    //     f.acc_src = acc_src;
-    //     f.acc_des = acc_des;
-
-    //     dispatch(policy,f);
-
-    //     // get results stored in functor
-    //     float64 min_val = f.min_val;
-    //     index_t min_loc = f.min_loc;
-
-    //     // sync values to node["des"], 
-    //     // (no op if node["des"] was originally in
-    //     //  same memory space as node["src"])
-    //     acc_des.sync(node["des"]); 
-    // }
+        float64_accessor verify(node["des"]);
+        verify.use_with(ExecutionPolicy::host());
+        verify_doubled_values(verify);
+    }
 }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -394,9 +394,6 @@ TEST(conduit_execution, strawman)
         float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
         float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
-        src_device_ptr = nullptr;
-        des_device_ptr = nullptr;
-
         if (start_on_device)
         {
             src_device_ptr = static_cast<float64*>(

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -386,36 +386,36 @@ TEST(conduit_execution, strawman)
 {
     conduit_device_prepare();
 
-    auto setup_node = [](Node &node,
-                         const bool start_on_device,
-                         float64 *&src_device_ptr,
-                         float64 *&des_device_ptr)
+    auto setup_host_backed_node = [](Node &node)
     {
         float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
         float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
-        if (start_on_device)
-        {
-            src_device_ptr = static_cast<float64*>(
-                execution::DeviceMemory::allocate(sizeof(float64) * 4));
-            des_device_ptr = static_cast<float64*>(
-                execution::DeviceMemory::allocate(sizeof(float64) * 4));
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
+    };
 
-            conduit::execution::MagicMemory::copy(src_device_ptr,
-                                                  &src_vals[0],
-                                                  sizeof(float64) * 4);
-            conduit::execution::MagicMemory::copy(des_device_ptr,
-                                                  &des_vals[0],
-                                                  sizeof(float64) * 4);
+    auto setup_device_backed_node = [](Node &node,
+                                       float64 *&src_device_ptr,
+                                       float64 *&des_device_ptr)
+    {
+        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
-            node["src"].set_external(src_device_ptr, 4);
-            node["des"].set_external(des_device_ptr, 4);
-        }
-        else
-        {
-            node["src"].set(src_vals, 4);
-            node["des"].set(des_vals, 4);
-        }
+        src_device_ptr = static_cast<float64*>(
+            execution::DeviceMemory::allocate(sizeof(float64) * 4));
+        des_device_ptr = static_cast<float64*>(
+            execution::DeviceMemory::allocate(sizeof(float64) * 4));
+
+        conduit::execution::MagicMemory::copy(src_device_ptr,
+                                              &src_vals[0],
+                                              sizeof(float64) * 4);
+        conduit::execution::MagicMemory::copy(des_device_ptr,
+                                              &des_vals[0],
+                                              sizeof(float64) * 4);
+
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
     };
 
     auto run_policy_and_sync = [&](ExecutionPolicy policy,
@@ -425,7 +425,14 @@ TEST(conduit_execution, strawman)
         float64 *des_device_ptr = nullptr;
         Node node;
 
-        setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
+        if (start_on_device)
+        {
+            setup_device_backed_node(node, src_device_ptr, des_device_ptr);
+        }
+        else
+        {
+            setup_host_backed_node(node);
+        }
 
         {
             // DataAccessors wrap node leaf data.
@@ -489,7 +496,14 @@ TEST(conduit_execution, strawman)
         float64 *des_device_ptr = nullptr;
         Node node;
 
-        setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
+        if (start_on_device)
+        {
+            setup_device_backed_node(node, src_device_ptr, des_device_ptr);
+        }
+        else
+        {
+            setup_host_backed_node(node);
+        }
 
         {
             // DataAccessors wrap node leaf data.
@@ -556,7 +570,14 @@ TEST(conduit_execution, strawman)
         float64 *des_device_ptr = nullptr;
         Node node;
 
-        setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
+        if (start_on_device)
+        {
+            setup_device_backed_node(node, src_device_ptr, des_device_ptr);
+        }
+        else
+        {
+            setup_host_backed_node(node);
+        }
 
         {
             // DataAccessors wrap node leaf data.

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -426,11 +426,11 @@ TEST(conduit_execution, strawman)
     {
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
+        Node node;
+
+        setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
 
         {
-            Node node;
-            setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
-
             // DataAccessors wrap node leaf data.
             float64_accessor acc_src(node["src"]);
             float64_accessor acc_des(node["des"]);
@@ -466,17 +466,17 @@ TEST(conduit_execution, strawman)
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
             }
-
-            float64_accessor result_acc(node["des"]);
-            // Verification runs on the host, so use a host execution policy
-            // in case node["des"] still owns device-backed data here.
-            result_acc.use_with(ExecutionPolicy::host());
-            EXPECT_EQ(result_acc.number_of_elements(), 4);
-            EXPECT_EQ(result_acc[0], 2.0);
-            EXPECT_EQ(result_acc[1], 4.0);
-            EXPECT_EQ(result_acc[2], 6.0);
-            EXPECT_EQ(result_acc[3], 8.0);
         }
+
+        float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
 
         if (start_on_device)
         {
@@ -490,12 +490,11 @@ TEST(conduit_execution, strawman)
     {
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
-        float64 *owned_des_ptr = nullptr;
+        Node node;
+
+        setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
 
         {
-            Node node;
-            setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
-
             // DataAccessors wrap node leaf data.
             float64_accessor acc_src(node["src"]);
             float64_accessor acc_des(node["des"]);
@@ -528,25 +527,26 @@ TEST(conduit_execution, strawman)
             {
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
             }
-
-            float64_accessor result_acc(node["des"]);
-            // Verification runs on the host, so use a host execution policy
-            // in case node["des"] still owns device-backed data here.
-            result_acc.use_with(ExecutionPolicy::host());
-            EXPECT_EQ(result_acc.number_of_elements(), 4);
-            EXPECT_EQ(result_acc[0], 2.0);
-            EXPECT_EQ(result_acc[1], 4.0);
-            EXPECT_EQ(result_acc[2], 6.0);
-            EXPECT_EQ(result_acc[3], 8.0);
-
-            owned_des_ptr = static_cast<float64*>(node["des"].data_ptr());
         }
+
+        float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
 
         if (start_on_device)
         {
             execution::DeviceMemory::deallocate(src_device_ptr);
 
-            if (des_device_ptr != owned_des_ptr)
+            // If we started on the device and ran on the host, assume()
+            // adopted a new host buffer for node["des"], so the original
+            // external device destination allocation still needs cleanup.
+            if (policy.is_host_policy())
             {
                 execution::DeviceMemory::deallocate(des_device_ptr);
             }
@@ -557,11 +557,11 @@ TEST(conduit_execution, strawman)
     {
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
+        Node node;
+
+        setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
 
         {
-            Node node;
-            setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
-
             // DataAccessors wrap node leaf data.
             float64_accessor acc_src(node["src"]);
             float64_accessor acc_des(node["des"]);
@@ -607,17 +607,17 @@ TEST(conduit_execution, strawman)
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
             }
-
-            float64_accessor result_acc(node["des"]);
-            // Verification runs on the host, so use a host execution policy
-            // in case node["des"] still owns device-backed data here.
-            result_acc.use_with(ExecutionPolicy::host());
-            EXPECT_EQ(result_acc.number_of_elements(), 4);
-            EXPECT_EQ(result_acc[0], 2.0);
-            EXPECT_EQ(result_acc[1], 4.0);
-            EXPECT_EQ(result_acc[2], 6.0);
-            EXPECT_EQ(result_acc[3], 8.0);
         }
+
+        float64_accessor result_acc(node["des"]);
+        // Verification runs on the host, so use a host execution policy
+        // in case node["des"] still owns device-backed data here.
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
 
         if (start_on_device)
         {

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -484,13 +484,13 @@ TEST(conduit_execution, strawman)
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
             }
 
-            float64_accessor verify(node["des"]);
-            verify.use_with(ExecutionPolicy::host());
-            EXPECT_EQ(verify.number_of_elements(), 4);
-            EXPECT_EQ(verify[0], 2.0);
-            EXPECT_EQ(verify[1], 4.0);
-            EXPECT_EQ(verify[2], 6.0);
-            EXPECT_EQ(verify[3], 8.0);
+            float64_accessor result_acc(node["des"]);
+            result_acc.use_with(ExecutionPolicy::host());
+            EXPECT_EQ(result_acc.number_of_elements(), 4);
+            EXPECT_EQ(result_acc[0], 2.0);
+            EXPECT_EQ(result_acc[1], 4.0);
+            EXPECT_EQ(result_acc[2], 6.0);
+            EXPECT_EQ(result_acc[3], 8.0);
         }
 
         cleanup_external_device_data(src_device_ptr, des_device_ptr);
@@ -540,13 +540,13 @@ TEST(conduit_execution, strawman)
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
             }
 
-            float64_accessor verify(node["des"]);
-            verify.use_with(ExecutionPolicy::host());
-            EXPECT_EQ(verify.number_of_elements(), 4);
-            EXPECT_EQ(verify[0], 2.0);
-            EXPECT_EQ(verify[1], 4.0);
-            EXPECT_EQ(verify[2], 6.0);
-            EXPECT_EQ(verify[3], 8.0);
+            float64_accessor result_acc(node["des"]);
+            result_acc.use_with(ExecutionPolicy::host());
+            EXPECT_EQ(result_acc.number_of_elements(), 4);
+            EXPECT_EQ(result_acc[0], 2.0);
+            EXPECT_EQ(result_acc[1], 4.0);
+            EXPECT_EQ(result_acc[2], 6.0);
+            EXPECT_EQ(result_acc[3], 8.0);
         }
 
         cleanup_external_device_data(src_device_ptr, des_device_ptr);
@@ -608,13 +608,13 @@ TEST(conduit_execution, strawman)
                 EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
             }
 
-            float64_accessor verify(node["des"]);
-            verify.use_with(ExecutionPolicy::host());
-            EXPECT_EQ(verify.number_of_elements(), 4);
-            EXPECT_EQ(verify[0], 2.0);
-            EXPECT_EQ(verify[1], 4.0);
-            EXPECT_EQ(verify[2], 6.0);
-            EXPECT_EQ(verify[3], 8.0);
+            float64_accessor result_acc(node["des"]);
+            result_acc.use_with(ExecutionPolicy::host());
+            EXPECT_EQ(result_acc.number_of_elements(), 4);
+            EXPECT_EQ(result_acc[0], 2.0);
+            EXPECT_EQ(result_acc[1], 4.0);
+            EXPECT_EQ(result_acc[2], 6.0);
+            EXPECT_EQ(result_acc[3], 8.0);
         }
 
         cleanup_external_device_data(src_device_ptr, des_device_ptr);
@@ -667,4 +667,215 @@ TEST(conduit_execution, strawman)
     {
         run_where_src_is(true);
     }
+
+    // // TODO are there other cases in the notes?
+    // //------------------------------------------------------
+    // // forall cases
+    // //------------------------------------------------------
+
+    // //------------------------------------------------------
+    // // run on device
+    // //------------------------------------------------------
+    // if (ExecutionPolicy::is_device_enabled())
+    // {
+    //     Node node;
+    //     std::vector<int64> data_src = {0, 1, 2, 3};
+    //     node["src"].set(data_src);
+    //     std::vector<int64> data_des = {0, 0, 0, 0};
+    //     node["src"].set(data_des);
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+
+    //     acc_src.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+    //     {
+    //         const float64 val = 2.0 * acc_src[idx];
+    //         acc_des.set(idx,val);
+    //     });
+    //     CONDUIT_DEVICE_ERROR_CHECK();
+
+    //     // sync values to node["des"]
+    //     // (no op if node["des"] was originally device memory)
+    //     acc_des.sync();
+    // }
+
+    // //------------------------------------------------------
+    // // run on device, 
+    // // result stays on device and is owned by node["des"],
+    // // even if not on the device before hand
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+
+    //     acc_src.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+    //     {
+    //         const float64 val = 2.0 * acc_src[idx];
+    //         acc_des.set(idx,val);
+    //     });
+    //     CONDUIT_DEVICE_ERROR_CHECK();
+
+    //     // move results to be owned by node["des"]
+    //     // (no op if node["des"] was originally device memory)
+    //     acc_des.move(node["des"]); 
+    // }
+
+    // //------------------------------------------------------
+    // // run where the src data is
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = acc_src.active_space().execution_policy();
+    //     acc_des.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
+    //     {
+    //         const float64 val = 2.0 * acc_src[idx];
+    //         acc_des.set(idx,val);
+    //     });
+    //     CONDUIT_DEVICE_ERROR_CHECK();
+
+    //     // sync values to node["des"], 
+    //     // (no op if node["des"] was originally in 
+    //     //  same memory space as node["src"] )
+    //     acc_des.sync(node["des"]); 
+    // }
+
+    // //------------------------------------------------------
+    // // more complex cases
+    // //------------------------------------------------------
+
+    // //------------------------------------------------------
+    // // complex run on device 
+    // // double lambda forwarding concrete template tag
+    // // for use in lambda
+    // //
+    // // ( requires c++ 20 b/c of templated lambda)
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+    //     acc_des.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     index_t min_loc = -1;
+    //     float64 min_val = 0;
+
+    //     dispatch(policy, [&] <typename Exec>(Exec &exec)
+    //     {
+    //         float64 identity = std::numeric_limits<float64>::max();
+    //         using for_policy    = typename Exec::for_policy;
+    //         using reduce_policy = typename Exec::reduce_policy;
+
+    //         ReduceMinLoc<reduce_policy,float64> reducer(identity,-1);
+
+    //         forall<for_policy>(0, size, [=] EXEC_LAMBDA (int i)
+    //         {
+    //             const float64 val = 2.0 * acc_src[idx];
+    //             reducer.minloc(val,i);
+    //             acc_des.set(idx,val);
+    //         });
+    //         CONDUIT_DEVICE_ERROR_CHECK();
+
+    //         min_val = reducer.get();
+    //         min_loc = reducer.getLoc();
+    //     });
+
+    //     // sync values to node["des"], 
+    //     // (no op if node["des"] was originally in
+    //     //  same memory space as node["src"] )
+    //     acc_des.sync(node["des"]); 
+    // }
+
+    // //------------------------------------------------------
+    // // complex run on device using functor
+    // // (functor implementation)
+    // //------------------------------------------------------
+    // struct ExecFunctor
+    // {
+    //     float64 min_val;
+    //     index_t min_loc;
+
+    //     ExecutionAccessor<float64> acc_src;
+    //     ExecutionAccessor<float64> acc_des;
+
+    //     template<typename Exec>
+    //     void operator()(Exec &exec)
+    //     {
+    //         float64 identity = std::numeric_limits<float64>::max();
+    //         using for_policy    = typename Exec::for_policy;
+    //         using reduce_policy = typename Exec::reduce_policy;
+
+    //         ReduceMinLoc<reduce_policy,float64> reducer(identity, -1);
+
+    //         forall<for_policy>(0, size, [=] (int i)
+    //         {
+    //             const float64 val = 2.0 * acc_src[idx];
+    //             reducer.minloc(val,i);
+    //             acc_des.set(idx,val);
+    //         });
+    //         CONDUIT_DEVICE_ERROR_CHECK();
+
+    //         min_val = reducer.get();
+    //         min_loc = reducer.getLoc();
+    //     }
+    // };
+
+    // //------------------------------------------------------
+    // // complex run on device using functor 
+    // // (functor dispatch)
+    // //------------------------------------------------------
+    // {
+    //     Node node;
+    //     ExecutionAccessor<float64> acc_src(node["src"]);
+    //     ExecutionAccessor<float64> acc_des(node["des"]);
+
+    //     ExecutionPolicy policy = ExecutionPolicy::device();
+    //     acc_des.use_with(policy);
+    //     acc_des.use_with(policy);
+
+    //     index_t size = acc_src.number_of_elements();
+
+    //     ExecFunctor f();
+
+    //     // init functor
+    //     f.acc_src = acc_src;
+    //     f.acc_des = acc_des;
+
+    //     dispatch(policy,f);
+
+    //     // get results stored in functor
+    //     float64 min_val = f.min_val;
+    //     index_t min_loc = f.min_loc;
+
+    //     // sync values to node["des"], 
+    //     // (no op if node["des"] was originally in
+    //     //  same memory space as node["src"])
+    //     acc_des.sync(node["des"]); 
+    // }
 }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -393,6 +393,7 @@ strawman_make_device_buffer(const float64 *host_vals, index_t num_vals)
     return device_ptr;
 }
 
+//-----------------------------------------------------------------------------
 void
 strawman_run_policy_and_sync(Node &node,
                              ExecutionPolicy policy,
@@ -577,7 +578,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
     const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
     // Run with an explicit host execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to host memory.
     {
         std::cout << "sync policy=host src_start=host des_start=host" << std::endl;
 
@@ -594,7 +595,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
     if (ExecutionPolicy::is_device_enabled())
     {
         // Run with an explicit device execution policy.
-        // node["des"] is synced back to the memory space where it started.
+        // node["des"] is synced back to host memory.
         std::cout << "sync policy=device src_start=host des_start=host" << std::endl;
 
         float64 *src_device_ptr = nullptr;
@@ -639,7 +640,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
     }
 
     // Use the location of node["src"] to choose where to execute.
-    // node["des"] is then synced back to the memory space where it started.
+    // node["des"] is then synced back to host memory.
     {
         std::cout << "active_space src_start=host des_start=host" << std::endl;
 
@@ -667,7 +668,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     }
 
     // Run with an explicit host execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to device memory.
     {
         std::cout << "sync policy=host src_start=device des_start=device" << std::endl;
 
@@ -686,7 +687,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
     }
 
     // Run with an explicit device execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to device memory.
     {
         std::cout << "sync policy=device src_start=device des_start=device" << std::endl;
 
@@ -739,11 +740,10 @@ TEST(conduit_execution, strawman_src_device_des_device)
         strawman_expect_doubled_des(node);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
-        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Use the location of node["src"] to choose where to execute.
-    // node["des"] is then synced back to the memory space where it started.
+    // node["des"] is then synced back to device memory.
     {
         std::cout << "active_space src_start=device des_start=device" << std::endl;
 
@@ -775,7 +775,7 @@ TEST(conduit_execution, strawman_src_host_des_device)
     }
 
     // Run with an explicit host execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to device memory.
     {
         std::cout << "sync policy=host src_start=host des_start=device" << std::endl;
 
@@ -792,7 +792,7 @@ TEST(conduit_execution, strawman_src_host_des_device)
     }
 
     // Run with an explicit device execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to device memory.
     {
         std::cout << "sync policy=device src_start=host des_start=device" << std::endl;
 
@@ -839,11 +839,10 @@ TEST(conduit_execution, strawman_src_host_des_device)
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
         strawman_expect_doubled_des(node);
         node.reset();
-        execution::DeviceMemory::deallocate(des_device_ptr);
     }
 
     // Use the location of node["src"] to choose where to execute.
-    // node["des"] is then synced back to the memory space where it started.
+    // node["des"] is then synced back to device memory.
     {
         std::cout << "active_space src_start=host des_start=device" << std::endl;
 
@@ -873,7 +872,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
     }
 
     // Run with an explicit host execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to host memory.
     {
         std::cout << "sync policy=host src_start=device des_start=host" << std::endl;
 
@@ -890,7 +889,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
     }
 
     // Run with an explicit device execution policy.
-    // node["des"] is synced back to the memory space where it started.
+    // node["des"] is synced back to host memory.
     {
         std::cout << "sync policy=device src_start=device des_start=host" << std::endl;
 
@@ -941,7 +940,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
     }
 
     // Use the location of node["src"] to choose where to execute.
-    // node["des"] is then synced back to the memory space where it started.
+    // node["des"] is then synced back to host memory.
     {
         std::cout << "active_space src_start=device des_start=host" << std::endl;
 

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -389,16 +389,6 @@ TEST(conduit_execution, strawman)
     conduit_device_prepare();
 
     //-----------------------------------------------------------------------------
-    auto verify_doubled_values = [](float64_accessor &acc)
-    {
-        EXPECT_EQ(acc.number_of_elements(), 4);
-        EXPECT_EQ(acc[0], 2.0);
-        EXPECT_EQ(acc[1], 4.0);
-        EXPECT_EQ(acc[2], 6.0);
-        EXPECT_EQ(acc[3], 8.0);
-    };
-
-    //-----------------------------------------------------------------------------
     // run wherever the source data is
     //-----------------------------------------------------------------------------
     {
@@ -428,7 +418,11 @@ TEST(conduit_execution, strawman)
         acc_des.sync();
 
         float64_accessor verify(node["des"]);
-        verify_doubled_values(verify);
+        EXPECT_EQ(verify.number_of_elements(), 4);
+        EXPECT_EQ(verify[0], 2.0);
+        EXPECT_EQ(verify[1], 4.0);
+        EXPECT_EQ(verify[2], 6.0);
+        EXPECT_EQ(verify[3], 8.0);
     }
 
     //-----------------------------------------------------------------------------
@@ -461,7 +455,11 @@ TEST(conduit_execution, strawman)
         acc_des.sync();
 
         float64_accessor verify(node["des"]);
-        verify_doubled_values(verify);
+        EXPECT_EQ(verify.number_of_elements(), 4);
+        EXPECT_EQ(verify[0], 2.0);
+        EXPECT_EQ(verify[1], 4.0);
+        EXPECT_EQ(verify[2], 6.0);
+        EXPECT_EQ(verify[3], 8.0);
     }
 
     //-----------------------------------------------------------------------------
@@ -496,6 +494,10 @@ TEST(conduit_execution, strawman)
 
         float64_accessor verify(node["des"]);
         verify.use_with(ExecutionPolicy::host());
-        verify_doubled_values(verify);
+        EXPECT_EQ(verify.number_of_elements(), 4);
+        EXPECT_EQ(verify[0], 2.0);
+        EXPECT_EQ(verify[1], 4.0);
+        EXPECT_EQ(verify[2], 6.0);
+        EXPECT_EQ(verify[3], 8.0);
     }
 }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -386,7 +386,6 @@ TEST(conduit_execution, strawman)
 {
     conduit_device_prepare();
 
-    //-----------------------------------------------------------------------------
     auto setup_node = [](Node &node,
                          const bool start_on_device,
                          float64 *&src_device_ptr,
@@ -422,22 +421,6 @@ TEST(conduit_execution, strawman)
         }
     };
 
-    //-----------------------------------------------------------------------------
-    auto cleanup_external_device_data = [](float64 *src_device_ptr,
-                                           float64 *des_device_ptr)
-    {
-        if (nullptr != src_device_ptr)
-        {
-            execution::DeviceMemory::deallocate(src_device_ptr);
-        }
-
-        if (nullptr != des_device_ptr)
-        {
-            execution::DeviceMemory::deallocate(des_device_ptr);
-        }
-    };
-
-    //-----------------------------------------------------------------------------
     auto run_policy_and_sync = [&](ExecutionPolicy policy,
                                    const bool start_on_device)
     {
@@ -493,15 +476,19 @@ TEST(conduit_execution, strawman)
             EXPECT_EQ(result_acc[3], 8.0);
         }
 
-        cleanup_external_device_data(src_device_ptr, des_device_ptr);
+        if (start_on_device)
+        {
+            execution::DeviceMemory::deallocate(src_device_ptr);
+            execution::DeviceMemory::deallocate(des_device_ptr);
+        }
     };
 
-    //-----------------------------------------------------------------------------
     auto run_policy_and_assume = [&](ExecutionPolicy policy,
                                      const bool start_on_device)
     {
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
+        float64 *owned_des_ptr = nullptr;
 
         {
             Node node;
@@ -547,12 +534,21 @@ TEST(conduit_execution, strawman)
             EXPECT_EQ(result_acc[1], 4.0);
             EXPECT_EQ(result_acc[2], 6.0);
             EXPECT_EQ(result_acc[3], 8.0);
+
+            owned_des_ptr = static_cast<float64*>(node["des"].data_ptr());
         }
 
-        cleanup_external_device_data(src_device_ptr, des_device_ptr);
+        if (start_on_device)
+        {
+            execution::DeviceMemory::deallocate(src_device_ptr);
+
+            if (des_device_ptr != owned_des_ptr)
+            {
+                execution::DeviceMemory::deallocate(des_device_ptr);
+            }
+        }
     };
 
-    //-----------------------------------------------------------------------------
     auto run_where_src_is = [&](const bool start_on_device)
     {
         float64 *src_device_ptr = nullptr;
@@ -617,7 +613,11 @@ TEST(conduit_execution, strawman)
             EXPECT_EQ(result_acc[3], 8.0);
         }
 
-        cleanup_external_device_data(src_device_ptr, des_device_ptr);
+        if (start_on_device)
+        {
+            execution::DeviceMemory::deallocate(src_device_ptr);
+            execution::DeviceMemory::deallocate(des_device_ptr);
+        }
     };
 
     //-----------------------------------------------------------------------------

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -387,47 +387,266 @@ TEST(conduit_execution, strawman)
     conduit_device_prepare();
 
     //-----------------------------------------------------------------------------
+    auto setup_node = [](Node &node,
+                         const bool start_on_device,
+                         float64 *&src_device_ptr,
+                         float64 *&des_device_ptr)
+    {
+        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
+
+        src_device_ptr = nullptr;
+        des_device_ptr = nullptr;
+
+        if (start_on_device)
+        {
+            src_device_ptr = static_cast<float64*>(
+                execution::DeviceMemory::allocate(sizeof(float64) * 4));
+            des_device_ptr = static_cast<float64*>(
+                execution::DeviceMemory::allocate(sizeof(float64) * 4));
+
+            conduit::execution::MagicMemory::copy(src_device_ptr,
+                                                  &src_vals[0],
+                                                  sizeof(float64) * 4);
+            conduit::execution::MagicMemory::copy(des_device_ptr,
+                                                  &des_vals[0],
+                                                  sizeof(float64) * 4);
+
+            node["src"].set_external(src_device_ptr, 4);
+            node["des"].set_external(des_device_ptr, 4);
+        }
+        else
+        {
+            node["src"].set(src_vals, 4);
+            node["des"].set(des_vals, 4);
+        }
+    };
+
+    //-----------------------------------------------------------------------------
+    auto cleanup_external_device_data = [](float64 *src_device_ptr,
+                                           float64 *des_device_ptr)
+    {
+        if (nullptr != src_device_ptr)
+        {
+            execution::DeviceMemory::deallocate(src_device_ptr);
+        }
+
+        if (nullptr != des_device_ptr)
+        {
+            execution::DeviceMemory::deallocate(des_device_ptr);
+        }
+    };
+
+    //-----------------------------------------------------------------------------
+    auto run_policy_and_sync = [&](ExecutionPolicy policy,
+                                   const bool start_on_device)
+    {
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+
+        {
+            Node node;
+            setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
+
+            // DataAccessors wrap node leaf data.
+            float64_accessor acc_src(node["src"]);
+            float64_accessor acc_des(node["des"]);
+
+            // Ask the accessors to move their data to the memory space occupied
+            // by the requested execution policy if their data is not already
+            // there.
+            acc_src.use_with(policy);
+            acc_des.use_with(policy);
+
+            // Our forall will execute in the memory space selected by the
+            // requested ExecutionPolicy.
+            index_t size = acc_src.number_of_elements();
+            conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+            {
+                const float64 val = 2.0 * acc_src[idx];
+                acc_des.set(idx, val);
+            });
+            CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+            // Sync values to node["des"].
+            // This is a no op if node["des"] was originally in the same memory
+            // space as the requested execution policy.
+            acc_des.sync();
+
+            if (start_on_device)
+            {
+                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+            }
+            else
+            {
+                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+            }
+
+            float64_accessor verify(node["des"]);
+            verify.use_with(ExecutionPolicy::host());
+            EXPECT_EQ(verify.number_of_elements(), 4);
+            EXPECT_EQ(verify[0], 2.0);
+            EXPECT_EQ(verify[1], 4.0);
+            EXPECT_EQ(verify[2], 6.0);
+            EXPECT_EQ(verify[3], 8.0);
+        }
+
+        cleanup_external_device_data(src_device_ptr, des_device_ptr);
+    };
+
+    //-----------------------------------------------------------------------------
+    auto run_policy_and_assume = [&](ExecutionPolicy policy,
+                                     const bool start_on_device)
+    {
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+
+        {
+            Node node;
+            setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
+
+            // DataAccessors wrap node leaf data.
+            float64_accessor acc_src(node["src"]);
+            float64_accessor acc_des(node["des"]);
+
+            // Ask the accessors to move their data to the memory space occupied
+            // by the requested execution policy if their data is not already
+            // there.
+            acc_src.use_with(policy);
+            acc_des.use_with(policy);
+
+            // Our forall will execute in the memory space selected by the
+            // requested ExecutionPolicy.
+            index_t size = acc_src.number_of_elements();
+            conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+            {
+                const float64 val = 2.0 * acc_src[idx];
+                acc_des.set(idx, val);
+            });
+            CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+            // node["des"] takes ownership of the data in the active execution
+            // space. This is a no op if node["des"] was already in that space.
+            acc_des.assume();
+
+            if (policy.is_device_policy())
+            {
+                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+            }
+            else
+            {
+                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+            }
+
+            float64_accessor verify(node["des"]);
+            verify.use_with(ExecutionPolicy::host());
+            EXPECT_EQ(verify.number_of_elements(), 4);
+            EXPECT_EQ(verify[0], 2.0);
+            EXPECT_EQ(verify[1], 4.0);
+            EXPECT_EQ(verify[2], 6.0);
+            EXPECT_EQ(verify[3], 8.0);
+        }
+
+        cleanup_external_device_data(src_device_ptr, des_device_ptr);
+    };
+
+    //-----------------------------------------------------------------------------
+    auto run_where_src_is = [&](const bool start_on_device)
+    {
+        float64 *src_device_ptr = nullptr;
+        float64 *des_device_ptr = nullptr;
+
+        {
+            Node node;
+            setup_node(node, start_on_device, src_device_ptr, des_device_ptr);
+
+            // DataAccessors wrap node leaf data.
+            float64_accessor acc_src(node["src"]);
+            float64_accessor acc_des(node["des"]);
+
+            // Use the location of the source data.
+            ExecutionPolicy policy = acc_src.active_space();
+            if (start_on_device)
+            {
+                EXPECT_TRUE(policy.is_device_policy());
+            }
+            else
+            {
+                EXPECT_TRUE(policy.is_host_policy());
+            }
+
+            // Ask the accessors to move their data to the memory space occupied
+            // by node["src"] if their data is not already there.
+            acc_src.use_with(policy);
+            acc_des.use_with(policy);
+
+            // Our forall will execute on the memory space occupied by node["src"]
+            // because it was passed an ExecutionPolicy for that space.
+            index_t size = acc_src.number_of_elements();
+            conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+            {
+                const float64 val = 2.0 * acc_src[idx];
+                acc_des.set(idx, val);
+            });
+            CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+            // Sync values to node["des"].
+            // This is a no op if node["des"] was originally in the same memory
+            // space as node["src"].
+            acc_des.sync();
+
+            if (start_on_device)
+            {
+                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+                EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+            }
+            else
+            {
+                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
+                EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+            }
+
+            float64_accessor verify(node["des"]);
+            verify.use_with(ExecutionPolicy::host());
+            EXPECT_EQ(verify.number_of_elements(), 4);
+            EXPECT_EQ(verify[0], 2.0);
+            EXPECT_EQ(verify[1], 4.0);
+            EXPECT_EQ(verify[2], 6.0);
+            EXPECT_EQ(verify[3], 8.0);
+        }
+
+        cleanup_external_device_data(src_device_ptr, des_device_ptr);
+    };
+
+    //-----------------------------------------------------------------------------
+    // run on host
+    //-----------------------------------------------------------------------------
+    run_policy_and_sync(ExecutionPolicy::host(), false);
+
+    if (ExecutionPolicy::is_device_enabled())
+    {
+        run_policy_and_sync(ExecutionPolicy::host(), true);
+    }
+
+    //-----------------------------------------------------------------------------
     // run on device
     //-----------------------------------------------------------------------------
     if (ExecutionPolicy::is_device_enabled())
     {
-        Node node;
-        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-        node["src"].set(src_vals, 4);
-        node["des"].set(des_vals, 4);
+        run_policy_and_sync(ExecutionPolicy::device(), false);
+        run_policy_and_sync(ExecutionPolicy::device(), true);
+    }
 
-        // DataAccessors wrap node leaf data.
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
+    //-----------------------------------------------------------------------------
+    // run on host and leave the result on the host
+    //-----------------------------------------------------------------------------
+    run_policy_and_assume(ExecutionPolicy::host(), false);
 
-        ExecutionPolicy policy = ExecutionPolicy::device();
-
-        // Ask the accessors to move their data to the device if their data is
-        // not already there.
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
-
-        // Our forall will execute on the device because it was passed a device
-        // ExecutionPolicy.
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-        // Sync values to node["des"].
-        // This is a no op if node["des"] was originally device memory.
-        acc_des.sync();
-
-        float64_accessor verify(node["des"]);
-        EXPECT_EQ(verify.number_of_elements(), 4);
-        EXPECT_EQ(verify[0], 2.0);
-        EXPECT_EQ(verify[1], 4.0);
-        EXPECT_EQ(verify[2], 6.0);
-        EXPECT_EQ(verify[3], 8.0);
+    if (ExecutionPolicy::is_device_enabled())
+    {
+        run_policy_and_assume(ExecutionPolicy::host(), true);
     }
 
     //-----------------------------------------------------------------------------
@@ -435,301 +654,17 @@ TEST(conduit_execution, strawman)
     //-----------------------------------------------------------------------------
     if (ExecutionPolicy::is_device_enabled())
     {
-        Node node;
-        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-        node["src"].set(src_vals, 4);
-        node["des"].set(des_vals, 4);
-
-        // DataAccessors wrap node leaf data.
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
-
-        ExecutionPolicy policy = ExecutionPolicy::device();
-
-        // Ask the accessors to move their data to the device if their data is
-        // not already there.
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
-
-        // Our forall will execute on the device because it was passed a device
-        // ExecutionPolicy.
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-        // node["des"] takes ownership of the data on the device.
-        // This is a no op if node["des"] was originally device memory.
-        acc_des.assume();
-        EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
-
-        float64_accessor verify(node["des"]);
-        verify.use_with(ExecutionPolicy::host());
-        EXPECT_EQ(verify.number_of_elements(), 4);
-        EXPECT_EQ(verify[0], 2.0);
-        EXPECT_EQ(verify[1], 4.0);
-        EXPECT_EQ(verify[2], 6.0);
-        EXPECT_EQ(verify[3], 8.0);
+        run_policy_and_assume(ExecutionPolicy::device(), false);
+        run_policy_and_assume(ExecutionPolicy::device(), true);
     }
 
     //-----------------------------------------------------------------------------
     // run wherever the source data is
     //-----------------------------------------------------------------------------
+    run_where_src_is(false);
+
+    if (ExecutionPolicy::is_device_enabled())
     {
-        Node node;
-        float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-        float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-        node["src"].set(src_vals, 4);
-        node["des"].set(des_vals, 4);
-
-        // DataAccessors wrap node leaf data.
-        float64_accessor acc_src(node["src"]);
-        float64_accessor acc_des(node["des"]);
-
-        // Use the location of the source data.
-        ExecutionPolicy policy = acc_src.active_space();
-        EXPECT_TRUE(policy.is_host_policy());
-
-        // Ask the accessors to move their data to the memory space occupied by
-        // node["src"] if their data is not already there.
-        acc_src.use_with(policy);
-        acc_des.use_with(policy);
-
-        // Our forall will execute on the memory space occupied by node["src"]
-        // because it was passed an ExecutionPolicy for that space.
-        index_t size = acc_src.number_of_elements();
-        conduit::execution::forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-        {
-            const float64 val = 2.0 * acc_src[idx];
-            acc_des.set(idx, val);
-        });
-        CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-        // Sync values to node["des"].
-        // This is a no op if node["des"] was originally in the same memory
-        // space as node["src"].
-        acc_des.sync();
-
-        float64_accessor verify(node["des"]);
-        EXPECT_EQ(verify.number_of_elements(), 4);
-        EXPECT_EQ(verify[0], 2.0);
-        EXPECT_EQ(verify[1], 4.0);
-        EXPECT_EQ(verify[2], 6.0);
-        EXPECT_EQ(verify[3], 8.0);
+        run_where_src_is(true);
     }
-
-    // // TODO are there other cases in the notes?
-    // //------------------------------------------------------
-    // // forall cases
-    // //------------------------------------------------------
-
-    // //------------------------------------------------------
-    // // run on device
-    // //------------------------------------------------------
-    // if (ExecutionPolicy::is_device_enabled())
-    // {
-    //     Node node;
-    //     std::vector<int64> data_src = {0, 1, 2, 3};
-    //     node["src"].set(data_src);
-    //     std::vector<int64> data_des = {0, 0, 0, 0};
-    //     node["src"].set(data_des);
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
-
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
-
-    //     acc_src.use_with(policy);
-    //     acc_des.use_with(policy);
-
-    //     index_t size = acc_src.number_of_elements();
-
-    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-    //     {
-    //         const float64 val = 2.0 * acc_src[idx];
-    //         acc_des.set(idx,val);
-    //     });
-    //     CONDUIT_DEVICE_ERROR_CHECK();
-
-    //     // sync values to node["des"]
-    //     // (no op if node["des"] was originally device memory)
-    //     acc_des.sync();
-    // }
-
-    // //------------------------------------------------------
-    // // run on device, 
-    // // result stays on device and is owned by node["des"],
-    // // even if not on the device before hand
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
-
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
-
-    //     acc_src.use_with(policy);
-    //     acc_des.use_with(policy);
-
-    //     index_t size = acc_src.number_of_elements();
-
-    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-    //     {
-    //         const float64 val = 2.0 * acc_src[idx];
-    //         acc_des.set(idx,val);
-    //     });
-    //     CONDUIT_DEVICE_ERROR_CHECK();
-
-    //     // move results to be owned by node["des"]
-    //     // (no op if node["des"] was originally device memory)
-    //     acc_des.move(node["des"]); 
-    // }
-
-    // //------------------------------------------------------
-    // // run where the src data is
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
-
-    //     ExecutionPolicy policy = acc_src.active_space().execution_policy();
-    //     acc_des.use_with(policy);
-    //     acc_des.use_with(policy);
-
-    //     index_t size = acc_src.number_of_elements();
-
-    //     forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
-    //     {
-    //         const float64 val = 2.0 * acc_src[idx];
-    //         acc_des.set(idx,val);
-    //     });
-    //     CONDUIT_DEVICE_ERROR_CHECK();
-
-    //     // sync values to node["des"], 
-    //     // (no op if node["des"] was originally in 
-    //     //  same memory space as node["src"] )
-    //     acc_des.sync(node["des"]); 
-    // }
-
-    // //------------------------------------------------------
-    // // more complex cases
-    // //------------------------------------------------------
-
-    // //------------------------------------------------------
-    // // complex run on device 
-    // // double lambda forwarding concrete template tag
-    // // for use in lambda
-    // //
-    // // ( requires c++ 20 b/c of templated lambda)
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
-
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
-    //     acc_des.use_with(policy);
-    //     acc_des.use_with(policy);
-
-    //     index_t size = acc_src.number_of_elements();
-
-    //     index_t min_loc = -1;
-    //     float64 min_val = 0;
-
-    //     dispatch(policy, [&] <typename Exec>(Exec &exec)
-    //     {
-    //         float64 identity = std::numeric_limits<float64>::max();
-    //         using for_policy    = typename Exec::for_policy;
-    //         using reduce_policy = typename Exec::reduce_policy;
-
-    //         ReduceMinLoc<reduce_policy,float64> reducer(identity,-1);
-
-    //         forall<for_policy>(0, size, [=] EXEC_LAMBDA (int i)
-    //         {
-    //             const float64 val = 2.0 * acc_src[idx];
-    //             reducer.minloc(val,i);
-    //             acc_des.set(idx,val);
-    //         });
-    //         CONDUIT_DEVICE_ERROR_CHECK();
-
-    //         min_val = reducer.get();
-    //         min_loc = reducer.getLoc();
-    //     });
-
-    //     // sync values to node["des"], 
-    //     // (no op if node["des"] was originally in
-    //     //  same memory space as node["src"] )
-    //     acc_des.sync(node["des"]); 
-    // }
-
-    // //------------------------------------------------------
-    // // complex run on device using functor
-    // // (functor implementation)
-    // //------------------------------------------------------
-    // struct ExecFunctor
-    // {
-    //     float64 min_val;
-    //     index_t min_loc;
-
-    //     ExecutionAccessor<float64> acc_src;
-    //     ExecutionAccessor<float64> acc_des;
-
-    //     template<typename Exec>
-    //     void operator()(Exec &exec)
-    //     {
-    //         float64 identity = std::numeric_limits<float64>::max();
-    //         using for_policy    = typename Exec::for_policy;
-    //         using reduce_policy = typename Exec::reduce_policy;
-
-    //         ReduceMinLoc<reduce_policy,float64> reducer(identity, -1);
-
-    //         forall<for_policy>(0, size, [=] (int i)
-    //         {
-    //             const float64 val = 2.0 * acc_src[idx];
-    //             reducer.minloc(val,i);
-    //             acc_des.set(idx,val);
-    //         });
-    //         CONDUIT_DEVICE_ERROR_CHECK();
-
-    //         min_val = reducer.get();
-    //         min_loc = reducer.getLoc();
-    //     }
-    // };
-
-    // //------------------------------------------------------
-    // // complex run on device using functor 
-    // // (functor dispatch)
-    // //------------------------------------------------------
-    // {
-    //     Node node;
-    //     ExecutionAccessor<float64> acc_src(node["src"]);
-    //     ExecutionAccessor<float64> acc_des(node["des"]);
-
-    //     ExecutionPolicy policy = ExecutionPolicy::device();
-    //     acc_des.use_with(policy);
-    //     acc_des.use_with(policy);
-
-    //     index_t size = acc_src.number_of_elements();
-
-    //     ExecFunctor f();
-
-    //     // init functor
-    //     f.acc_src = acc_src;
-    //     f.acc_des = acc_des;
-
-    //     dispatch(policy,f);
-
-    //     // get results stored in functor
-    //     float64 min_val = f.min_val;
-    //     index_t min_loc = f.min_loc;
-
-    //     // sync values to node["des"], 
-    //     // (no op if node["des"] was originally in
-    //     //  same memory space as node["src"])
-    //     acc_des.sync(node["des"]); 
-    // }
 }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -556,21 +556,6 @@ strawman_run_where_src_is(Node &node,
 }
 
 //-----------------------------------------------------------------------------
-void
-strawman_expect_doubled_des(Node &node)
-{
-    float64_accessor result_acc(node["des"]);
-    // Verification runs on the host, so use a host execution policy
-    // in case node["des"] still owns device-backed data here.
-    result_acc.use_with(ExecutionPolicy::host());
-    EXPECT_EQ(result_acc.number_of_elements(), 4);
-    EXPECT_EQ(result_acc[0], 2.0);
-    EXPECT_EQ(result_acc[1], 4.0);
-    EXPECT_EQ(result_acc[2], 6.0);
-    EXPECT_EQ(result_acc[3], 8.0);
-}
-
-//-----------------------------------------------------------------------------
 TEST(conduit_execution, strawman_src_host_des_host)
 {
     conduit_device_prepare();
@@ -588,7 +573,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
     }
 
@@ -604,7 +595,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
     }
 
@@ -619,7 +616,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
     }
 
@@ -635,7 +638,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
     }
 
@@ -650,7 +659,13 @@ TEST(conduit_execution, strawman_src_host_des_host)
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
         strawman_run_where_src_is(node, false, false, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
     }
 }
@@ -680,7 +695,13 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -699,7 +720,13 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -718,7 +745,13 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -737,7 +770,13 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -755,7 +794,13 @@ TEST(conduit_execution, strawman_src_device_des_device)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_where_src_is(node, true, true, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -786,7 +831,13 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -803,7 +854,13 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -820,7 +877,13 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -837,7 +900,13 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
     }
 
@@ -853,7 +922,13 @@ TEST(conduit_execution, strawman_src_host_des_device)
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
         strawman_run_where_src_is(node, false, false, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -883,7 +958,13 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -900,7 +981,13 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -917,7 +1004,13 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -934,7 +1027,13 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -951,7 +1050,13 @@ TEST(conduit_execution, strawman_src_device_des_host)
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
         strawman_run_where_src_is(node, true, true, false);
-        strawman_expect_doubled_des(node);
+        float64_accessor result_acc(node["des"]);
+        result_acc.use_with(ExecutionPolicy::host());
+        EXPECT_EQ(result_acc.number_of_elements(), 4);
+        EXPECT_EQ(result_acc[0], 2.0);
+        EXPECT_EQ(result_acc[1], 4.0);
+        EXPECT_EQ(result_acc[2], 6.0);
+        EXPECT_EQ(result_acc[3], 8.0);
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -389,43 +389,15 @@ enum StrawmanStartSpace
 };
 
 //-----------------------------------------------------------------------------
-void
-strawman_setup_node(Node &node,
-                    StrawmanStartSpace src_start_space,
-                    StrawmanStartSpace des_start_space,
-                    float64 *&src_device_ptr,
-                    float64 *&des_device_ptr)
+float64 *
+strawman_make_device_buffer(const float64 *host_vals, index_t num_vals)
 {
-    float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
-    float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
-
-    if (src_start_space == STRAWMAN_START_ON_DEVICE)
-    {
-        src_device_ptr = static_cast<float64*>(
-            execution::DeviceMemory::allocate(sizeof(float64) * 4));
-        conduit::execution::MagicMemory::copy(src_device_ptr,
-                                              &src_vals[0],
-                                              sizeof(float64) * 4);
-        node["src"].set_external(src_device_ptr, 4);
-    }
-    else
-    {
-        node["src"].set(src_vals, 4);
-    }
-
-    if (des_start_space == STRAWMAN_START_ON_DEVICE)
-    {
-        des_device_ptr = static_cast<float64*>(
-            execution::DeviceMemory::allocate(sizeof(float64) * 4));
-        conduit::execution::MagicMemory::copy(des_device_ptr,
-                                              &des_vals[0],
-                                              sizeof(float64) * 4);
-        node["des"].set_external(des_device_ptr, 4);
-    }
-    else
-    {
-        node["des"].set(des_vals, 4);
-    }
+    float64 *device_ptr = static_cast<float64*>(
+        execution::DeviceMemory::allocate(sizeof(float64) * num_vals));
+    conduit::execution::MagicMemory::copy(device_ptr,
+                                          host_vals,
+                                          sizeof(float64) * num_vals);
+    return device_ptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -500,16 +472,6 @@ strawman_run_policy_and_sync(Node &node,
             EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
     }
-
-    float64_accessor result_acc(node["des"]);
-    // Verification runs on the host, so use a host execution policy
-    // in case node["des"] still owns device-backed data here.
-    result_acc.use_with(ExecutionPolicy::host());
-    EXPECT_EQ(result_acc.number_of_elements(), 4);
-    EXPECT_EQ(result_acc[0], 2.0);
-    EXPECT_EQ(result_acc[1], 4.0);
-    EXPECT_EQ(result_acc[2], 6.0);
-    EXPECT_EQ(result_acc[3], 8.0);
 }
 
 //-----------------------------------------------------------------------------
@@ -562,16 +524,6 @@ strawman_run_policy_and_assume(Node &node,
             EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
     }
-
-    float64_accessor result_acc(node["des"]);
-    // Verification runs on the host, so use a host execution policy
-    // in case node["des"] still owns device-backed data here.
-    result_acc.use_with(ExecutionPolicy::host());
-    EXPECT_EQ(result_acc.number_of_elements(), 4);
-    EXPECT_EQ(result_acc[0], 2.0);
-    EXPECT_EQ(result_acc[1], 4.0);
-    EXPECT_EQ(result_acc[2], 6.0);
-    EXPECT_EQ(result_acc[3], 8.0);
 }
 
 //-----------------------------------------------------------------------------
@@ -635,7 +587,12 @@ strawman_run_where_src_is(Node &node,
             EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
         }
     }
+}
 
+//-----------------------------------------------------------------------------
+void
+strawman_expect_doubled_des(Node &node)
+{
     float64_accessor result_acc(node["des"]);
     // Verification runs on the host, so use a host execution policy
     // in case node["des"] still owns device-backed data here.
@@ -651,6 +608,8 @@ strawman_run_where_src_is(Node &node,
 TEST(conduit_execution, strawman_src_host_des_host)
 {
     conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
     // Run with an explicit host execution policy.
     // node["des"] is synced back to the memory space where it started.
@@ -660,12 +619,10 @@ TEST(conduit_execution, strawman_src_host_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_HOST,
@@ -682,12 +639,10 @@ TEST(conduit_execution, strawman_src_host_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_HOST,
@@ -703,12 +658,10 @@ TEST(conduit_execution, strawman_src_host_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_HOST,
@@ -725,12 +678,10 @@ TEST(conduit_execution, strawman_src_host_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_HOST,
@@ -746,12 +697,10 @@ TEST(conduit_execution, strawman_src_host_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        node["src"].set(src_vals, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_where_src_is(node, false, false, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_HOST,
@@ -764,6 +713,8 @@ TEST(conduit_execution, strawman_src_host_des_host)
 TEST(conduit_execution, strawman_src_device_des_device)
 {
     conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
     if (!ExecutionPolicy::is_device_enabled())
     {
@@ -778,12 +729,12 @@ TEST(conduit_execution, strawman_src_device_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_DEVICE,
@@ -799,12 +750,12 @@ TEST(conduit_execution, strawman_src_device_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_DEVICE,
@@ -820,12 +771,12 @@ TEST(conduit_execution, strawman_src_device_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_DEVICE,
@@ -841,12 +792,12 @@ TEST(conduit_execution, strawman_src_device_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_DEVICE,
@@ -862,12 +813,12 @@ TEST(conduit_execution, strawman_src_device_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_where_src_is(node, true, true, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_DEVICE,
@@ -880,6 +831,8 @@ TEST(conduit_execution, strawman_src_device_des_device)
 TEST(conduit_execution, strawman_src_host_des_device)
 {
     conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
     if (!ExecutionPolicy::is_device_enabled())
     {
@@ -894,12 +847,11 @@ TEST(conduit_execution, strawman_src_host_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), false, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_DEVICE,
@@ -915,12 +867,11 @@ TEST(conduit_execution, strawman_src_host_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), false, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_DEVICE,
@@ -936,12 +887,11 @@ TEST(conduit_execution, strawman_src_host_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), false, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_DEVICE,
@@ -957,12 +907,11 @@ TEST(conduit_execution, strawman_src_host_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), false, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_DEVICE,
@@ -978,12 +927,11 @@ TEST(conduit_execution, strawman_src_host_des_device)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_HOST,
-                            STRAWMAN_START_ON_DEVICE,
-                            src_device_ptr,
-                            des_device_ptr);
+        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        node["src"].set(src_vals, 4);
+        node["des"].set_external(des_device_ptr, 4);
         strawman_run_where_src_is(node, false, false, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_HOST,
                               STRAWMAN_START_ON_DEVICE,
@@ -996,6 +944,8 @@ TEST(conduit_execution, strawman_src_host_des_device)
 TEST(conduit_execution, strawman_src_device_des_host)
 {
     conduit_device_prepare();
+    const float64 src_vals[4] = {1.0, 2.0, 3.0, 4.0};
+    const float64 des_vals[4] = {0.0, 0.0, 0.0, 0.0};
 
     if (!ExecutionPolicy::is_device_enabled())
     {
@@ -1010,12 +960,11 @@ TEST(conduit_execution, strawman_src_device_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::host(), true, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_HOST,
@@ -1031,12 +980,11 @@ TEST(conduit_execution, strawman_src_device_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_sync(node, ExecutionPolicy::device(), true, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_HOST,
@@ -1052,12 +1000,11 @@ TEST(conduit_execution, strawman_src_device_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::host(), true, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_HOST,
@@ -1073,12 +1020,11 @@ TEST(conduit_execution, strawman_src_device_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_policy_and_assume(node, ExecutionPolicy::device(), true, true);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_HOST,
@@ -1094,12 +1040,11 @@ TEST(conduit_execution, strawman_src_device_des_host)
         float64 *src_device_ptr = nullptr;
         float64 *des_device_ptr = nullptr;
         Node node;
-        strawman_setup_node(node,
-                            STRAWMAN_START_ON_DEVICE,
-                            STRAWMAN_START_ON_HOST,
-                            src_device_ptr,
-                            des_device_ptr);
+        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        node["src"].set_external(src_device_ptr, 4);
+        node["des"].set(des_vals, 4);
         strawman_run_where_src_is(node, true, true, false);
+        strawman_expect_doubled_des(node);
         strawman_cleanup_node(node,
                               STRAWMAN_START_ON_DEVICE,
                               STRAWMAN_START_ON_HOST,

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -20,6 +20,13 @@ using namespace conduit;
 using conduit::execution::ExecutionPolicy;
 
 //-----------------------------------------------------------------------------
+void
+conduit_device_prepare()
+{
+    execution::init_device_memory_handlers();
+}
+
+//-----------------------------------------------------------------------------
 void *
 allocate_for_policy(ExecutionPolicy policy, index_t bytes)
 {
@@ -69,10 +76,117 @@ for_each_enabled_policy(Func &&func)
 }
 
 //-----------------------------------------------------------------------------
-void
-conduit_device_prepare()
+float64 *
+make_float64_device_buffer(const float64 *host_vals, index_t num_vals)
 {
-    execution::init_device_memory_handlers();
+    float64 *device_ptr = static_cast<float64*>(
+        execution::DeviceMemory::allocate(sizeof(float64) * num_vals));
+    conduit::execution::MagicMemory::copy(device_ptr,
+                                          host_vals,
+                                          sizeof(float64) * num_vals);
+    return device_ptr;
+}
+
+//-----------------------------------------------------------------------------
+void
+run_policy_and_sync(Node &node,
+                    ExecutionPolicy policy)
+{
+    // DataAccessors wrap node leaf data.
+    float64_accessor acc_src(node["src"]);
+    float64_accessor acc_des(node["des"]);
+
+    // Ask the accessors to move their data to the memory space occupied
+    // by the requested execution policy if their data is not already
+    // there.
+    acc_src.use_with(policy);
+    acc_des.use_with(policy);
+
+    // Our forall will execute in the memory space selected by the
+    // requested ExecutionPolicy.
+    index_t size = acc_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * acc_src[idx];
+        acc_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+    // Sync values to node["des"].
+    // This is a no op if node["des"] was originally in the same memory
+    // space as the requested execution policy.
+    acc_des.sync();
+}
+
+//-----------------------------------------------------------------------------
+void
+run_policy_and_assume(Node &node,
+                      ExecutionPolicy policy)
+{
+    // DataAccessors wrap node leaf data.
+    float64_accessor acc_src(node["src"]);
+    float64_accessor acc_des(node["des"]);
+
+    // Ask the accessors to move their data to the memory space occupied
+    // by the requested execution policy if their data is not already
+    // there.
+    acc_src.use_with(policy);
+    acc_des.use_with(policy);
+
+    // Our forall will execute in the memory space selected by the
+    // requested ExecutionPolicy.
+    index_t size = acc_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * acc_src[idx];
+        acc_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+    // node["des"] takes ownership of the data in the active execution
+    // space. This is a no op if node["des"] was already in that space.
+    acc_des.assume();
+}
+
+//-----------------------------------------------------------------------------
+void
+run_using_active_space(Node &node,
+                       const bool expect_device_policy)
+{
+    // DataAccessors wrap node leaf data.
+    float64_accessor acc_src(node["src"]);
+    float64_accessor acc_des(node["des"]);
+
+    // Use the location of the source data.
+    ExecutionPolicy policy = acc_src.active_space();
+    if (expect_device_policy)
+    {
+        EXPECT_TRUE(policy.is_device_policy());
+    }
+    else
+    {
+        EXPECT_TRUE(policy.is_host_policy());
+    }
+
+    // Ask the accessors to move their data to the memory space occupied
+    // by node["src"] if their data is not already there.
+    acc_src.use_with(policy);
+    acc_des.use_with(policy);
+
+    // Our forall will execute on the memory space occupied by node["src"]
+    // because it was passed an ExecutionPolicy for that space.
+    index_t size = acc_src.number_of_elements();
+    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
+    {
+        const float64 val = 2.0 * acc_src[idx];
+        acc_des.set(idx, val);
+    });
+    CONDUIT_DEVICE_ERROR_CHECK(policy);
+
+    // Sync values to node["des"].
+    // This is a no op if node["des"] was originally in the same memory
+    // space as node["src"].
+    acc_des.sync();
 }
 
 // TODO someday we want allocator to make sense for nodes when we are done with them
@@ -144,6 +258,8 @@ struct MySpecialFunctor
     }
 };
 
+//-----------------------------------------------------------------------------
+// Tests
 //-----------------------------------------------------------------------------
 TEST(conduit_execution, test_forall)
 {
@@ -382,123 +498,10 @@ TEST(conduit_execution, for_all_and_dispatch)
 }
 
 //-----------------------------------------------------------------------------
-float64 *
-strawman_make_device_buffer(const float64 *host_vals, index_t num_vals)
-{
-    float64 *device_ptr = static_cast<float64*>(
-        execution::DeviceMemory::allocate(sizeof(float64) * num_vals));
-    conduit::execution::MagicMemory::copy(device_ptr,
-                                          host_vals,
-                                          sizeof(float64) * num_vals);
-    return device_ptr;
-}
-
-//-----------------------------------------------------------------------------
-void
-strawman_run_policy_and_sync(Node &node,
-                             ExecutionPolicy policy)
-{
-    // DataAccessors wrap node leaf data.
-    float64_accessor acc_src(node["src"]);
-    float64_accessor acc_des(node["des"]);
-
-    // Ask the accessors to move their data to the memory space occupied
-    // by the requested execution policy if their data is not already
-    // there.
-    acc_src.use_with(policy);
-    acc_des.use_with(policy);
-
-    // Our forall will execute in the memory space selected by the
-    // requested ExecutionPolicy.
-    index_t size = acc_src.number_of_elements();
-    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-    {
-        const float64 val = 2.0 * acc_src[idx];
-        acc_des.set(idx, val);
-    });
-    CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-    // Sync values to node["des"].
-    // This is a no op if node["des"] was originally in the same memory
-    // space as the requested execution policy.
-    acc_des.sync();
-
-}
-
-//-----------------------------------------------------------------------------
-void
-strawman_run_policy_and_assume(Node &node,
-                               ExecutionPolicy policy)
-{
-    // DataAccessors wrap node leaf data.
-    float64_accessor acc_src(node["src"]);
-    float64_accessor acc_des(node["des"]);
-
-    // Ask the accessors to move their data to the memory space occupied
-    // by the requested execution policy if their data is not already
-    // there.
-    acc_src.use_with(policy);
-    acc_des.use_with(policy);
-
-    // Our forall will execute in the memory space selected by the
-    // requested ExecutionPolicy.
-    index_t size = acc_src.number_of_elements();
-    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-    {
-        const float64 val = 2.0 * acc_src[idx];
-        acc_des.set(idx, val);
-    });
-    CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-    // node["des"] takes ownership of the data in the active execution
-    // space. This is a no op if node["des"] was already in that space.
-    acc_des.assume();
-
-}
-
-//-----------------------------------------------------------------------------
-void
-strawman_run_where_src_is(Node &node,
-                          const bool expect_device_policy)
-{
-    // DataAccessors wrap node leaf data.
-    float64_accessor acc_src(node["src"]);
-    float64_accessor acc_des(node["des"]);
-
-    // Use the location of the source data.
-    ExecutionPolicy policy = acc_src.active_space();
-    if (expect_device_policy)
-    {
-        EXPECT_TRUE(policy.is_device_policy());
-    }
-    else
-    {
-        EXPECT_TRUE(policy.is_host_policy());
-    }
-
-    // Ask the accessors to move their data to the memory space occupied
-    // by node["src"] if their data is not already there.
-    acc_src.use_with(policy);
-    acc_des.use_with(policy);
-
-    // Our forall will execute on the memory space occupied by node["src"]
-    // because it was passed an ExecutionPolicy for that space.
-    index_t size = acc_src.number_of_elements();
-    conduit::execution::forall(policy, 0, size, [acc_src, acc_des] EXEC_LAMBDA(index_t idx)
-    {
-        const float64 val = 2.0 * acc_src[idx];
-        acc_des.set(idx, val);
-    });
-    CONDUIT_DEVICE_ERROR_CHECK(policy);
-
-    // Sync values to node["des"].
-    // This is a no op if node["des"] was originally in the same memory
-    // space as node["src"].
-    acc_des.sync();
-
-}
-
-//-----------------------------------------------------------------------------
+// Test the strawman execution paths when both node["src"] and node["des"]
+// start in host memory. The covered cases are explicit host `sync`, explicit
+// device `sync`, explicit host `assume`, explicit device `assume`, and
+// `active_space` dispatch from host-backed source data.
 TEST(conduit_execution, strawman_src_host_des_host)
 {
     conduit_device_prepare();
@@ -510,14 +513,14 @@ TEST(conduit_execution, strawman_src_host_des_host)
     {
         std::cout << "sync policy=host src_start=host des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+
+        run_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -525,6 +528,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
     }
 
@@ -534,14 +538,14 @@ TEST(conduit_execution, strawman_src_host_des_host)
         // node["des"] is synced back to host memory.
         std::cout << "sync policy=device src_start=host des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+
+        run_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -549,6 +553,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
     }
 
@@ -557,14 +562,14 @@ TEST(conduit_execution, strawman_src_host_des_host)
     {
         std::cout << "assume policy=host src_start=host des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+
+        run_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -572,6 +577,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
     }
 
@@ -581,14 +587,14 @@ TEST(conduit_execution, strawman_src_host_des_host)
         // node["des"] keeps the device-backed result buffer.
         std::cout << "assume policy=device src_start=host des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+
+        run_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -596,6 +602,7 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
     }
 
@@ -604,14 +611,14 @@ TEST(conduit_execution, strawman_src_host_des_host)
     {
         std::cout << "active_space src_start=host des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
         node["src"].set(src_vals, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_where_src_is(node, false);
+
+        run_using_active_space(node, false);
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -619,11 +626,16 @@ TEST(conduit_execution, strawman_src_host_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
     }
 }
 
 //-----------------------------------------------------------------------------
+// Test the strawman execution paths when both node["src"] and node["des"]
+// start in device memory. The covered cases are explicit host `sync`,
+// explicit device `sync`, explicit host `assume`, explicit device `assume`,
+// and `active_space` dispatch from device-backed source data.
 TEST(conduit_execution, strawman_src_device_des_device)
 {
     conduit_device_prepare();
@@ -640,16 +652,16 @@ TEST(conduit_execution, strawman_src_device_des_device)
     {
         std::cout << "sync policy=host src_start=device des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+
+        run_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -657,6 +669,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -667,16 +680,16 @@ TEST(conduit_execution, strawman_src_device_des_device)
     {
         std::cout << "sync policy=device src_start=device des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+
+        run_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -684,6 +697,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -694,16 +708,16 @@ TEST(conduit_execution, strawman_src_device_des_device)
     {
         std::cout << "assume policy=host src_start=device des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+
+        run_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -711,6 +725,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -721,16 +736,16 @@ TEST(conduit_execution, strawman_src_device_des_device)
     {
         std::cout << "assume policy=device src_start=device des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+
+        run_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -738,6 +753,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -747,16 +763,16 @@ TEST(conduit_execution, strawman_src_device_des_device)
     {
         std::cout << "active_space src_start=device des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_where_src_is(node, true);
+
+        run_using_active_space(node, true);
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -764,6 +780,7 @@ TEST(conduit_execution, strawman_src_device_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
         execution::DeviceMemory::deallocate(des_device_ptr);
@@ -771,6 +788,10 @@ TEST(conduit_execution, strawman_src_device_des_device)
 }
 
 //-----------------------------------------------------------------------------
+// Test the strawman execution paths when node["src"] starts in host memory
+// and node["des"] starts in device memory. The covered cases are explicit
+// host `sync`, explicit device `sync`, explicit host `assume`, explicit
+// device `assume`, and `active_space` dispatch from host-backed source data.
 TEST(conduit_execution, strawman_src_host_des_device)
 {
     conduit_device_prepare();
@@ -787,15 +808,15 @@ TEST(conduit_execution, strawman_src_host_des_device)
     {
         std::cout << "sync policy=host src_start=host des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+
+        run_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -803,6 +824,7 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -812,15 +834,15 @@ TEST(conduit_execution, strawman_src_host_des_device)
     {
         std::cout << "sync policy=device src_start=host des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+
+        run_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -828,6 +850,7 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -837,15 +860,15 @@ TEST(conduit_execution, strawman_src_host_des_device)
     {
         std::cout << "assume policy=host src_start=host des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+
+        run_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -853,6 +876,7 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
@@ -862,15 +886,15 @@ TEST(conduit_execution, strawman_src_host_des_device)
     {
         std::cout << "assume policy=device src_start=host des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+
+        run_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -878,6 +902,7 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
     }
 
@@ -886,15 +911,15 @@ TEST(conduit_execution, strawman_src_host_des_device)
     {
         std::cout << "active_space src_start=host des_start=device" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        des_device_ptr = strawman_make_device_buffer(des_vals, 4);
+        float64 *des_device_ptr = make_float64_device_buffer(des_vals, 4);
         node["src"].set(src_vals, 4);
         node["des"].set_external(des_device_ptr, 4);
-        strawman_run_where_src_is(node, false);
+
+        run_using_active_space(node, false);
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -902,12 +927,17 @@ TEST(conduit_execution, strawman_src_host_des_device)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(des_device_ptr);
     }
 }
 
 //-----------------------------------------------------------------------------
+// Test the strawman execution paths when node["src"] starts in device memory
+// and node["des"] starts in host memory. The covered cases are explicit
+// host `sync`, explicit device `sync`, explicit host `assume`, explicit
+// device `assume`, and `active_space` dispatch from device-backed source data.
 TEST(conduit_execution, strawman_src_device_des_host)
 {
     conduit_device_prepare();
@@ -924,15 +954,15 @@ TEST(conduit_execution, strawman_src_device_des_host)
     {
         std::cout << "sync policy=host src_start=device des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::host());
+
+        run_policy_and_sync(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -940,6 +970,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -949,15 +980,15 @@ TEST(conduit_execution, strawman_src_device_des_host)
     {
         std::cout << "sync policy=device src_start=device des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_sync(node, ExecutionPolicy::device());
+
+        run_policy_and_sync(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -965,6 +996,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -974,15 +1006,15 @@ TEST(conduit_execution, strawman_src_device_des_host)
     {
         std::cout << "assume policy=host src_start=device des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::host());
+
+        run_policy_and_assume(node, ExecutionPolicy::host());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -990,6 +1022,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -999,15 +1032,15 @@ TEST(conduit_execution, strawman_src_device_des_host)
     {
         std::cout << "assume policy=device src_start=device des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_policy_and_assume(node, ExecutionPolicy::device());
+
+        run_policy_and_assume(node, ExecutionPolicy::device());
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -1015,6 +1048,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }
@@ -1024,15 +1058,15 @@ TEST(conduit_execution, strawman_src_device_des_host)
     {
         std::cout << "active_space src_start=device des_start=host" << std::endl;
 
-        float64 *src_device_ptr = nullptr;
-        float64 *des_device_ptr = nullptr;
         Node node;
-        src_device_ptr = strawman_make_device_buffer(src_vals, 4);
+        float64 *src_device_ptr = make_float64_device_buffer(src_vals, 4);
         node["src"].set_external(src_device_ptr, 4);
         node["des"].set(des_vals, 4);
-        strawman_run_where_src_is(node, true);
+
+        run_using_active_space(node, true);
         EXPECT_TRUE(execution::DeviceMemory::is_device_ptr(node["src"].data_ptr()));
         EXPECT_FALSE(execution::DeviceMemory::is_device_ptr(node["des"].data_ptr()));
+
         float64_accessor result_acc(node["des"]);
         result_acc.use_with(ExecutionPolicy::host());
         EXPECT_EQ(result_acc.number_of_elements(), 4);
@@ -1040,6 +1074,7 @@ TEST(conduit_execution, strawman_src_device_des_host)
         EXPECT_EQ(result_acc[1], 4.0);
         EXPECT_EQ(result_acc[2], 6.0);
         EXPECT_EQ(result_acc[3], 8.0);
+
         node.reset();
         execution::DeviceMemory::deallocate(src_device_ptr);
     }

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -468,6 +468,8 @@ TEST(conduit_execution, strawman)
             }
 
             float64_accessor result_acc(node["des"]);
+            // Verification runs on the host, so use a host execution policy
+            // in case node["des"] still owns device-backed data here.
             result_acc.use_with(ExecutionPolicy::host());
             EXPECT_EQ(result_acc.number_of_elements(), 4);
             EXPECT_EQ(result_acc[0], 2.0);
@@ -528,6 +530,8 @@ TEST(conduit_execution, strawman)
             }
 
             float64_accessor result_acc(node["des"]);
+            // Verification runs on the host, so use a host execution policy
+            // in case node["des"] still owns device-backed data here.
             result_acc.use_with(ExecutionPolicy::host());
             EXPECT_EQ(result_acc.number_of_elements(), 4);
             EXPECT_EQ(result_acc[0], 2.0);
@@ -605,6 +609,8 @@ TEST(conduit_execution, strawman)
             }
 
             float64_accessor result_acc(node["des"]);
+            // Verification runs on the host, so use a host execution policy
+            // in case node["des"] still owns device-backed data here.
             result_acc.use_with(ExecutionPolicy::host());
             EXPECT_EQ(result_acc.number_of_elements(), 4);
             EXPECT_EQ(result_acc[0], 2.0);


### PR DESCRIPTION
```c++
///////////////////////////////////////////////////////////////////////
//
// Strawman API of forall - run on device
//

// DataAccessors wrap node leaf data.
float64_accessor acc_src(node["src"]);
float64_accessor acc_des(node["des"]);

// We ask the DataAccessors to move their data to the device if their data is not already there.
ExecutionPolicy policy = ExecutionPolicy::device();
acc_src.use_with(policy);
acc_des.use_with(policy);

// Our forall will execute on the device because it was passed a device ExecutionPolicy.
index_t size = acc_src.number_of_elements();forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
{
	const float64 val = 2.0 * acc_src[idx];
	acc_des.set(idx, val);
});
CONDUIT_DEVICE_ERROR_CHECK();

// Sync values to node["des"] (no op if node["des"] was originally device memory).
acc_des.sync();

///////////////////////////////////////////////////////////////////////
//
// Strawman API of forall - run on device and leave the result on the device
//

// DataAccessors wrap node leaf data.
float64_accessor acc_src(node["src"]);
float64_accessor acc_des(node["des"]);

// We ask the DataAccessors to move their data to the device if their data is not already there.
ExecutionPolicy policy = ExecutionPolicy::device();
acc_src.use_with(policy);
acc_des.use_with(policy);

// Our forall will execute on the device because it was passed a device ExecutionPolicy.
index_t size = acc_src.number_of_elements();forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
{
	const float64 val = 2.0 * acc_src[idx];
	acc_des.set(idx, val);
});
CONDUIT_DEVICE_ERROR_CHECK();

// node["des"] takes ownership of the data on the device. (no op if node["des"] was originally device memory).
acc_des.assume();

///////////////////////////////////////////////////////////////////////
//
// Strawman API of forall - run wherever the source data is
//

// DataAccessors wrap node leaf data.
float64_accessor acc_src(node["src"]);
float64_accessor acc_des(node["des"]);

// We ask the ExecutionAccessors to move their data to the memory space occupied by node["src"] if their data is not already there.
ExecutionPolicy policy = acc_src.active_space();
acc_src.use_with(policy);
acc_des.use_with(policy);

// Our forall will execute on the memory space occupied by node["src"] because it was passed an ExecutionPolicy for that space. 
index_t size = acc_src.number_of_elements();forall(policy, 0, size, [=] EXEC_LAMBDA(index_t idx)
{
	const float64 val = 2.0 * acc_src[idx];
	acc_des.set(idx, val);
});
CONDUIT_DEVICE_ERROR_CHECK();

// Sync values to node["des"] (no op if node["des"] was originally in the same memory space as node["src"]).
acc_des.sync(); 

```