### PR TITLE
Change implementation for determining MPI tag limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ Notable changes to Conduit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project aspires to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### Conduit
+
+#### Blueprint
+
+### Fixed
+
+#### Conduit
+
+#### Blueprint
+
+#### Relay
+- The `conduit::relay::mpi::safe_tag` function and its underlying logic to probe the maximum allowable MPI tag were modified to avoid `MPI_Waitall`. Tag values now use modulo above the upper limit as opposed to clamping.
+
+### Changed
+
 ## [0.9.7] - Released 2026-05-27
 
 ### Added

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 
 #include "conduit_relay_mpi.hpp"
+#include "conduit_relay_mpi_internal.hpp"
 #include <algorithm>
 #include <iostream>
 #include <limits>
@@ -476,36 +477,38 @@ private:
     /**
      * @brief Test whether a tag can be used safely on the communicator.
      *
-     * @note Use a single MPI_Sendrecv instead of self-posted Isend/Irecv +
-     *       MPI_Waitall. That avoids a problematic completion path on some MPI
-     *       stacks while still exercising the communicator and tag.
+     * @note Use a single MPI_Sendrecv to the local rank instead of
+     *       self-posted Isend/Irecv + MPI_Waitall. That avoids a problematic
+     *       completion path on some MPI stacks without introducing any
+     *       cross-rank coordination into safe_tag().
      */
     static bool testTag(int tag, MPI_Comm comm)
     {
-        int rank = 0, size = 1;
+        int rank = 0;
         MPI_Comm_rank(comm, &rank);
-        MPI_Comm_size(comm, &size);
-
-        const int dest = (size > 1) ? ((rank + 1) % size) : rank;
-        const int src  = (size > 1) ? ((rank + size - 1) % size) : rank;
 
         int send_value = rank;
         int recv_value = -1;
         const int mpi_error = MPI_Sendrecv(&send_value,
                                            1,
                                            MPI_INT,
-                                           dest,
+                                           rank,
                                            tag,
                                            &recv_value,
                                            1,
                                            MPI_INT,
-                                           src,
+                                           rank,
                                            tag,
                                            comm,
                                            MPI_STATUS_IGNORE);
         return mpi_error == MPI_SUCCESS;
     }
 };
