### PR TITLE
Device Support: Fix Array Size Warning

### DIFF
--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -434,7 +434,7 @@ run_test_forall()
 
         const index_t size = EXECUTION_TEST_ARRAY_SIZE;
 
-        index_t host_vals[size];
+        std::vector<index_t> host_vals(size);
         index_t *vals_ptr = nullptr;
         if (policy.is_device_policy())
         {
@@ -455,7 +455,7 @@ run_test_forall()
         });
         CONDUIT_DEVICE_ERROR_CHECK(policy);
 
-        conduit::execution::MagicMemory::copy(&host_vals[0],
+        conduit::execution::MagicMemory::copy(host_vals.data(),
                                               vals_ptr,
                                               sizeof(index_t) * size);
 


### PR DESCRIPTION
Fixes this:

```
/usr/workspace/justin/conduit_builds/develop_06_17_2026_HIP/conduit/src/tests/conduit/t_conduit_execution.cpp:437:28: warning: variable length arrays in C++ are a Clang extension
      [-Wvla-cxx-extension]
  437 |         index_t host_vals[size];
      |                           ^~~~
/usr/workspace/justin/conduit_builds/develop_06_17_2026_HIP/conduit/src/tests/conduit/t_conduit_execution.cpp:437:28: note: initializer of 'size' is not a constant expression
/usr/workspace/justin/conduit_builds/develop_06_17_2026_HIP/conduit/src/tests/conduit/t_conduit_execution.cpp:435:23: note: declared here
  435 |         const index_t size = EXECUTION_TEST_ARRAY_SIZE;
      |                       ^

```