### PR TITLE
Reorganize execution macros to avoid a circular dependency

### DIFF
--- a/src/libs/conduit/conduit_execution.hpp
+++ b/src/libs/conduit/conduit_execution.hpp
@@ -18,6 +18,9 @@
 #include "conduit_execution_policy.hpp"
 #include "conduit_annotations.hpp"
 
+// CONDUIT_DEVICE_ERROR_CHECK: error checking macro
+#define CONDUIT_DEVICE_ERROR_CHECK( policy ) conduit::execution::device_error_check(policy, __FILE__, __LINE__);
+
 #include <algorithm>
 #include <iostream>
 #include <limits>

--- a/src/libs/conduit/conduit_execution.hpp
+++ b/src/libs/conduit/conduit_execution.hpp
@@ -13,13 +13,12 @@
 
 #include "conduit_config.hpp"
 
+// CONDUIT_DEVICE_ERROR_CHECK: error checking macro
+#define CONDUIT_DEVICE_ERROR_CHECK( policy ) conduit::execution::device_error_check(policy, __FILE__, __LINE__);
 
 #include "conduit_execution_macros.hpp"
 #include "conduit_execution_policy.hpp"
 #include "conduit_annotations.hpp"
-
-// CONDUIT_DEVICE_ERROR_CHECK: error checking macro
-#define CONDUIT_DEVICE_ERROR_CHECK( policy ) conduit::execution::device_error_check(policy, __FILE__, __LINE__);
 
 #include <algorithm>
 #include <iostream>

--- a/src/libs/conduit/conduit_execution.hpp
+++ b/src/libs/conduit/conduit_execution.hpp
@@ -13,52 +13,8 @@
 
 #include "conduit_config.hpp"
 
-// 
-// Macro disambiguation:
-// 
 
-// 1. CONDUIT_USE_CUDA/CONDUIT_USE_HIP: our build enabled these
-// backends.
-
-// 2. CONDUIT_USE_DEVICE: we are using CUDA or HIP and UMPIRE is
-// enabled.
-#if (defined(CONDUIT_USE_CUDA) || defined(CONDUIT_USE_HIP)) && defined(CONDUIT_USE_UMPIRE)
-#define CONDUIT_USE_DEVICE
-#endif
-
-// 3. CONDUIT_TU_IS_CUDA/CONDUIT_TU_IS_HIP: our current translation
-// unit is a CUDA/HIP target. We cannot get away with just using
-// CONDUIT_USE_*** because execution is included broadly, and
-// normal host-only TUs will not compile symbols like
-// RAJA::cuda_exec/RAJA::hip_exec.
-#if defined(CONDUIT_USE_CUDA) && defined(__CUDACC__)
-#define CONDUIT_TU_IS_CUDA
-#endif
-
-#if defined(CONDUIT_USE_HIP) && defined(__HIPCC__)
-#define CONDUIT_TU_IS_HIP
-#endif
-
-// 4. CONDUIT_DEVICE_COMPILE: means the compiler is compiling
-// for the device right now (typically there is a host compilation
-// pass and a device pass). This is useful for having different
-// behavior for host and device (like for error-handling).
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
-#define CONDUIT_DEVICE_COMPILE
-#endif
-
-// 5. CONDUIT_EXEC: host/device function decorator. For a
-// CUDA/HIP TU, any function marked with this is compiled for both
-// host and device, while for a normal C++ TU it means nothing.
-#if defined(CONDUIT_TU_IS_CUDA) || defined(CONDUIT_TU_IS_HIP)
-#define CONDUIT_EXEC __host__ __device__
-#else
-#define CONDUIT_EXEC
-#endif
-
-// 6. CONDUIT_DEVICE_ERROR_CHECK: error checking macro
-#define CONDUIT_DEVICE_ERROR_CHECK( policy ) conduit::execution::device_error_check(policy, __FILE__, __LINE__);
-
+#include "conduit_execution_macros.hpp"
 #include "conduit_execution_policy.hpp"
 #include "conduit_annotations.hpp"
 