+
+int detail::tag_upper_bound_probe(MPI_Comm comm)
+{
+    return TagLimits::probe(comm);
+}
 
 //---------------------------------------------------------------------------//
 /**

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -527,7 +527,8 @@ bool invalid_tag(int tag)
 /**
  @brief Return a tag value that is safe to use with MPI functions. The tag is
         determined dynamically the first time the function is called. If the
-        input tag is greater than the max tag then the value is clamped.
+        input tag is greater than the max tag then the value wraps into the
+        valid range.
 
  @param tag The input tag.
  @param comm The MPI communicator.
@@ -550,7 +551,10 @@ int safe_tag(int tag, MPI_Comm comm)
     const int tag_upper_bound = it->second;
     if(newtag > tag_upper_bound)
     {
-        newtag = tag_upper_bound;
+        if(tag_upper_bound < std::numeric_limits<int>::max())
+        {
+            newtag %= (tag_upper_bound + 1);
+        }
     }
 
     return newtag;

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -465,7 +465,19 @@ private:
     {
         // Temporarily override MPI error handler with a more benign one.
         HandleMPICommError err(comm);
-        return probeTagUpperBound(0, std::numeric_limits<int>::max(), comm);
+        int valid_low = minimum_upper_bound();
+        if(!testTag(valid_low, comm))
+        {
+            return valid_low;
+        }
+
+        const int invalid_high = findInvalidHigh(valid_low, comm);
+        if(invalid_high < 0)
+        {
+            return valid_low;
+        }
+
+        return probeTagUpperBound(valid_low, invalid_high, comm);
     }
 
     /**
@@ -505,6 +517,45 @@ private:
         }
 
         return valid_low;
+    }
+
+    /**
+     * @brief Find an invalid tag above a known-valid lower bound.
+     *
+     * @param valid_low A tag value already known to be valid.
+     * @param comm The MPI communicator.
+     *
+     * @return An invalid tag above @p valid_low, or -1 if none was found.
+     *
+     * @note Grow the search range gradually instead of testing INT_MAX first.
+     *       Some MPI stacks handle wildly invalid tags poorly even with
+     *       non-aborting error handlers installed.
+     */
+    static int findInvalidHigh(int valid_low, MPI_Comm comm)
+    {
+        const int max_search_tag = std::numeric_limits<int>::max() - 1;
+        int candidate = valid_low;
+
+        while(candidate < max_search_tag)
+        {
+            const int next = (candidate <= (max_search_tag - 1) / 2)
+                ? (candidate * 2) + 1
+                : max_search_tag;
+
+            if(next <= candidate)
+            {
+                break;
+            }
+
+            if(!testTag(next, comm))
+            {
+                return next;
+            }
+
+            candidate = next;
+        }
+
+        return -1;
     }
 
     /**

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -14,7 +14,6 @@
 #include <iostream>
 #include <limits>
 #include <map>
-#include <mutex>
 
 //-----------------------------------------------------------------------------
 /// The CONDUIT_CHECK_MPI_ERROR macro is used to check return values for
@@ -435,10 +434,7 @@ private:
     static int cached_probe(MPI_Comm comm)
     {
         static std::map<MPI_Fint, int> probed_upper_bounds;
-        static std::mutex probed_upper_bounds_mutex;
-
         const MPI_Fint comm_id = MPI_Comm_c2f(comm);
-        std::lock_guard<std::mutex> guard(probed_upper_bounds_mutex);
 
         std::map<MPI_Fint, int>::const_iterator it = probed_upper_bounds.find(comm_id);
         if(it == probed_upper_bounds.end())

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <mutex>
 
 //-----------------------------------------------------------------------------
 /// The CONDUIT_CHECK_MPI_ERROR macro is used to check return values for
@@ -378,7 +379,7 @@ public:
           return queried;
       }
 
-      const int probed = probe(comm);
+      const int probed = cached_probe(comm);
       if(probed >= 0)
       {
           return probed;
@@ -387,6 +388,8 @@ public:
       // MPI guarantees support for tags at least this large.
       return minimum_upper_bound();
     }
+
+    friend int detail::tag_upper_bound_probe(MPI_Comm comm);
 
 private:
     static int minimum_upper_bound()
@@ -417,6 +420,31 @@ private:
             }
         }
         return -1;
+    }
+
+    /**
+     * @brief Cache probed fallback results for communicators that do not
+     *        report a usable MPI_TAG_UB value.
+     *
+     * @note This cache is only used on the probe fallback path so the normal
+     *       query path always reflects the communicator's current MPI_TAG_UB.
+     */
+    static int cached_probe(MPI_Comm comm)
+    {
+        static std::map<MPI_Fint, int> probed_upper_bounds;
+        static std::mutex probed_upper_bounds_mutex;
+
+        const MPI_Fint comm_id = MPI_Comm_c2f(comm);
+        std::lock_guard<std::mutex> guard(probed_upper_bounds_mutex);
+
+        std::map<MPI_Fint, int>::const_iterator it = probed_upper_bounds.find(comm_id);
+        if(it == probed_upper_bounds.end())
+        {
+            it = probed_upper_bounds.insert(std::make_pair(comm_id,
+                                                           probe(comm))).first;
+        }
+
+        return it->second;
     }
 
     /**
@@ -540,18 +568,8 @@ bool invalid_tag(int tag)
  */
 int safe_tag(int tag, MPI_Comm comm)
 {
-    static std::map<MPI_Fint, int> tag_upper_bounds;
-    const MPI_Fint comm_id = MPI_Comm_c2f(comm);
-
-    std::map<MPI_Fint, int>::const_iterator it = tag_upper_bounds.find(comm_id);
-    if(it == tag_upper_bounds.end())
-    {
-        it = tag_upper_bounds.insert(std::make_pair(comm_id,
-                                                    TagLimits::upper_bound(comm))).first;
-    }
-
     int newtag = std::max(0, tag);
-    const int tag_upper_bound = it->second;
+    const int tag_upper_bound = TagLimits::upper_bound(comm);
     if(newtag > tag_upper_bound)
     {
         if(tag_upper_bound < std::numeric_limits<int>::max())

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -556,10 +556,11 @@ bool invalid_tag(int tag)
 
 //---------------------------------------------------------------------------//
 /**
- @brief Return a tag value that is safe to use with MPI functions. The tag is
-        determined dynamically the first time the function is called. If the
-        input tag is greater than the max tag then the value wraps into the
-        valid range.
+ @brief Return an MPI-valid tag in the range [0,MPI_TAG_UB].
+
+ @note This function guarantees MPI validity, not uniqueness. If the input tag
+       exceeds the communicator's upper bound, the wrapped result may alias a
+       different logical tag.
 
  @param tag The input tag.
  @param comm The MPI communicator.

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <iostream>
 #include <limits>
+#include <map>
 
 //-----------------------------------------------------------------------------
 /// The CONDUIT_CHECK_MPI_ERROR macro is used to check return values for
@@ -365,14 +366,33 @@ public:
      *
      * @return The tag upper limit.
      *
-     * @note We probe to determine the value since query is not as reliable across MPI distributions.
+     * @note Prefer the standard MPI_TAG_UB query and only fall back to probing
+     *       if the communicator does not report a usable value.
      */
     static int upper_bound(MPI_Comm comm)
     {
-      return probe(comm);
+      const int queried = query(comm);
+      if(queried >= 0)
+      {
+          return queried;
+      }
+
+      const int probed = probe(comm);
+      if(probed >= 0)
+      {
+          return probed;
+      }
+
+      // MPI guarantees support for tags at least this large.
+      return minimum_upper_bound();
     }
 
 private:
+    static int minimum_upper_bound()
+    {
+        return 32767;
+    }
+
     /**
      * @brief Query MPI for the maximum tag value.
      *
@@ -380,24 +400,22 @@ private:
      *
      * @return The tag upper bound or -1 on error.
      *
-     * @note This is how we are supposed to be able to ask for the max tag value.
-     *       However, this method does not seem reliable across MPIs and it is
-     *       possible for the query to return values that still do not work in
-     *       Isend/Irecv sometimes.
+     * @note MPI returns MPI_TAG_UB as a pointer to an integer value.
      */
     static int query(MPI_Comm comm)
     {
-        bool ok = false;
-        int tag_ub = 0, flag = 0;
-        int mpi_error = MPI_Comm_get_attr(comm, MPI_TAG_UB, &tag_ub, &flag);
+        int flag = 0;
+        int *tag_ub_ptr = nullptr;
+        int mpi_error = MPI_Comm_get_attr(comm, MPI_TAG_UB, &tag_ub_ptr, &flag);
         if(mpi_error == MPI_SUCCESS && flag != 0)
         {
-            if(tag_ub > 0)
+            const int tag_ub = (tag_ub_ptr != nullptr) ? *tag_ub_ptr : -1;
+            if(tag_ub >= 0)
             {
-                ok = true;
+                return tag_ub;
             }
         }
-        return ok ? tag_ub : -1;
+        return -1;
     }
 
     /**
@@ -413,8 +431,7 @@ private:
     {
         // Temporarily override MPI error handler with a more benign one.
         HandleMPICommError err(comm);
-        int tag = probeTagUpperBound(0, std::numeric_limits<int>::max(), comm);
-        return tag;
+        return probeTagUpperBound(0, std::numeric_limits<int>::max(), comm);
     }
 
     /**
@@ -426,58 +443,67 @@ private:
      *
      * @return The max tag value.
      *
-     * @note The rank sends a message to itself using a tag value. The result of that
-     *       is used to narrow the range of tag values.
+     * @note The tag range is searched using a message exchange on the
+     *       communicator so we can narrow the valid range without relying on
+     *       MPI_Waitall completion semantics.
      */
     static int probeTagUpperBound(int low, int high, MPI_Comm comm)
     {
-        int tag;
-        if((high - low) < 2)
+        if(testTag(high, comm))
         {
-            tag = low;
+            return high;
         }
-        else
+
+        int valid_low = low;
+        int invalid_high = high;
+
+        while((invalid_high - valid_low) >= 2)
         {
-            int rank;
-            MPI_Comm_rank(comm, &rank);
-
-            tag = low + (high-low) / 2;
-
-            // Try sending with the current tag.
-            int srcBuff = 0;
-            MPI_Request requests[2];
-            int mpi_error = MPI_Isend(&srcBuff,
-                                      1,
-                                      MPI_INT,
-                                      rank,
-                                      tag,
-                                      comm,
-                                      &requests[0]);
-            if(mpi_error == MPI_SUCCESS)
+            const int tag = valid_low + (invalid_high - valid_low) / 2;
+            if(testTag(tag, comm))
             {
-                // It worked.
-                // Issue the recv.
-                int destBuff = 0;
-                MPI_Irecv(&destBuff,
-                          1,
-                          MPI_INT,
-                          rank,
-                          tag,
-                          comm,
-                          &requests[1]);
-
-                MPI_Status statuses[2];
-                MPI_Waitall(2, requests, statuses);
-                // good search, we are done.
-                return tag;
+                valid_low = tag;
             }
             else
             {
-                // keep looking for a lower tag limit
-                tag = probeTagUpperBound(low, tag, comm);
+                invalid_high = tag;
             }
         }
-        return tag;
+
+        return valid_low;
+    }
+
+    /**
+     * @brief Test whether a tag can be used safely on the communicator.
+     *
+     * @note Use a single MPI_Sendrecv instead of self-posted Isend/Irecv +
+     *       MPI_Waitall. That avoids a problematic completion path on some MPI
+     *       stacks while still exercising the communicator and tag.
+     */
+    static bool testTag(int tag, MPI_Comm comm)
+    {
+        int rank = 0, size = 1;
+        MPI_Comm_rank(comm, &rank);
+        MPI_Comm_size(comm, &size);
+
+        const int dest = (size > 1) ? ((rank + 1) % size) : rank;
+        const int src  = (size > 1) ? ((rank + size - 1) % size) : rank;
+
+        int send_value = rank;
+        int recv_value = -1;
+        const int mpi_error = MPI_Sendrecv(&send_value,
+                                           1,
+                                           MPI_INT,
+                                           dest,
+                                           tag,
+                                           &recv_value,
+                                           1,
+                                           MPI_INT,
+                                           src,
+                                           tag,
+                                           comm,
+                                           MPI_STATUS_IGNORE);
+        return mpi_error == MPI_SUCCESS;
     }
 };
 
@@ -510,15 +536,18 @@ bool invalid_tag(int tag)
  */
 int safe_tag(int tag, MPI_Comm comm)
 {
-    static constexpr int UPPER_BOUND_NOT_SET = -1;
-    static int tag_upper_bound = UPPER_BOUND_NOT_SET;
-    if(tag_upper_bound == UPPER_BOUND_NOT_SET)
+    static std::map<MPI_Fint, int> tag_upper_bounds;
+    const MPI_Fint comm_id = MPI_Comm_c2f(comm);
+
+    std::map<MPI_Fint, int>::const_iterator it = tag_upper_bounds.find(comm_id);
+    if(it == tag_upper_bounds.end())
     {
-        // The first time through, determine the upper bound.
-        tag_upper_bound = TagLimits::upper_bound(comm);
+        it = tag_upper_bounds.insert(std::make_pair(comm_id,
+                                                    TagLimits::upper_bound(comm))).first;
     }
 
     int newtag = std::max(0, tag);
+    const int tag_upper_bound = it->second;
     if(newtag > tag_upper_bound)
     {
         newtag = tag_upper_bound;
@@ -2378,5 +2407,3 @@ about(Node &n)
 //-----------------------------------------------------------------------------
 // -- end conduit:: --
 //-----------------------------------------------------------------------------
-
-

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -625,11 +625,12 @@ send_using_schema(const Node &node, int dest, int tag, MPI_Comm comm)
                      "(" << std::numeric_limits<int>::max() << ")")
     }
 
+    const int newtag = safe_tag(tag, comm);
     int mpi_error = MPI_Send(const_cast<void*>(n_msg.data_ptr()),
                              static_cast<int>(msg_data_size),
                              MPI_BYTE,
                              dest,
-                             tag,
+                             newtag,
                              comm);
 
     CONDUIT_CHECK_MPI_ERROR(mpi_error);
@@ -644,7 +645,8 @@ recv_using_schema(Node &node, int src, int tag, MPI_Comm comm)
 {
     MPI_Status status;
 
-    int mpi_error = MPI_Probe(src, tag, comm, &status);
+    const int newtag = safe_tag(tag, comm);
+    int mpi_error = MPI_Probe(src, newtag, comm, &status);
 
     CONDUIT_CHECK_MPI_ERROR(mpi_error);
 
@@ -762,11 +764,12 @@ send(const Node &node, int dest, int tag, MPI_Comm comm)
                      "(" << std::numeric_limits<int>::max() << ")")
     }
 
