### PR TITLE
disable use of hdf5 file locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 #### Relay
 - Fixed a crash when reading Silo/Overlink files with missing material names.
 
+### Changed
+
+#### Relay
+- Disabled use of HDF5 file locking.
+
 ## [0.9.6] - Released 2026-04-14
 
 ### Added

--- a/src/libs/relay/conduit_relay_io_hdf5.cpp
+++ b/src/libs/relay/conduit_relay_io_hdf5.cpp
@@ -3624,6 +3624,26 @@ create_hdf5_file_access_plist()
                                  << "property list " << h5_fa_props);
 
     }
+    
+    
+    if( (major_num == 1 && minor_num >= 10) ||
+         major_num > 1 )
+    {
+    
+    // H5Pset_file_locking() is available starting in 1.10.7 and beyond
+
+    #if H5_VERSION_GE(1, 10, 7)
+        
+        // for all versions after 1.10.7, ignore file locking
+        h5_status =  H5Pset_file_locking(h5_fa_props,
+                                         false, // use file locking == false
+                                         true); // ignore file locking when disabled
+        CONDUIT_CHECK_HDF5_ERROR(h5_status,
+                                 "Failed to disable file locking in "
+                                 << "property list " << h5_fa_props);
+    #endif
+    }
+    
     return h5_fa_props;
 }
 

--- a/src/tests/relay/t_relay_io_hdf5.cpp
+++ b/src/tests/relay/t_relay_io_hdf5.cpp
@@ -1623,12 +1623,12 @@ TEST(conduit_relay_io_hdf5, check_if_file_is_hdf5_file)
 
     // check behavior with files that have open handles
     hid_t h5_file_id = io::hdf5_open_file_for_read_write(tout);
-    EXPECT_TRUE(io::is_hdf5_file(tout));
     io::hdf5_close_file(h5_file_id);
+    EXPECT_TRUE(io::is_hdf5_file(tout));
 
     h5_file_id = io::hdf5_open_file_for_read(tout);
-    EXPECT_TRUE(io::is_hdf5_file(tout));
     io::hdf5_close_file(h5_file_id);
+    EXPECT_TRUE(io::is_hdf5_file(tout));
 
     tout = "tout_hdf5_check_non_hdf5_file.json";
 


### PR DESCRIPTION
file locking can block workflows were folks iteratively running and replacing their simulation results while they are have them open in visit 