--- a/src/libs/conduit/conduit_execution_macros.hpp
+++ b/src/libs/conduit/conduit_execution_macros.hpp
@@ -11,6 +11,8 @@
 #ifndef CONDUIT_EXECUTION_MACROS_HPP
 #define CONDUIT_EXECUTION_MACROS_HPP
 
+#include "conduit_config.h"
+
 //
 // Macro disambiguation:
 //
@@ -53,8 +55,5 @@
 #else
 #define CONDUIT_EXEC
 #endif
-
-// 6. CONDUIT_DEVICE_ERROR_CHECK: error checking macro
-#define CONDUIT_DEVICE_ERROR_CHECK( policy ) conduit::execution::device_error_check(policy, __FILE__, __LINE__);
 
 #endif

--- a/src/libs/conduit/conduit_execution_macros.hpp
+++ b/src/libs/conduit/conduit_execution_macros.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_execution_macros.hpp
+///
+//-----------------------------------------------------------------------------
+
+#ifndef CONDUIT_EXECUTION_MACROS_HPP
+#define CONDUIT_EXECUTION_MACROS_HPP
+
+//
+// Macro disambiguation:
+//
+
+// 1. CONDUIT_USE_CUDA/CONDUIT_USE_HIP: our build enabled these
+// backends.
+
+// 2. CONDUIT_USE_DEVICE: we are using CUDA or HIP and UMPIRE is
+// enabled.
+#if (defined(CONDUIT_USE_CUDA) || defined(CONDUIT_USE_HIP)) && defined(CONDUIT_USE_UMPIRE)
+#define CONDUIT_USE_DEVICE
+#endif
+
+// 3. CONDUIT_TU_IS_CUDA/CONDUIT_TU_IS_HIP: our current translation
+// unit is a CUDA/HIP target. We cannot get away with just using
+// CONDUIT_USE_*** because execution is included broadly, and
+// normal host-only TUs will not compile symbols like
+// RAJA::cuda_exec/RAJA::hip_exec.
+#if defined(CONDUIT_USE_CUDA) && defined(__CUDACC__)
+#define CONDUIT_TU_IS_CUDA
+#endif
+
+#if defined(CONDUIT_USE_HIP) && defined(__HIPCC__)
+#define CONDUIT_TU_IS_HIP
+#endif
+
+// 4. CONDUIT_DEVICE_COMPILE: means the compiler is compiling
+// for the device right now (typically there is a host compilation
+// pass and a device pass). This is useful for having different
+// behavior for host and device (like for error-handling).
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#define CONDUIT_DEVICE_COMPILE
+#endif
+
+// 5. CONDUIT_EXEC: host/device function decorator. For a
+// CUDA/HIP TU, any function marked with this is compiled for both
+// host and device, while for a normal C++ TU it means nothing.
+#if defined(CONDUIT_TU_IS_CUDA) || defined(CONDUIT_TU_IS_HIP)
+#define CONDUIT_EXEC __host__ __device__
+#else
+#define CONDUIT_EXEC
+#endif
+
+// 6. CONDUIT_DEVICE_ERROR_CHECK: error checking macro
+#define CONDUIT_DEVICE_ERROR_CHECK( policy ) conduit::execution::device_error_check(policy, __FILE__, __LINE__);
+
+#endif

--- a/src/libs/conduit/conduit_execution_policy.hpp
+++ b/src/libs/conduit/conduit_execution_policy.hpp
@@ -12,6 +12,7 @@
 #define CONDUIT_EXECUTION_POLICY_HPP
 
 #include "conduit_config.h"
+#include "conduit_execution_macros.hpp"
 #include "conduit_utils.hpp"
 #include "conduit_memory_manager.hpp"
 


### PR DESCRIPTION
clangd was upset about a circular dependency caused by `conduit_execution_policy.hpp` depending on `CONDUIT_EXEC`, which was defined in `conduit_execution.hpp`. Moving the macros into their own file fixes the circular dependency.