+    const int newtag = safe_tag(tag, comm);
     int mpi_error = MPI_Send(const_cast<void*>(snd_ptr),
                              static_cast<int>(snd_size),
                              MPI_BYTE,
                              dest,
-                             tag,
+                             newtag,
                              comm);
 
     CONDUIT_CHECK_MPI_ERROR(mpi_error);
@@ -806,11 +809,12 @@ recv(Node &node, int src, int tag, MPI_Comm comm)
     }
 
 
+    const int newtag = safe_tag(tag, comm);
     int mpi_error = MPI_Recv(const_cast<void*>(rcv_ptr),
                              static_cast<int>(rcv_size),
                              MPI_BYTE,
                              src,
-                             tag,
+                             newtag,
                              comm,
                              &status);
 

--- a/src/libs/relay/conduit_relay_mpi.cpp
+++ b/src/libs/relay/conduit_relay_mpi.cpp
@@ -428,6 +428,9 @@ private:
      *
      * @note This cache is only used on the probe fallback path so the normal
      *       query path always reflects the communicator's current MPI_TAG_UB.
+     *       The fallback probe is only for communicators where MPI_TAG_UB is
+     *       unavailable or unusable, and probing performs MPI traffic on the
+     *       communicator while determining the limit.
      */
     static int cached_probe(MPI_Comm comm)
     {
@@ -454,7 +457,9 @@ private:
      *
      * @note MPI error handlers are installed that ignore problems, preventing the
      *       program from dying if the default handler is set to abort on error. The
-     *       error handler is restored when leaving this function.
+     *       error handler is restored when leaving this function. This probe is
+     *       only used when MPI_TAG_UB cannot be queried successfully, and it
+     *       performs MPI traffic on the supplied communicator.
      */
     static int probe(MPI_Comm comm)
     {

--- a/src/libs/relay/conduit_relay_mpi.hpp
+++ b/src/libs/relay/conduit_relay_mpi.hpp
@@ -79,8 +79,8 @@ namespace mpi
 
     /**
       @brief MPI tags can be in the range [0,MPI_TAG_UB]. The values are
-             implementation-dependent. If the tag is not in that range, return
-             MPI_TAG_UB so it is safe to use with MPI functions.
+             implementation-dependent. If the tag is not in that range, wrap it
+             into the valid range so it is safe to use with MPI functions.
 
       @param tag The input tag.
       @param comm The MPI communicator.
@@ -394,4 +394,3 @@ private:
 
 
 #endif
-

--- a/src/libs/relay/conduit_relay_mpi.hpp
+++ b/src/libs/relay/conduit_relay_mpi.hpp
@@ -78,9 +78,17 @@ namespace mpi
 //-----------------------------------------------------------------------------
 
     /**
-      @brief MPI tags can be in the range [0,MPI_TAG_UB]. The values are
-             implementation-dependent. If the tag is not in that range, wrap it
-             into the valid range so it is safe to use with MPI functions.
+      @brief Return an MPI-valid tag in the range [0,MPI_TAG_UB].
+
+             MPI tag limits are communicator-dependent and implementation-
+             dependent. If the input tag is outside the valid range, this
+             function wraps it into the valid range so it can be used safely
+             with MPI functions.
+
+             This function only guarantees MPI validity. It does not preserve
+             uniqueness when wrapping occurs, so distinct input tags may map to
+             the same MPI tag. Callers must not rely on wrapped tags as a
+             uniqueness mechanism.
 
       @param tag The input tag.
       @param comm The MPI communicator.

--- a/src/libs/relay/conduit_relay_mpi_internal.hpp
+++ b/src/libs/relay/conduit_relay_mpi_internal.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and other Conduit
+// Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
+// other details. No copyright assignment is required to contribute to Conduit.
+
+//-----------------------------------------------------------------------------
+///
+/// file: conduit_relay_mpi_internal.hpp
+///
+//-----------------------------------------------------------------------------
+
+#ifndef CONDUIT_RELAY_MPI_INTERNAL_HPP
+#define CONDUIT_RELAY_MPI_INTERNAL_HPP
+
+#include "conduit_relay_mpi.hpp"
+
+namespace conduit
+{
+namespace relay
+{
+namespace mpi
+{
+namespace detail
+{
+
+// Internal helper for in-tree tests. This header is not installed.
+int CONDUIT_RELAY_API tag_upper_bound_probe(MPI_Comm comm);
+
+}
+}
+}
+}
+
+#endif

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -684,6 +684,53 @@ TEST(conduit_mpi_test, send_recv_without_using_schema)
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, send_recv_without_using_schema_oversized_tag)
+{
+    MPI_Comm dup_comm = MPI_COMM_NULL;
+    ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
+
+    const int tag_ub = detail::tag_upper_bound_probe(dup_comm);
+    ASSERT_GE(tag_ub, 32767);
+
+    if(tag_ub > std::numeric_limits<int>::max() - 5)
+    {
+        GTEST_SKIP() << "Cannot test oversized blocking tags without overflow.";
+    }
+
+    const int oversized_tag = tag_ub + 5;
+
+    Node n;
+    int rank = mpi::rank(dup_comm);
+
+    n.set(DataType::c_double(3));
+
+    if(rank == 0)
+    {
+        double_array vals = n.value();
+        vals[0] = rank + 1;
+        vals[1] = 3.4124 * rank;
+        vals[2] = 10.7 - rank;
+
+        mpi::send(n, 1, oversized_tag, dup_comm);
+    }
+    else if(rank == 1)
+    {
+        mpi::recv(n, 0, oversized_tag, dup_comm);
+    }
+
+    if(rank == 0 || rank == 1)
+    {
+        double_array vals = n.value();
+        EXPECT_EQ(vals[0], 1);
+        EXPECT_EQ(vals[1], 0);
+        EXPECT_EQ(vals[2], 10.7);
+    }
+
+    EXPECT_EQ(MPI_Barrier(dup_comm), MPI_SUCCESS);
+    EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
+}
+
+//-----------------------------------------------------------------------------
 TEST(conduit_mpi_test, send_recv_without_using_schema_any_source_any_tag)
 {
     Node n;

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -19,6 +19,33 @@ using namespace conduit;
 using namespace conduit::relay;
 using namespace conduit::relay::mpi;
 
+namespace
+{
+
+// Mirror safe_tag() upper-bound selection so overflow-tag tests use the
+// same communicator limit as the implementation under test.
+int safe_tag_effective_upper_bound(MPI_Comm comm)
+{
+    int flag = 0;
+    int *tag_ub_ptr = nullptr;
+    const int mpi_error = MPI_Comm_get_attr(comm,
+                                            MPI_TAG_UB,
+                                            &tag_ub_ptr,
+                                            &flag);
+    if(mpi_error == MPI_SUCCESS &&
+       flag != 0 &&
+       tag_ub_ptr != nullptr &&
+       *tag_ub_ptr >= 0)
+    {
+        return *tag_ub_ptr;
+    }
+
+    const int probed_tag_ub = detail::tag_upper_bound_probe(comm);
+    return probed_tag_ub >= 0 ? probed_tag_ub : 32767;
+}
+
+}
+
 
 //-----------------------------------------------------------------------------
 TEST(conduit_mpi_test, conduit_dtype_to_mpi_dtype)
@@ -89,17 +116,8 @@ TEST(conduit_mpi_test, mpi_dtype_to_conduit_dtype)
 //-----------------------------------------------------------------------------
 TEST(conduit_mpi_test, safe_tag_wraps_to_mpi_tag_ub_range)
 {
-    int flag = 0;
-    int *tag_ub_ptr = nullptr;
-    const int mpi_error = MPI_Comm_get_attr(MPI_COMM_WORLD,
-                                            MPI_TAG_UB,
-                                            &tag_ub_ptr,
-                                            &flag);
-    ASSERT_EQ(mpi_error, MPI_SUCCESS);
-    ASSERT_NE(flag, 0);
-    ASSERT_NE(tag_ub_ptr, nullptr);
-
-    const int expected_tag_ub = *tag_ub_ptr;
+    const int expected_tag_ub = safe_tag_effective_upper_bound(MPI_COMM_WORLD);
+    EXPECT_GE(expected_tag_ub, 32767);
     EXPECT_EQ(safe_tag(-42, MPI_COMM_WORLD), 0);
 
     const int wrapped_tag = expected_tag_ub > std::numeric_limits<int>::max() - 5
@@ -237,7 +255,7 @@ TEST(conduit_mpi_test, safe_tag_wraps_first_consecutive_overflow_tags)
     MPI_Comm dup_comm = MPI_COMM_NULL;
     ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
 
-    const int tag_ub = detail::tag_upper_bound_probe(dup_comm);
+    const int tag_ub = safe_tag_effective_upper_bound(dup_comm);
     EXPECT_GE(tag_ub, 32767);
 
     int min_tag_ub = -1;
@@ -689,7 +707,7 @@ TEST(conduit_mpi_test, send_recv_without_using_schema_oversized_tag)
     MPI_Comm dup_comm = MPI_COMM_NULL;
     ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
 
-    const int tag_ub = detail::tag_upper_bound_probe(dup_comm);
+    const int tag_ub = safe_tag_effective_upper_bound(dup_comm);
     ASSERT_GE(tag_ub, 32767);
 
     if(tag_ub > std::numeric_limits<int>::max() - 5)

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -9,6 +9,7 @@
 //-----------------------------------------------------------------------------
 
 #include "conduit_relay_mpi.hpp"
+#include "conduit_relay_mpi_internal.hpp"
 #include <iostream>
 #include "math.h"
 #include <limits>
@@ -158,6 +159,43 @@ TEST(conduit_mpi_test, mpi_minimum_tag_32767_is_valid)
               MPI_SUCCESS);
     EXPECT_EQ(recv_value, src);
 
+    EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, tag_probe_is_rank_local)
+{
+    MPI_Comm dup_comm = MPI_COMM_NULL;
+    ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
+
+    int rank = 0;
+    ASSERT_EQ(MPI_Comm_rank(dup_comm, &rank), MPI_SUCCESS);
+
+    const int probe_count = 1 + (rank % 3);
+    for(int i = 0; i < probe_count; i++)
+    {
+        const int probed_tag_ub = detail::tag_upper_bound_probe(dup_comm);
+        EXPECT_GE(probed_tag_ub, 32767);
+
+        int send_value = rank;
+        int recv_value = -1;
+        EXPECT_EQ(MPI_Sendrecv(&send_value,
+                               1,
+                               MPI_INT,
+                               rank,
+                               probed_tag_ub,
+                               &recv_value,
+                               1,
+                               MPI_INT,
+                               rank,
+                               probed_tag_ub,
+                               dup_comm,
+                               MPI_STATUS_IGNORE),
+                  MPI_SUCCESS);
+        EXPECT_EQ(recv_value, rank);
+    }
+
+    EXPECT_EQ(MPI_Barrier(dup_comm), MPI_SUCCESS);
     EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
 }
 

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -86,7 +86,7 @@ TEST(conduit_mpi_test, mpi_dtype_to_conduit_dtype)
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_mpi_test, safe_tag_clamps_to_mpi_tag_ub)
+TEST(conduit_mpi_test, safe_tag_wraps_to_mpi_tag_ub_range)
 {
     int flag = 0;
     int *tag_ub_ptr = nullptr;
@@ -99,14 +99,19 @@ TEST(conduit_mpi_test, safe_tag_clamps_to_mpi_tag_ub)
     ASSERT_NE(tag_ub_ptr, nullptr);
 
     const int expected_tag_ub = *tag_ub_ptr;
-    EXPECT_EQ(safe_tag(std::numeric_limits<int>::max(), MPI_COMM_WORLD),
-              expected_tag_ub);
     EXPECT_EQ(safe_tag(-42, MPI_COMM_WORLD), 0);
+
+    const int wrapped_tag = expected_tag_ub > std::numeric_limits<int>::max() - 5
+        ? expected_tag_ub
+        : expected_tag_ub + 5;
+    const int expected_wrapped_tag = expected_tag_ub > std::numeric_limits<int>::max() - 5
+        ? expected_tag_ub
+        : 4;
+    EXPECT_EQ(safe_tag(wrapped_tag, MPI_COMM_WORLD), expected_wrapped_tag);
 
     MPI_Comm dup_comm = MPI_COMM_NULL;
     ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
-    EXPECT_EQ(safe_tag(std::numeric_limits<int>::max(), dup_comm),
-              expected_tag_ub);
+    EXPECT_EQ(safe_tag(wrapped_tag, dup_comm), expected_wrapped_tag);
     EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
 }
 

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -200,6 +200,80 @@ TEST(conduit_mpi_test, tag_probe_is_rank_local)
 }
 
 //-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, tag_probe_upper_bound_is_consistent_across_ranks)
+{
+    MPI_Comm dup_comm = MPI_COMM_NULL;
+    ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
+
+    const int local_tag_ub = detail::tag_upper_bound_probe(dup_comm);
+    EXPECT_GE(local_tag_ub, 32767);
+
+    int min_tag_ub = -1;
+    int max_tag_ub = -1;
+    ASSERT_EQ(MPI_Allreduce(&local_tag_ub,
+                            &min_tag_ub,
+                            1,
+                            MPI_INT,
+                            MPI_MIN,
+                            dup_comm),
+              MPI_SUCCESS);
+    ASSERT_EQ(MPI_Allreduce(&local_tag_ub,
+                            &max_tag_ub,
+                            1,
+                            MPI_INT,
+                            MPI_MAX,
+                            dup_comm),
+              MPI_SUCCESS);
+
+    EXPECT_EQ(min_tag_ub, max_tag_ub);
+    EXPECT_EQ(local_tag_ub, min_tag_ub);
+
+    EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, safe_tag_wraps_first_consecutive_overflow_tags)
+{
+    MPI_Comm dup_comm = MPI_COMM_NULL;
+    ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
+
+    const int tag_ub = detail::tag_upper_bound_probe(dup_comm);
+    EXPECT_GE(tag_ub, 32767);
+
+    int min_tag_ub = -1;
+    int max_tag_ub = -1;
+    ASSERT_EQ(MPI_Allreduce(&tag_ub,
+                            &min_tag_ub,
+                            1,
+                            MPI_INT,
+                            MPI_MIN,
+                            dup_comm),
+              MPI_SUCCESS);
+    ASSERT_EQ(MPI_Allreduce(&tag_ub,
+                            &max_tag_ub,
+                            1,
+                            MPI_INT,
+                            MPI_MAX,
+                            dup_comm),
+              MPI_SUCCESS);
+    ASSERT_EQ(min_tag_ub, max_tag_ub);
+
+    if(tag_ub > std::numeric_limits<int>::max() - 2)
+    {
+        GTEST_SKIP() << "Cannot test tags above the communicator upper bound without overflow.";
+    }
+
+    const int wrapped_tag0 = safe_tag(tag_ub + 1, dup_comm);
+    const int wrapped_tag1 = safe_tag(tag_ub + 2, dup_comm);
+
+    EXPECT_EQ(wrapped_tag0, 0);
+    EXPECT_EQ(wrapped_tag1, 1);
+    EXPECT_NE(wrapped_tag0, wrapped_tag1);
+
+    EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
+}
+
+//-----------------------------------------------------------------------------
 TEST(conduit_mpi_test, reduce)
 {
     Node n_snd, n_reduce;

--- a/src/tests/relay/t_relay_mpi_test.cpp
+++ b/src/tests/relay/t_relay_mpi_test.cpp
@@ -11,6 +11,7 @@
 #include "conduit_relay_mpi.hpp"
 #include <iostream>
 #include "math.h"
+#include <limits>
 #include "gtest/gtest.h"
 
 using namespace conduit;
@@ -82,6 +83,77 @@ TEST(conduit_mpi_test, mpi_dtype_to_conduit_dtype)
 
     EXPECT_TRUE(DataType(mpi_dtype_to_conduit_dtype_id(MPI_FLOAT)).is_float());
     EXPECT_TRUE(DataType(mpi_dtype_to_conduit_dtype_id(MPI_DOUBLE)).is_double());
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, safe_tag_clamps_to_mpi_tag_ub)
+{
+    int flag = 0;
+    int *tag_ub_ptr = nullptr;
+    const int mpi_error = MPI_Comm_get_attr(MPI_COMM_WORLD,
+                                            MPI_TAG_UB,
+                                            &tag_ub_ptr,
+                                            &flag);
+    ASSERT_EQ(mpi_error, MPI_SUCCESS);
+    ASSERT_NE(flag, 0);
+    ASSERT_NE(tag_ub_ptr, nullptr);
+
+    const int expected_tag_ub = *tag_ub_ptr;
+    EXPECT_EQ(safe_tag(std::numeric_limits<int>::max(), MPI_COMM_WORLD),
+              expected_tag_ub);
+    EXPECT_EQ(safe_tag(-42, MPI_COMM_WORLD), 0);
+
+    MPI_Comm dup_comm = MPI_COMM_NULL;
+    ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
+    EXPECT_EQ(safe_tag(std::numeric_limits<int>::max(), dup_comm),
+              expected_tag_ub);
+    EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_mpi_test, mpi_minimum_tag_32767_is_valid)
+{
+    int flag = 0;
+    int *tag_ub_ptr = nullptr;
+    const int mpi_error = MPI_Comm_get_attr(MPI_COMM_WORLD,
+                                            MPI_TAG_UB,
+                                            &tag_ub_ptr,
+                                            &flag);
+    ASSERT_EQ(mpi_error, MPI_SUCCESS);
+    if(flag != 0 && tag_ub_ptr != nullptr)
+    {
+        EXPECT_GE(*tag_ub_ptr, 32767);
+    }
+
+    MPI_Comm dup_comm = MPI_COMM_NULL;
+    ASSERT_EQ(MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm), MPI_SUCCESS);
+    ASSERT_EQ(MPI_Comm_set_errhandler(dup_comm, MPI_ERRORS_RETURN), MPI_SUCCESS);
+
+    int rank = 0, size = 1;
+    ASSERT_EQ(MPI_Comm_rank(dup_comm, &rank), MPI_SUCCESS);
+    ASSERT_EQ(MPI_Comm_size(dup_comm, &size), MPI_SUCCESS);
+
+    const int dest = (size > 1) ? ((rank + 1) % size) : rank;
+    const int src  = (size > 1) ? ((rank + size - 1) % size) : rank;
+
+    int send_value = rank;
+    int recv_value = -1;
+    EXPECT_EQ(MPI_Sendrecv(&send_value,
+                           1,
+                           MPI_INT,
+                           dest,
+                           32767,
+                           &recv_value,
+                           1,
+                           MPI_INT,
+                           src,
+                           32767,
+                           dup_comm,
+                           MPI_STATUS_IGNORE),
+              MPI_SUCCESS);
+    EXPECT_EQ(recv_value, src);
+
+    EXPECT_EQ(MPI_Comm_free(&dup_comm), MPI_SUCCESS);
 }
 
 //-----------------------------------------------------------------------------
@@ -1402,4 +1474,3 @@ int main(int argc, char* argv[])
 
     return result;
 }
-


### PR DESCRIPTION
The previous implementation for determining MPI tag upper limits failed in a `MPI_Waitall` to self on one platform. The implementation was changed to try and first query the value from the communicator attributes and failing that determine the number using messages, similar to before but with a `MPI_Sendrecv` to self.

* Changed implementation
* Tags above the limit are wrapped now with mod instead of using clamping
* Improved tests