### PR TITLE
allow runtime string with fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to Conduit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project aspires to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+#### Conduit
+- Fixed an issue with fmt runtime use of a string that causes a compile error with gcc 13 and c++20.
+
 ## [0.9.6] - Released 2026-04-14
 
 ### Added

--- a/src/libs/relay/conduit_relay_io_blueprint.cpp
+++ b/src/libs/relay/conduit_relay_io_blueprint.cpp
@@ -217,7 +217,7 @@ public:
                 std::string res = pattern;
                 res.replace(pattern_idx,
                             4,
-                            conduit_fmt::format(pat,idx));
+                            conduit_fmt::format(conduit_fmt::runtime(pat),idx));
                 return res;
             }
         }

--- a/src/libs/relay/conduit_relay_io_handle_sidre.cpp
+++ b/src/libs/relay/conduit_relay_io_handle_sidre.cpp
@@ -554,7 +554,7 @@ SidreIOHandle::expand_pattern(const std::string pattern,
             std::string res = pattern;
             res.replace(pattern_idx,
                         4,
-                        conduit_fmt::format(pat,idx));
+                        conduit_fmt::format(conduit_fmt::runtime(pat),idx));
             return res;
         }
     }


### PR DESCRIPTION
resolves compile error with gcc13 and c++20