### PR TITLE
Add the rest of the mesh transform benchmarks and improve the benchmarking infrastructure

### DIFF
--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -19,6 +19,7 @@
 
 #include "conduit_annotations.hpp"
 #include "conduit_data_type.hpp"
+#include "conduit_node.hpp"
 
 // This is not needed after device support is added back
 #if defined(CONDUIT_USE_OPENMP)
@@ -64,32 +65,40 @@ get_exec_configs()
 {
     // In the pre-device execution model world, we don't have the concept of
     // host vs device execution
-    //                                src       exec      dest
-    std::vector<ExecConfig> configs{{"host", "host", "host"}};
+    std::vector<ExecConfig> configs{
+        //source location, execution location, output location
+        {"host",           "host",             "host"},
+    };
     return configs;
 }
 
 //-----------------------------------------------------------------------------
 template <typename SetupFn, typename RunFn>
 void
-exec(const char *name,
+exec(const std::string &name,
      SetupFn &&setup,
      RunFn &&run,
      const index_t warmup,
      const index_t iterations,
      const std::vector<index_t> &dim_sizes)
 {
+    const std::vector<ExecConfig> configs = get_exec_configs();
+
     // Benchmark each data size
     for (const auto &dim_size : dim_sizes)
     {
         // Benchmark each possible configuration
-        for (auto &config : get_exec_configs())
+        for (ExecConfig config : configs)
         {
             config.dim_size = dim_size;
 
             // Build the input once, outside the timed regions
             Node input;
             setup(config, input);
+
+            // Reused across every iteration. It gets reset() immediately
+            // before each call, so run() always sees it empty.
+            Node dst;
 
             // Execute `run` `warmup` times
             {
@@ -98,7 +107,8 @@ exec(const char *name,
                 CONDUIT_ANNOTATE_MARK_SCOPE("warmup");
                 for (index_t i = 0; i < warmup; i++)
                 {
-                    run(input);
+                    dst.reset();
+                    run(input, dst);
                 }
             }
 
@@ -107,7 +117,7 @@ exec(const char *name,
                 // This scope name is used to identify specific benchmarks in
                 // the Caliper output and identify their attributes
                 // (dim size, policy, etc.)
-                const std::string scope_name = std::string(name)
+                const std::string scope_name = name
                     + "_dim-"  + std::to_string(dim_size)
                     + "_src-"  + config.src_location
                     + "_exec-" + config.exec_location
@@ -119,7 +129,8 @@ exec(const char *name,
                 CONDUIT_ANNOTATE_MARK_SCOPE(scope_name.c_str());
                 for (index_t i = 0; i < iterations; i++)
                 {
-                    run(input);
+                    dst.reset();
+                    run(input, dst);
                 }
             }
         }

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -88,7 +88,7 @@ exec(const std::string &name,
     for (const auto &dim_size : dim_sizes)
     {
         // Benchmark each possible configuration
-        for (ExecConfig &config : configs)
+        for (ExecConfig config : configs)
         {
             config.dim_size = dim_size;
 

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -19,7 +19,6 @@
 
 #include "conduit_annotations.hpp"
 #include "conduit_data_type.hpp"
-#include "conduit_node.hpp"
 
 // This is not needed after device support is added back
 #if defined(CONDUIT_USE_OPENMP)

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -38,6 +38,17 @@ namespace benchmark
 {
 
 //-----------------------------------------------------------------------------
+inline
+std::string
+get_timestamp()
+{
+    std::time_t t = std::time(nullptr);
+    std::ostringstream oss;
+    oss << std::put_time(std::localtime(&t), "%Y%m%d_%H%M%S");
+    return oss.str();
+}
+
+//-----------------------------------------------------------------------------
 struct ExecConfig
 {
     std::string src_location;

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -86,9 +86,13 @@ exec(const std::string &name,
     // Capture input/output data sizes to include in the scope name below.
     // This is a function of (name, npts) and never changes between
     // iterations.
-    run(input, output);
-    const std::string sizes = size_info(input, output);
-    output.reset();
+    std::string sizes;
+    {
+        CONDUIT_ANNOTATE_MARK_SCOPE("size_probe");
+        run(input, output);
+        sizes = size_info(input, output);
+        output.reset();
+    }
 
     // Execute `run` `warmup` times
     {

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -55,7 +55,6 @@ struct ExecConfig
     std::string src_location;
     std::string exec_location;
     std::string output_location;
-    index_t dim_size = 1;
 };
 
 //-----------------------------------------------------------------------------
@@ -84,20 +83,20 @@ exec(const std::string &name,
 {
     const std::vector<ExecConfig> configs = get_exec_configs();
 
-    // Benchmark each data size
-    for (const auto &dim_size : dim_sizes)
+
+    // Benchmark each possible configuration
+    for (const ExecConfig &config : configs)
     {
-        // Benchmark each possible configuration
-        for (ExecConfig config : configs)
+        // Benchmark each data size
+        for (const auto &npts : dim_sizes)
         {
-            config.dim_size = dim_size;
-
-            // Build the input once, outside the timed regions
+            // Build the input mesh once, outside the timed regions
             Node input;
-            setup(config, input);
+            setup(config, npts, input);
 
-            // Reused across every iteration. It gets reset() immediately
-            // before each call, so run() always sees it empty.
+            // The output node, reused across every iteration. It
+            // gets reset() immediately before each call, so run()
+            // always receives an empty node.
             Node dst;
 
             // Execute `run` `warmup` times
@@ -107,8 +106,8 @@ exec(const std::string &name,
                 CONDUIT_ANNOTATE_MARK_SCOPE("warmup");
                 for (index_t i = 0; i < warmup; i++)
                 {
-                    dst.reset();
                     run(input, dst);
+                    dst.reset();
                 }
             }
 
@@ -118,7 +117,7 @@ exec(const std::string &name,
                 // the Caliper output and identify their attributes
                 // (dim size, policy, etc.)
                 const std::string scope_name = name
-                    + "_dim-"  + std::to_string(dim_size)
+                    + "_dim-"  + std::to_string(npts)
                     + "_src-"  + config.src_location
                     + "_exec-" + config.exec_location
                     + "_out-"  + config.output_location
@@ -129,8 +128,8 @@ exec(const std::string &name,
                 CONDUIT_ANNOTATE_MARK_SCOPE(scope_name.c_str());
                 for (index_t i = 0; i < iterations; i++)
                 {
-                    dst.reset();
                     run(input, dst);
+                    dst.reset();
                 }
             }
         }

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -88,7 +88,7 @@ exec(const std::string &name,
     for (const auto &dim_size : dim_sizes)
     {
         // Benchmark each possible configuration
-        for (ExecConfig config : configs)
+        for (ExecConfig &config : configs)
         {
             config.dim_size = dim_size;
 

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -38,17 +38,6 @@ namespace benchmark
 {
 
 //-----------------------------------------------------------------------------
-inline
-std::string
-get_timestamp()
-{
-    std::time_t t = std::time(nullptr);
-    std::ostringstream oss;
-    oss << std::put_time(std::localtime(&t), "%Y%m%d_%H%M%S");
-    return oss.str();
-}
-
-//-----------------------------------------------------------------------------
 struct ExecConfig
 {
     std::string src_location;

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -116,10 +116,12 @@ exec(const std::string &name,
             + "_threads-" + std::to_string(omp_get_max_threads())
 #endif
             + "_iter-" + std::to_string(iterations);
-        CONDUIT_ANNOTATE_MARK_SCOPE(scope_name.c_str());
+
         for (index_t i = 0; i < iterations; i++)
         {
+            CONDUIT_ANNOTATE_MARK_BEGIN(scope_name.c_str());
             run(input, output);
+            CONDUIT_ANNOTATE_MARK_END(scope_name.c_str());
             output.reset();
         }
     }

--- a/src/libs/conduit/conduit_benchmark.hpp
+++ b/src/libs/conduit/conduit_benchmark.hpp
@@ -63,7 +63,7 @@ std::vector<ExecConfig>
 get_exec_configs()
 {
     // In the pre-device execution model world, we don't have the concept of
-    // host vs device execution
+    // host vs device execution.
     std::vector<ExecConfig> configs{
         //source location, execution location, output location
         {"host",           "host",             "host"},
@@ -72,66 +72,56 @@ get_exec_configs()
 }
 
 //-----------------------------------------------------------------------------
-template <typename SetupFn, typename RunFn>
+template <typename RunFn, typename SizeFn>
 void
 exec(const std::string &name,
-     SetupFn &&setup,
+     const Node &input,
+     Node &output,
      RunFn &&run,
+     SizeFn &&size_info,
+     const ExecConfig &config,
+     const index_t npts,
      const index_t warmup,
-     const index_t iterations,
-     const std::vector<index_t> &dim_sizes)
+     const index_t iterations)
 {
-    const std::vector<ExecConfig> configs = get_exec_configs();
+    // Capture input/output data sizes to include in the scope name below.
+    // This is a function of (name, npts) and never changes between
+    // iterations.
+    run(input, output);
+    const std::string sizes = size_info(input, output);
+    output.reset();
 
-
-    // Benchmark each possible configuration
-    for (const ExecConfig &config : configs)
+    // Execute `run` `warmup` times
     {
-        // Benchmark each data size
-        for (const auto &npts : dim_sizes)
+        // Scope this separately to make it easier to disregard warmup
+        // iterations in the timing output.
+        CONDUIT_ANNOTATE_MARK_SCOPE("warmup");
+        for (index_t i = 0; i < warmup; i++)
         {
-            // Build the input mesh once, outside the timed regions
-            Node input;
-            setup(config, npts, input);
+            run(input, output);
+            output.reset();
+        }
+    }
 
-            // The output node, reused across every iteration. It
-            // gets reset() immediately before each call, so run()
-            // always receives an empty node.
-            Node dst;
-
-            // Execute `run` `warmup` times
-            {
-                // Scope this separately to make it easier to disregard
-                // warmup iterations in the timing output
-                CONDUIT_ANNOTATE_MARK_SCOPE("warmup");
-                for (index_t i = 0; i < warmup; i++)
-                {
-                    run(input, dst);
-                    dst.reset();
-                }
-            }
-
-            // Execute `run` `iterations` times
-            {
-                // This scope name is used to identify specific benchmarks in
-                // the Caliper output and identify their attributes
-                // (dim size, policy, etc.)
-                const std::string scope_name = name
-                    + "_dim-"  + std::to_string(npts)
-                    + "_src-"  + config.src_location
-                    + "_exec-" + config.exec_location
-                    + "_out-"  + config.output_location
+    // Execute `run` `iterations` times
+    {
+        // This scope name is used to identify specific benchmarks in the
+        // Caliper output and identify their attributes.
+        const std::string scope_name = name
+            + "_dim-"  + std::to_string(npts)
+            + "_" + sizes
+            + "_src-"  + config.src_location
+            + "_exec-" + config.exec_location
+            + "_out-"  + config.output_location
 #if defined(CONDUIT_USE_OPENMP)
-                    + "_threads-" + std::to_string(omp_get_max_threads())
+            + "_threads-" + std::to_string(omp_get_max_threads())
 #endif
-                    + "_iter-" + std::to_string(iterations);
-                CONDUIT_ANNOTATE_MARK_SCOPE(scope_name.c_str());
-                for (index_t i = 0; i < iterations; i++)
-                {
-                    run(input, dst);
-                    dst.reset();
-                }
-            }
+            + "_iter-" + std::to_string(iterations);
+        CONDUIT_ANNOTATE_MARK_SCOPE(scope_name.c_str());
+        for (index_t i = 0; i < iterations; i++)
+        {
+            run(input, output);
+            output.reset();
         }
     }
 }

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -212,8 +212,8 @@ def plot_group(panels, path, suptitle, ylabel, y_scale=1.0, y_log=False,
 
     if legend_label is not None:
         handles, labels = axes[0].get_legend_handles_labels()
-        fig.legend(handles, labels, loc="center left",
-                  bbox_to_anchor=(1.0, 0.5), fontsize=9)
+        fig.legend(handles, labels, loc="lower left",
+                  bbox_to_anchor=(1.0, 0.0), fontsize=9)
         fig.savefig(path, dpi=150, bbox_inches="tight")
     else:
         fig.savefig(path, dpi=150)
@@ -384,14 +384,14 @@ def main():
             mesh_time_panels, out_dir / "mesh_scaling.png",
             suptitle=f"Mesh conversion benchmark: avg time per iteration ({iters_label})",
             ylabel="avg time / iteration (ms)", y_scale=1e3,
-            legend_label=MESH_SERIES_LABEL,
+            stack_vertical=True, legend_label=MESH_SERIES_LABEL,
         )
     if generate_time_panels:
         plot_group(
             generate_time_panels, out_dir / "generate_scaling.png",
             suptitle=f"Generate-function benchmark: avg time per iteration ({iters_label})",
             ylabel="avg time / iteration (ms)", y_scale=1e3,
-            series_order=SHAPE_ORDER,
+            series_order=SHAPE_ORDER, stack_vertical=True,
         )
 
     mesh_per_elem_panels = build_line_panels(
@@ -440,7 +440,6 @@ def main():
             row_label="source representation", col_label="target representation",
             cbar_label="avg time / element (ns)", cell_fmt=format_ns_cell,
         )
-
     shape_lookup = {}
     for r in generate_records:
         operation, shape = split_generate_name(r["name"])

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -2,9 +2,46 @@
 # Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
 # other details. No copyright assignment is required to contribute to Conduit.
 
-# Plots .cali output from t_blueprint_mesh_transform_benchmark. Run with no
-# arguments to plot the most recently written .cali file in the current
-# directory, or pass a path to a specific one.
+# Plots .cali output from t_blueprint_mesh_transform_benchmark.
+#
+# Usage:
+#     python3 plot_benchmark_output.py [path/to/file.cali]
+#
+#     With no arguments, the most recently modified .cali file in the current
+#     working directory is used. With one argument, a specific .cali file is
+#     used. There are no flags or other options.
+#
+# Examples:
+#     # Run the benchmark, which writes <YYYYmmdd_HHMMSS>.cali
+#     # into its own working directory, so run the plotting script from that
+#     # same directory.
+#     ./t_blueprint_mesh_transform_benchmark
+#     python3 plot_benchmark_output.py
+#
+#     # Plot a specific run, from anywhere.
+#     python3 plot_benchmark_output.py /path/to/20260803_120000.cali
+#
+# Input:
+#     A Caliper .cali file produced by t_blueprint_mesh_transform_benchmark.
+#     Note that the benchmark only writes a .cali file if Conduit was built
+#     with Caliper support; otherwise it prints
+#     a warning and produces no timing output.
+#
+# Output:
+#     A directory next to the .cali file, named after it with the extension
+#     stripped (e.g. 20260803_120000.cali -> 20260803_120000/), containing:
+#       - mesh_scaling.png, mesh_scaling_per_element.png
+#       - generate_scaling.png, generate_scaling_per_element.png
+#       - mesh_conversion_heatmap_dim-<N>.png (and _per_element variant)
+#       - generate_heatmap_dim-<N>.png (and _per_element variant)
+#       - generate_growth_heatmap_dim-<N>.png
+#       - thicket_mesh_heatmap.png, thicket_generate_heatmap.png,
+#         thicket_boxplot.png (skipped if seaborn is not installed)
+#       - individual/<figure name>/<panel>.png, one single-panel image per
+#         panel of each multi-panel figure above
+#
+# Requirements:
+#     pip install thicket caliper-reader matplotlib numpy seaborn
 
 import math
 import sys

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -3,6 +3,7 @@
 # other details. No copyright assignment is required to contribute to Conduit.
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -22,31 +23,54 @@ COORDSET_CONVERSIONS = [
 ]
 
 TOPOLOGY_CONVERSIONS = [
-    "topology_uniform_to_rectilinear",
-    "topology_uniform_to_structured",
     "topology_uniform_to_unstructured",
-    "topology_rectilinear_to_structured",
     "topology_rectilinear_to_unstructured",
     "topology_structured_to_unstructured",
 ]
 
-CONVERSIONS = COORDSET_CONVERSIONS + TOPOLOGY_CONVERSIONS
+UNSTRUCTURED_GENERATE_FUNCTIONS = [
+    "to_polytopal",
+    "generate_offsets",
+    "generate_offsets_inline",
+    "generate_points",
+    "generate_lines",
+    "generate_faces",
+    "generate_centroids",
+    "generate_sides",
+    "generate_corners",
+]
+
+UNSTRUCTURED_GENERATE_ELEM_TYPES = ["quads", "hexs"]
+
+UNSTRUCTURED_GENERATE_CONVERSIONS = [
+    f"{fn}_{elem}"
+    for fn in UNSTRUCTURED_GENERATE_FUNCTIONS
+    for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
+]
+
+CONVERSIONS = COORDSET_CONVERSIONS + TOPOLOGY_CONVERSIONS + UNSTRUCTURED_GENERATE_CONVERSIONS
 
 CONVERSION_LABELS = {
     "coordset_rectilinear_to_explicit": "rect→explicit",
     "coordset_uniform_to_explicit": "uniform→explicit",
     "coordset_uniform_to_rectilinear": "uniform→rect",
-    "topology_uniform_to_rectilinear": "uniform→rect",
-    "topology_uniform_to_structured": "uniform→struct",
     "topology_uniform_to_unstructured": "uniform→unstruct",
-    "topology_rectilinear_to_structured": "rect→struct",
     "topology_rectilinear_to_unstructured": "rect→unstruct",
     "topology_structured_to_unstructured": "struct→unstruct",
+    **{
+        f"{fn}_{elem}": f"{fn} ({elem})"
+        for fn in UNSTRUCTURED_GENERATE_FUNCTIONS
+        for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
+    },
 }
 
 CONVERSION_GROUPS = [
     ("coordset", COORDSET_CONVERSIONS),
     ("topology", TOPOLOGY_CONVERSIONS),
+] + [
+    (f"unstructured_generate_{elem}",
+     [f"{fn}_{elem}" for fn in UNSTRUCTURED_GENERATE_FUNCTIONS])
+    for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
 ]
 
 END_TO_END_GROUP_PANELS = [
@@ -57,7 +81,7 @@ END_TO_END_GROUP_PANELS = [
 COMPONENT_METRICS = [
     ("use_with", "use_with"),
     ("forall", "forall"),
-    ("sync", "sync"),
+    ("data movement", "data_movement"),
     ("other processing", "other_processing"),
 ]
 
@@ -90,57 +114,53 @@ def format_range_label(prefix, values):
     return f"{prefix}={values[0]}-{values[-1]}"
 
 
+KNOWN_BACKENDS = {"openmp", "cuda", "hip", "serial"}
+
+CONFIG_NAME_RE = re.compile(r"^(.+?)_dim-(\d+)_(.+)$")
+
+
 def parse_config_name(name):
-    conv_name = None
-    for c in CONVERSIONS:
-        if name.startswith(c + "_"):
-            conv_name = c
-            break
-    if conv_name is None:
+    match = CONFIG_NAME_RE.match(name)
+    if match is None:
         return None
+    conv_name, dim_str, rest = match.groups()
 
-    rest = name[len(conv_name) + 1 :]
-    parts = rest.split("_")
-
-    if len(parts) not in (5, 6, 7):
-        return None
+    backend = None
+    conv_parts = conv_name.split("_")
+    if len(conv_parts) > 1 and conv_parts[-1] in KNOWN_BACKENDS:
+        backend = conv_parts[-1]
+        conv_name = "_".join(conv_parts[:-1])
 
     values = {}
-    backend = None
-
-    # If the first token has no dash, treat it as backend
-    start_idx = 0
-    if "-" not in parts[0]:
-        backend = parts[0]
-        start_idx = 1
-
-    for field in parts[start_idx:]:
+    for field in rest.split("_"):
         if "-" not in field:
             return None
         key, value = field.split("-", 1)
         values[key] = value
 
-    required = {"dim", "src", "exec", "out", "iter"}
-    if set(values) not in (required, required | {"threads"}):
+    required = {"iter"}
+    optional = {"src", "exec", "out", "sync", "threads"}
+    if not (required <= set(values) <= required | optional):
         return None
-
-    if values["src"] not in ("host", "device"):
+    if "src" in values and values["src"] not in ("host", "device"):
         return None
-    if values["exec"] not in ("host", "device"):
+    if "exec" in values and values["exec"] not in ("host", "device"):
         return None
-    if values["out"] not in ("host", "device"):
+    if "out" in values and values["out"] not in ("host", "device"):
         return None
-    if not values["dim"].isdigit() or not values["iter"].isdigit():
+    if "sync" in values and values["sync"] not in ("sync", "assume"):
         return None
-
+    if not dim_str.isdigit() or not values["iter"].isdigit():
+        return None
     threads = None
     if "threads" in values:
         if not values["threads"].isdigit():
             return None
         threads = int(values["threads"])
 
-    cfg = (backend, values["src"], values["exec"], values["out"])
-    return conv_name, cfg, int(values["dim"]), int(values["iter"]), threads
+    cfg = (backend, values.get("src"), values.get("exec"), values.get("out"))
+    sync_strategy = values.get("sync")
+    return conv_name, cfg, int(dim_str), int(values["iter"]), threads, sync_strategy
 
 
 def parse_timestamp(cali_file):
@@ -186,8 +206,7 @@ def subtree_time(thicket, profile_id, node):
         total += subtree_time(thicket, profile_id, child)
     return total
 
-
-LEAF_METRIC_NAMES = ("use_with", "forall", "sync")
+LEAF_METRIC_NAMES = ("use_with", "forall", "sync", "assume")
 
 def accumulate_leaf_metrics(thicket, profile_id, node, totals):
     name = node.frame["name"]
@@ -203,16 +222,18 @@ def collect_data(thicket):
     data = {}
     dims_seen = set()
     backends_seen = set()
+    syncs_seen = set()
 
     root = list(thicket.graph.roots)[0]
     for cfg_node in root.children:
         parsed = parse_config_name(cfg_node.frame["name"])
         if parsed is None:
             continue
-        conv_name, cfg, dim, iters, threads = parsed
+        conv_name, cfg, dim, iters, threads, sync_strategy = parsed
         backend, _, _, _ = cfg
 
         dims_seen.add(dim)
+        syncs_seen.add(sync_strategy)
         if backend is not None:
             backends_seen.add(backend)
 
@@ -222,19 +243,19 @@ def collect_data(thicket):
         end_to_end = subtree_time(thicket, profile_id, cfg_node) / iters
         use_with = totals["use_with"] / iters
         forall = totals["forall"] / iters
-        sync = totals["sync"] / iters
+        data_movement = (totals["sync"] + totals["assume"]) / iters
 
-        data[(cfg, conv_name, dim)] = {
+        data[(cfg, conv_name, dim, sync_strategy)] = {
             "end_to_end": end_to_end,
             "use_with": use_with,
             "forall": forall,
-            "sync": sync,
-            "other_processing": max(0.0, end_to_end - (use_with + forall + sync)),
+            "data_movement": data_movement,
+            "other_processing": max(0.0, end_to_end - (use_with + forall + data_movement)),
             "iters": iters,
             "threads": threads,
         }
 
-    return data, sorted(dims_seen), backends_seen
+    return data, sorted(dims_seen), backends_seen, syncs_seen
 
 
 def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_label, per_element=False):
@@ -287,7 +308,8 @@ def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_labe
         ax.set_title(title, fontsize=17)
         ax.tick_params(axis="both", which="major", labelsize=13)
 
-        if per_element:
+        positive_values = [v for v in panel_values if v > 0]
+        if per_element and positive_values:
             # Per-element cost spans many orders of magnitude, so use
             # a log-scale y-axis
             ax.set_yscale("log")
@@ -352,7 +374,7 @@ def generate_plots(data, dims, cfg_keys, iters_label, out_dir, suffix="", includ
             )
 
 
-def generate_per_element_plots(data, dims, cfg_keys, iters_label, out_dir):
+def generate_per_element_plots(data, dims, cfg_keys, iters_label, out_dir, suffix=""):
     ylabel = "avg time / element"
 
     for group_name, group_panels in END_TO_END_GROUP_PANELS:
@@ -360,7 +382,7 @@ def generate_per_element_plots(data, dims, cfg_keys, iters_label, out_dir):
             data, dims, cfg_keys,
             group_panels,
             f"avg {group_name} time per element vs data size",
-            out_dir / f"end_to_end_combined_{group_name}_per_element.png",
+            out_dir / f"end_to_end_combined_{group_name}_per_element{suffix}.png",
             ylabel,
             iters_label,
             per_element=True,
@@ -371,7 +393,7 @@ def generate_per_element_plots(data, dims, cfg_keys, iters_label, out_dir):
             data, dims, cfg_keys,
             [(CONVERSION_LABELS[conv], conv, "end_to_end")],
             f"{CONVERSION_LABELS[conv]} avg end-to-end time per element vs data size",
-            out_dir / f"end_to_end_{conv}_per_element.png",
+            out_dir / f"end_to_end_{conv}_per_element{suffix}.png",
             ylabel,
             iters_label,
             per_element=True,
@@ -395,11 +417,9 @@ def main():
     except ReaderError as e:
         sys.exit(f"failed to read {cali_file}: {e}")
 
-    data, dims, backends_seen = collect_data(thicket)
+    data, dims, backends_seen, syncs_seen = collect_data(thicket)
     if not data:
         sys.exit(f"no benchmark config nodes found in {cali_file}")
-
-    cfg_keys = sorted({cfg for cfg, _, _ in data})
 
     iters_label = format_range_label("n", {entry["iters"] for entry in data.values()})
     threads_seen = {entry["threads"] for entry in data.values() if entry["threads"] is not None}
@@ -413,21 +433,35 @@ def main():
     if serial_only:
         print("no backend field found, treating runs as serial-only")
 
-    generate_plots(
-        data, dims, cfg_keys, iters_label, out_dir,
-        include_components=not serial_only,
-    )
-    generate_per_element_plots(data, dims, cfg_keys, iters_label, out_dir)
+    multi_sync = len(syncs_seen) > 1
+    for sync_strategy in sorted(syncs_seen, key=lambda s: (s is None, s)):
+        sync_data = {
+            (cfg, conv_name, dim): entry
+            for (cfg, conv_name, dim, s), entry in data.items()
+            if s == sync_strategy
+        }
+        cfg_keys = sorted({cfg for cfg, _, _ in sync_data})
+        sync_suffix = f"_{sync_strategy or 'no-sync'}" if multi_sync else ""
 
-    if not serial_only:
-        for backend in sorted(backends_seen):
-            backend_keys = [cfg for cfg in cfg_keys if cfg[0] == backend]
-            if backend_keys:
-                generate_plots(
-                    data, dims, backend_keys, iters_label, out_dir,
-                    suffix=f"_{backend}",
-                    include_components=True,
-                )
+        generate_plots(
+            sync_data, dims, cfg_keys, iters_label, out_dir,
+            suffix=sync_suffix,
+            include_components=not serial_only,
+        )
+        generate_per_element_plots(
+            sync_data, dims, cfg_keys, iters_label, out_dir,
+            suffix=sync_suffix,
+        )
+
+        if not serial_only:
+            for backend in sorted(backends_seen):
+                backend_keys = [cfg for cfg in cfg_keys if cfg[0] == backend]
+                if backend_keys:
+                    generate_plots(
+                        sync_data, dims, backend_keys, iters_label, out_dir,
+                        suffix=f"{sync_suffix}_{backend}",
+                        include_components=True,
+                    )
 
     print(f"wrote plots to {out_dir}/")
 

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -100,6 +100,35 @@ def find_time_column(dataframe):
     sys.exit(f"no time column found; columns were {list(dataframe.columns)}")
 
 
+INCLUSIVE_COLUMN = "inclusive#time.duration"
+
+
+def add_inclusive_column(thicket):
+    profile_id = thicket.dataframe.index.get_level_values("profile")[0]
+    time_column = find_time_column(thicket.dataframe)
+
+    def own_time(node):
+        try:
+            return float(thicket.dataframe.loc[(node, profile_id), time_column])
+        except (KeyError, TypeError):
+            return 0.0
+
+    def node_time(node):
+        return own_time(node) + sum(node_time(child) for child in node.children)
+
+    def all_nodes(node):
+        yield node
+        for child in node.children:
+            yield from all_nodes(child)
+
+    totals = {node: node_time(node)
+              for root in thicket.graph.roots for node in all_nodes(root)}
+    thicket.dataframe[INCLUSIVE_COLUMN] = [
+        totals.get(index[0], float("nan")) for index in thicket.dataframe.index
+    ]
+    return INCLUSIVE_COLUMN
+
+
 def collect(thicket):
     profile_id = thicket.dataframe.index.get_level_values("profile")[0]
     time_column = find_time_column(thicket.dataframe)
@@ -118,6 +147,9 @@ def collect(thicket):
         for child in node.children:
             yield from all_nodes(child)
 
+    # A region's reported time is the total spent inside it: its own time plus
+    # every nested region beneath it. Caliper stores only the own time, so the
+    # children have to be added back in.
     records = []
     for root in thicket.graph.roots:
         for node in all_nodes(root):
@@ -474,7 +506,7 @@ def main():
             cbar_label="output elements / input elements", cell_fmt=format_growth_cell,
         )
 
-    plot_thicket_views(thicket, records, find_time_column(thicket.dataframe), out_dir)
+    plot_thicket_views(thicket, records, add_inclusive_column(thicket), out_dir)
 
     print(f"wrote plots to {out_dir}/")
 

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -2,15 +2,13 @@
 # Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
 # other details. No copyright assignment is required to contribute to Conduit.
 
-import argparse
-import csv
+# Plots .cali output from t_blueprint_mesh_transform_benchmark. Run with no
+# arguments to plot the most recently written .cali file in the current
+# directory, or pass a path to a specific one.
+
 import math
-import re
 import sys
-from copy import copy
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import matplotlib
 
@@ -19,1394 +17,467 @@ import matplotlib.pyplot as plt
 import numpy as np
 import thicket as th
 from caliperreader.readererror import ReaderError
-from matplotlib.colors import LogNorm
-from matplotlib.ticker import FuncFormatter
+
+REQUIRED_FIELDS = ("dim", "inverts", "inelems", "outverts", "outelems", "iter")
 
 
-MESH_BENCHMARKS = [
-    ("mesh_uniform_to_rectilinear", "uniform → rectilinear"),
-    ("mesh_uniform_to_structured", "uniform → structured"),
-    ("mesh_uniform_to_unstructured", "uniform → unstructured"),
-    ("mesh_rectilinear_to_structured", "rectilinear → structured"),
-    ("mesh_rectilinear_to_unstructured", "rectilinear → unstructured"),
-    ("mesh_structured_to_unstructured", "structured → unstructured"),
-]
+def parse_scope_name(raw):
+    tokens = raw.split("_")
 
-MESH_LABELS = dict(MESH_BENCHMARKS)
-
-UNSTRUCTURED_OPERATIONS = [
-    ("to_polytopal", "to polytopal"),
-    ("generate_points", "generate points"),
-    ("generate_lines", "generate lines"),
-    ("generate_faces", "generate faces"),
-    ("generate_centroids", "generate centroids"),
-    ("generate_sides", "generate sides"),
-    ("generate_corners", "generate corners"),
-    ("generate_offsets", "generate offsets"),
-    ("generate_offsets_inline", "generate offsets inline"),
-]
-
-OPERATION_LABELS = dict(UNSTRUCTURED_OPERATIONS)
-OPERATION_ORDER = {
-    operation: index
-    for index, (operation, _) in enumerate(UNSTRUCTURED_OPERATIONS)
-}
-
-PREFERRED_ELEMENT_TYPE_ORDER = [
-    "tris",
-    "quads",
-    "tets",
-    "hexs",
-    "wedges",
-    "pyramids",
-    "mixed_2d",
-    "mixed",
-]
-
-ELEMENT_TYPE_NDIMS = {
-    "tris": 2,
-    "quads": 2,
-    "polygonal": 2,
-    "mixed_2d": 2,
-    "tets": 3,
-    "hexs": 3,
-    "wedges": 3,
-    "pyramids": 3,
-    "polyhedral": 3,
-    "mixed": 3,
-}
-
-MARKERS = ["o", "s", "^", "D", "v", "P", "X", "*"]
-
-CONFIG_NAME_RE = re.compile(
-    r"^(?P<benchmark>(?:mesh|unstructured)_.+?)"
-    r"_dim-(?P<dim>\d+)"
-    r"_(?P<metadata>.+)$"
-)
-
-TIMESTAMP_RE = re.compile(r"^\d{8}_\d{6}$")
-
-REQUIRED_METADATA_FIELDS = {"src", "exec", "out", "iter"}
-OPTIONAL_METADATA_FIELDS = {"backend", "sync", "threads"}
-ALLOWED_METADATA_FIELDS = (
-    REQUIRED_METADATA_FIELDS | OPTIONAL_METADATA_FIELDS
-)
-
-
-@dataclass(frozen=True)
-class Config:
-    backend: Optional[str]
-    src: str
-    execution: str
-    out: str
-    sync: Optional[str]
-    threads: Optional[int]
-
-
-@dataclass(frozen=True)
-class BenchmarkInfo:
-    name: str
-    family: str
-    label: str
-    operation: Optional[str]
-    element_type: Optional[str]
-    ndims: Optional[int]
-
-
-@dataclass(frozen=True)
-class BenchmarkResult:
-    benchmark: str
-    config: Config
-    dim: int
-    iterations: int
-    total_seconds: float
-    seconds_per_iteration: float
-
-
-def parse_config_name(name):
-    match = CONFIG_NAME_RE.match(name)
-    if match is None:
+    i = 0
+    while i < len(tokens) and "-" not in tokens[i]:
+        i += 1
+    name = "_".join(tokens[:i])
+    is_generate = any(name.startswith(op + "_") for op in OPERATIONS)
+    if not (name.startswith("mesh_") or is_generate):
         return None
 
-    benchmark = match.group("benchmark")
-    dim = int(match.group("dim"))
-
-    values = {}
-    for field in match.group("metadata").split("_"):
-        if "-" not in field:
+    fields = {}
+    for token in tokens[i:]:
+        if "-" not in token:
             return None
+        key, value = token.split("-", 1)
+        fields[key] = value
 
-        key, value = field.split("-", 1)
-        if not key or not value or key in values:
-            return None
-
-        values[key] = value
-
-    if not REQUIRED_METADATA_FIELDS <= values.keys():
+    if not all(fields.get(key, "").isdigit() for key in REQUIRED_FIELDS):
         return None
 
-    if values.keys() - ALLOWED_METADATA_FIELDS:
-        return None
-
-    if values["src"] not in {"host", "device"}:
-        return None
-
-    if values["exec"] not in {"host", "device"}:
-        return None
-
-    if values["out"] not in {"host", "device"}:
-        return None
-
-    if not values["iter"].isdigit():
-        return None
-
-    iterations = int(values["iter"])
-    if dim <= 1 or iterations <= 0:
-        return None
-
-    threads = None
-    if "threads" in values:
-        if not values["threads"].isdigit():
-            return None
-
-        threads = int(values["threads"])
-        if threads <= 0:
-            return None
-
-    config = Config(
-        backend=values.get("backend"),
-        src=values["src"],
-        execution=values["exec"],
-        out=values["out"],
-        sync=values.get("sync"),
-        threads=threads,
-    )
-
-    return benchmark, config, dim, iterations
+    parsed = {"name": name}
+    parsed.update((key, int(fields[key])) for key in REQUIRED_FIELDS)
+    return parsed
 
 
-def parse_unstructured_benchmark(name):
-    # Longer operation names must be checked first so generate_offsets_inline
-    # is not interpreted as generate_offsets plus an inline element type.
-    operations = sorted(
-        OPERATION_LABELS,
-        key=len,
-        reverse=True,
-    )
-
-    for operation in operations:
-        prefix = f"unstructured_{operation}_"
-        if name.startswith(prefix):
-            element_type = name[len(prefix):]
-            if element_type:
-                return operation, element_type
-
+def split_mesh_convert(name):
+    tokens = name.split("_")
+    if len(tokens) == 4 and tokens[0] == "mesh" and tokens[2] == "to":
+        return tokens[1], tokens[3]
     return None
 
+OPERATIONS = [
+    "generate_centroids",
+    "generate_points",
+    "generate_faces",
+    "generate_lines",
+    "generate_corners",
+    "generate_sides",
+    "to_polytopal",
+]
+MESH_SRC_ORDER = ["structured", "rectilinear", "uniform"]
+SHAPE_ORDER = ["quads", "hexs", "pyramids"]
+MESH_SERIES_LABEL = "serial - before device support"
 
-def classify_benchmark(name):
-    if name.startswith("mesh_"):
-        return BenchmarkInfo(
-            name=name,
-            family="mesh",
-            label=MESH_LABELS.get(name, name.replace("_", " ")),
-            operation=name.removeprefix("mesh_"),
-            element_type=None,
-            ndims=3,
-        )
-
-    parsed = parse_unstructured_benchmark(name)
-    if parsed is not None:
-        operation, element_type = parsed
-        return BenchmarkInfo(
-            name=name,
-            family="unstructured",
-            label=OPERATION_LABELS[operation],
-            operation=operation,
-            element_type=element_type,
-            ndims=ELEMENT_TYPE_NDIMS.get(element_type),
-        )
-
-    return BenchmarkInfo(
-        name=name,
-        family="other",
-        label=name.replace("_", " "),
-        operation=None,
-        element_type=None,
-        ndims=None,
-    )
+INDIVIDUAL_FIGSIZE = (6.4, 3.6)
+MAX_STACKED_ROWS = 4
 
 
-def config_sort_key(config):
-    return (
-        config.backend or "",
-        config.src,
-        config.execution,
-        config.out,
-        config.sync or "",
-        config.threads if config.threads is not None else -1,
-    )
+def ordered(values, preferred_order):
+    values = set(values)
+    return [v for v in preferred_order if v in values] + \
+        sorted(values - set(preferred_order))
 
 
-def format_config(config):
-    parts = []
-
-    if config.backend:
-        parts.append(config.backend)
-
-    parts.append(
-        f"{config.src} → {config.execution} → {config.out}"
-    )
-
-    if config.sync:
-        parts.append(f"sync={config.sync}")
-
-    if config.threads is not None:
-        parts.append(f"threads={config.threads}")
-
-    return ", ".join(parts)
-
-
-def config_slug(config):
-    parts = []
-
-    if config.backend:
-        parts.append(config.backend)
-
-    parts.extend([
-        config.src,
-        config.execution,
-        config.out,
-    ])
-
-    if config.sync:
-        parts.append(config.sync)
-
-    if config.threads is not None:
-        parts.append(f"threads-{config.threads}")
-
-    return safe_file_part("_".join(parts))
-
-
-def safe_file_part(value):
-    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
-
-
-def ordered_element_types(infos):
-    discovered = {
-        info.element_type
-        for info in infos.values()
-        if info.element_type is not None
-    }
-
-    ordered = [
-        element_type
-        for element_type in PREFERRED_ELEMENT_TYPE_ORDER
-        if element_type in discovered
-    ]
-
-    ordered.extend(
-        sorted(discovered - set(PREFERRED_ELEMENT_TYPE_ORDER))
-    )
-
-    return ordered
+def split_generate_name(name):
+    for operation in OPERATIONS:
+        if name.startswith(operation + "_"):
+            return operation, name[len(operation) + 1:]
+    return name, ""
 
 
 def find_cali_file():
-    candidates = [
-        path
-        for path in Path.cwd().glob("*.cali")
-        if TIMESTAMP_RE.match(path.stem)
-    ]
-    candidates.sort(reverse=True)
-
-    if not candidates:
-        sys.exit(
-            "no timestamped .cali files "
-            f"(YYYYMMDD_HHMMSS.cali) found in {Path.cwd()}"
-        )
-
-    print(f"using most recent Caliper file: {candidates[0]}")
-    return candidates[0]
+    files = list(Path.cwd().glob("*.cali"))
+    if not files:
+        sys.exit("no .cali files found in current directory")
+    return max(files, key=lambda path: path.stat().st_mtime)
 
 
 def find_time_column(dataframe):
-    preferred = (
-        "time",
-        "sum#sum#time.duration",
-        "sum#time.duration",
-        "time.duration",
-    )
-
-    for candidate in preferred:
-        if candidate in dataframe.columns:
-            return candidate
-
+    for name in ("time", "sum#sum#time.duration", "sum#time.duration"):
+        if name in dataframe.columns:
+            return name
     for column in dataframe.columns:
         if str(column).endswith("time.duration"):
             return column
-
-    raise RuntimeError(
-        "unable to find a Caliper time column; available columns are: "
-        + ", ".join(str(column) for column in dataframe.columns)
-    )
+    sys.exit(f"no time column found; columns were {list(dataframe.columns)}")
 
 
-def iter_graph_nodes(graph):
-    stack = list(graph.roots)
-    visited = set()
-
-    while stack:
-        node = stack.pop()
-        node_id = id(node)
-
-        if node_id in visited:
-            continue
-
-        visited.add(node_id)
-        yield node
-        stack.extend(node.children)
-
-
-def node_time(thicket, profile_id, node, time_column):
-    try:
-        value = thicket.dataframe.loc[
-            (node, profile_id),
-            time_column,
-        ]
-    except KeyError:
-        return float("nan")
-
-    try:
-        return float(np.asarray(value).reshape(-1)[0])
-    except (TypeError, ValueError, IndexError):
-        return float("nan")
-
-
-def inclusive_time(
-    thicket,
-    profile_id,
-    node,
-    time_column,
-    cache,
-):
-    node_id = id(node)
-    if node_id in cache:
-        return cache[node_id]
-
-    value = node_time(
-        thicket,
-        profile_id,
-        node,
-        time_column,
-    )
-    total = 0.0 if np.isnan(value) else value
-
-    for child in node.children:
-        total += inclusive_time(
-            thicket,
-            profile_id,
-            child,
-            time_column,
-            cache,
-        )
-
-    cache[node_id] = total
-    return total
-
-
-def collect_results(thicket):
-    profile_ids = list(
-        thicket.dataframe.index
-        .get_level_values("profile")
-        .unique()
-    )
-
-    if len(profile_ids) != 1:
-        raise RuntimeError(
-            "expected exactly one profile in the Caliper file, "
-            f"found {len(profile_ids)}"
-        )
-
-    profile_id = profile_ids[0]
+def collect(thicket):
+    profile_id = thicket.dataframe.index.get_level_values("profile")[0]
     time_column = find_time_column(thicket.dataframe)
-    time_cache = {}
 
-    results = []
-    seen = set()
-    malformed_names = []
+    def node_time(node):
+        try:
+            total = float(thicket.dataframe.loc[(node, profile_id), time_column])
+        except (KeyError, TypeError):
+            total = 0.0
+        for child in node.children:
+            total += node_time(child)
+        return total
 
-    for node in iter_graph_nodes(thicket.graph):
-        name = node.frame.get("name", "")
-        parsed = parse_config_name(name)
+    def all_nodes(node):
+        yield node
+        for child in node.children:
+            yield from all_nodes(child)
 
-        if parsed is None:
-            if (
-                isinstance(name, str)
-                and name.startswith(("mesh_", "unstructured_"))
-                and "_dim-" in name
-            ):
-                malformed_names.append(name)
+    records = []
+    for root in thicket.graph.roots:
+        for node in all_nodes(root):
+            parsed = parse_scope_name(str(node.frame.get("name", "")))
+            if parsed is None:
+                continue
+            parsed["avg_time"] = node_time(node) / parsed["iter"]
+            parsed["node"] = node
+            records.append(parsed)
+    return records
+
+
+def per_element_value(record):
+    if record["outelems"] <= 0:
+        return None
+    return record["avg_time"] / record["outelems"]
+
+
+def growth_value(record):
+    if record["inelems"] <= 0:
+        return None
+    return record["outelems"] / record["inelems"]
+
+
+def build_line_panels(records, group_series_fn, value_fn):
+    panels = {}
+    for record in records:
+        grouped = group_series_fn(record)
+        if grouped is None:
             continue
-
-        benchmark, config, dim, iterations = parsed
-        key = (benchmark, config, dim)
-
-        if key in seen:
-            raise RuntimeError(
-                "duplicate benchmark configuration encountered: "
-                f"{name}"
-            )
-
-        seen.add(key)
-
-        total = inclusive_time(
-            thicket,
-            profile_id,
-            node,
-            time_column,
-            time_cache,
-        )
-
-        results.append(
-            BenchmarkResult(
-                benchmark=benchmark,
-                config=config,
-                dim=dim,
-                iterations=iterations,
-                total_seconds=total,
-                seconds_per_iteration=total / iterations,
-            )
-        )
-
-    if malformed_names:
-        print(
-            "warning: ignored benchmark-like regions with unsupported "
-            "names:"
-        )
-        for name in sorted(set(malformed_names)):
-            print(f"  {name}")
-
-    return results, time_column
+        value = value_fn(record)
+        if value is None:
+            continue
+        panel_title, series_label = grouped
+        panels.setdefault(panel_title, {}).setdefault(series_label, []) \
+              .append((record["dim"], value))
+    return panels
 
 
-def base_grid_points(info, dim):
-    if info.ndims is None:
-        return None
-    return dim ** info.ndims
+def render_series(ax, series, title, y_scale, y_log, series_order=None,
+                  show_legend=True):
+    labels = ordered(series, series_order) if series_order else sorted(series)
+    for label in labels:
+        points = sorted(series[label])
+        dims = [str(dim) for dim, _ in points]
+        ys = [value * y_scale for _, value in points]
+        ax.plot(dims, ys, marker="o", label=label)
+
+    ax.set_title(title.replace("_", " "), fontsize=10)
+    ax.tick_params(labelsize=8)
+    if y_log:
+        ax.set_yscale("log")
+    else:
+        ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+    if show_legend:
+        ax.legend(fontsize=7)
 
 
-def base_grid_cells(info, dim):
-    if info.ndims is None:
-        return None
-    return (dim - 1) ** info.ndims
+def plot_group(panels, path, suptitle, ylabel, y_scale=1.0, y_log=False,
+              series_order=None, stack_vertical=False, legend_label=None):
+    titles = sorted(panels)
+    n = len(titles)
 
+    if stack_vertical:
+        rows = min(MAX_STACKED_ROWS, n)
+        columns = math.ceil(n / rows)
+        panel_width = 6.5
+    else:
+        columns = min(4, n)
+        rows = math.ceil(n / columns)
+        panel_width = 4.2
 
-def format_duration(seconds):
-    if not np.isfinite(seconds):
-        return "n/a"
-
-    seconds = abs(seconds)
-
-    if seconds == 0:
-        return "0"
-
-    if seconds < 1.0e-6:
-        return f"{seconds * 1.0e9:.3g} ns"
-
-    if seconds < 1.0e-3:
-        return f"{seconds * 1.0e6:.3g} µs"
-
-    if seconds < 1.0:
-        return f"{seconds * 1.0e3:.3g} ms"
-
-    return f"{seconds:.3g} s"
-
-
-def format_rate(rate):
-    if not np.isfinite(rate):
-        return "n/a"
-    return f"{rate:.3g}"
-
-
-def iteration_summary(results):
-    values = sorted({result.iterations for result in results})
-
-    if len(values) == 1:
-        return f"{values[0]} measured iterations"
-
-    return (
-        f"{values[0]}-{values[-1]} measured iterations"
+    fig, axes = plt.subplots(
+        rows, columns, figsize=(panel_width * columns, 3.2 * rows), squeeze=False
     )
+    if stack_vertical:
+        axes = [axes[row, col] for col in range(columns) for row in range(rows)]
+    else:
+        axes = list(axes.flatten())
 
+    show_axis_legend = legend_label is None
+    for ax, title in zip(axes, titles):
+        render_series(ax, panels[title], title, y_scale, y_log, series_order,
+                      show_legend=show_axis_legend)
+    for ax in axes[n:]:
+        ax.set_visible(False)
 
-def setup_x_axis(ax, values):
-    values = sorted(set(values))
-    if not values:
-        return
+    fig.suptitle(suptitle, fontsize=13, fontweight="bold", wrap=True)
+    fig.supxlabel("dim (points per axis)")
+    fig.supylabel(ylabel)
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
 
-    if (
-        len(values) > 1
-        and values[0] > 0
-        and values[-1] / values[0] >= 4
-    ):
-        ax.set_xscale("log", base=2)
-
-    ax.set_xticks(values)
-    ax.set_xticklabels([f"{value:,}" for value in values])
-
-
-def make_styles(items, cmap_name):
-    cmap = plt.get_cmap(cmap_name)
-
-    return {
-        item: (
-            cmap(index % cmap.N),
-            MARKERS[index % len(MARKERS)],
-        )
-        for index, item in enumerate(items)
-    }
-
-
-def save_figure(fig, path, dpi):
-    fig.savefig(
-        path,
-        dpi=dpi,
-        bbox_inches="tight",
-    )
+    if legend_label is not None:
+        handles, labels = axes[0].get_legend_handles_labels()
+        fig.legend(handles, labels, loc="center left",
+                  bbox_to_anchor=(1.0, 0.5), fontsize=9)
+        fig.savefig(path, dpi=150, bbox_inches="tight")
+    else:
+        fig.savefig(path, dpi=150)
     plt.close(fig)
     print(f"saved {path}")
 
+    individual_dir = path.parent / "individual" / path.stem
+    individual_dir.mkdir(parents=True, exist_ok=True)
+    for title in titles:
+        fig, ax = plt.subplots(figsize=INDIVIDUAL_FIGSIZE)
+        render_series(ax, panels[title], title, y_scale, y_log, series_order)
+        ax.set_title(f"{suptitle}\n{title.replace('_', ' ')}", fontsize=11)
+        ax.set_xlabel("dim (points per axis)")
+        ax.set_ylabel(ylabel)
+        fig.tight_layout()
+        fig.savefig(individual_dir / f"{title}.png", dpi=150)
+        plt.close(fig)
+    print(f"saved {len(titles)} individual plot(s) to {individual_dir}/")
 
-def plot_benchmark_grid(
-    results,
-    infos,
-    benchmark_names,
-    configs,
-    config_styles,
-    title,
-    path,
-    dpi,
-    x_mode,
-    log_y=False,
-    throughput=False,
-):
-    if not benchmark_names:
+
+def format_plain(value, sig_figs=3):
+    if value == 0:
+        return f"{0:.{sig_figs - 1}f}"
+    magnitude = math.floor(math.log10(abs(value)))
+    decimals = max(0, sig_figs - magnitude - 1)
+    return f"{value:.{decimals}f}"
+
+
+def format_ms_cell(value):
+    return format_plain(value, sig_figs=3)
+
+
+def format_ns_cell(value):
+    if value >= 1:
+        return f"{value:,.0f}"
+    return f"{value:.2f}"
+
+
+def format_growth_cell(value):
+    return f"{format_plain(value, sig_figs=2)}x"
+
+
+def render_heatmap(ax, matrix, rows, cols, title, cell_fmt=format_ms_cell):
+    im = ax.imshow(matrix, cmap="viridis", aspect="auto")
+    ax.set_xticks(range(len(cols)))
+    ax.set_xticklabels(cols, rotation=45, ha="right", fontsize=8)
+    ax.set_yticks(range(len(rows)))
+    ax.set_yticklabels(rows, fontsize=8)
+    ax.set_title(title, fontsize=10)
+
+    midpoint = np.nanmin(matrix) + (np.nanmax(matrix) - np.nanmin(matrix)) / 2 \
+        if np.any(~np.isnan(matrix)) else 0.0
+    for i in range(matrix.shape[0]):
+        for j in range(matrix.shape[1]):
+            value = matrix[i, j]
+            if np.isnan(value):
+                continue
+            color = "white" if value > midpoint else "black"
+            ax.text(j, i, cell_fmt(value), ha="center", va="center",
+                    fontsize=7, color=color)
+    return im
+
+
+def plot_heatmaps(lookup, rows, cols, dims, value_fn, out_dir, filename_prefix,
+                  suptitle, row_label, col_label, cbar_label,
+                  cell_fmt=format_ms_cell):
+    if not rows or not cols or not dims:
         return
 
-    columns = min(3, len(benchmark_names))
-    rows = math.ceil(len(benchmark_names) / columns)
+    width = 4.0 + 0.9 * len(cols)
+    height = 2.0 + 0.3 * len(rows)
 
-    fig, axes = plt.subplots(
-        rows,
-        columns,
-        figsize=(5.2 * columns, 3.8 * rows),
-        squeeze=False,
-    )
-    axes = axes.flatten()
+    for dim in dims:
+        matrix = np.full((len(rows), len(cols)), np.nan)
+        for i, row in enumerate(rows):
+            for j, col in enumerate(cols):
+                record = lookup.get((row, col, dim))
+                value = value_fn(record) if record is not None else None
+                if value is not None:
+                    matrix[i, j] = value
 
-    legend_entries = {}
-
-    for axis_index, benchmark in enumerate(benchmark_names):
-        ax = axes[axis_index]
-        info = infos[benchmark]
-
-        panel_results = [
-            result
-            for result in results
-            if result.benchmark == benchmark
-        ]
-
-        all_x_values = []
-        all_y_values = []
-
-        for config in configs:
-            config_results = sorted(
-                (
-                    result
-                    for result in panel_results
-                    if result.config == config
-                ),
-                key=lambda result: result.dim,
-            )
-
-            if not config_results:
-                continue
-
-            x_values = []
-            y_values = []
-
-            for result in config_results:
-                if x_mode == "points":
-                    x_value = base_grid_points(info, result.dim)
-                elif x_mode == "cells":
-                    x_value = base_grid_cells(info, result.dim)
-                else:
-                    x_value = result.dim
-
-                if x_value is None:
-                    continue
-
-                if throughput:
-                    cell_count = base_grid_cells(info, result.dim)
-                    if (
-                        cell_count is None
-                        or result.seconds_per_iteration <= 0
-                    ):
-                        continue
-
-                    y_value = (
-                        cell_count
-                        / result.seconds_per_iteration
-                        / 1.0e6
-                    )
-                else:
-                    y_value = result.seconds_per_iteration
-
-                x_values.append(x_value)
-                y_values.append(y_value)
-
-            if not x_values:
-                continue
-
-            color, marker = config_styles[config]
-            label = format_config(config)
-
-            line, = ax.plot(
-                x_values,
-                y_values,
-                color=color,
-                marker=marker,
-                linewidth=2,
-                markersize=6,
-                label=label,
-            )
-
-            legend_entries.setdefault(label, line)
-            all_x_values.extend(x_values)
-            all_y_values.extend(y_values)
-
-        setup_x_axis(ax, all_x_values)
-
-        if log_y and all(value > 0 for value in all_y_values):
-            ax.set_yscale("log")
-        else:
-            ax.set_ylim(bottom=0)
-
-        if throughput:
-            ax.yaxis.set_major_formatter(
-                FuncFormatter(
-                    lambda value, _: format_rate(value)
-                )
-            )
-        else:
-            ax.yaxis.set_major_formatter(
-                FuncFormatter(
-                    lambda value, _: format_duration(value)
-                )
-            )
-
-        ax.set_title(info.label, fontsize=12)
-        ax.grid(True, which="both", linestyle=":", alpha=0.45)
-
-    for axis_index in range(len(benchmark_names), len(axes)):
-        axes[axis_index].set_visible(False)
-
-    if x_mode == "points":
-        x_label = "input grid points"
-    elif x_mode == "cells":
-        x_label = "base-grid logical cells"
-    else:
-        x_label = "points per active axis"
-
-    y_label = (
-        "million base-grid logical cells / second"
-        if throughput
-        else "average time / iteration"
-    )
-
-    fig.suptitle(
-        f"{title} ({iteration_summary(results)})",
-        fontsize=17,
-        fontweight="bold",
-    )
-    fig.supxlabel(x_label, fontsize=13)
-    fig.supylabel(y_label, fontsize=13)
-
-    if legend_entries:
-        fig.legend(
-            legend_entries.values(),
-            legend_entries.keys(),
-            loc="center left",
-            bbox_to_anchor=(0.84, 0.5),
-            fontsize=10,
-        )
-        right = 0.82
-    else:
-        right = 0.97
-
-    fig.tight_layout(rect=(0.03, 0.03, right, 0.93))
-    save_figure(fig, path, dpi)
+        fig, ax = plt.subplots(figsize=(width, height))
+        im = render_heatmap(ax, matrix, rows, cols, f"{suptitle}\ndim={dim}",
+                            cell_fmt=cell_fmt)
+        cbar = fig.colorbar(im, ax=ax, label=cbar_label)
+        cbar.ax.ticklabel_format(style="plain", useOffset=False)
+        ax.set_xlabel(col_label)
+        ax.set_ylabel(row_label)
+        fig.tight_layout()
+        path = out_dir / f"{filename_prefix}_dim-{dim}.png"
+        fig.savefig(path, dpi=150)
+        plt.close(fig)
+        print(f"saved {path}")
 
 
-def plot_cross_type_comparison(
-    results,
-    infos,
-    config,
-    element_types,
-    element_styles,
-    out_dir,
-    dpi,
-    log_y,
-):
-    operations = [
-        operation
-        for operation, _ in UNSTRUCTURED_OPERATIONS
-        if any(
-            info.operation == operation
-            and info.element_type in element_types
-            and info.ndims is not None
-            for info in infos.values()
-        )
-    ]
-
-    if not operations:
+def plot_thicket_views(thicket, records, time_column, out_dir):
+    if not hasattr(th.stats, "display_heatmap"):
+        print("seaborn not installed; skipping thicket plots")
         return
 
-    columns = 3
-    rows = math.ceil(len(operations) / columns)
+    mean_column = th.stats.mean(thicket, columns=[time_column])[0]
+    full_statsframe = thicket.statsframe.dataframe
 
-    fig, axes = plt.subplots(
-        rows,
-        columns,
-        figsize=(5.2 * columns, 3.8 * rows),
-        squeeze=False,
-    )
-    axes = axes.flatten()
-
-    legend_entries = {}
-
-    for axis_index, operation in enumerate(operations):
-        ax = axes[axis_index]
-        all_x_values = []
-        all_y_values = []
-
-        for element_type in element_types:
-            matching_infos = [
-                info
-                for info in infos.values()
-                if info.operation == operation
-                and info.element_type == element_type
-                and info.ndims is not None
-            ]
-
-            if not matching_infos:
-                continue
-
-            benchmark = matching_infos[0].name
-            info = matching_infos[0]
-
-            matching_results = sorted(
-                (
-                    result
-                    for result in results
-                    if result.benchmark == benchmark
-                    and result.config == config
-                ),
-                key=lambda result: result.dim,
-            )
-
-            if not matching_results:
-                continue
-
-            x_values = [
-                base_grid_cells(info, result.dim)
-                for result in matching_results
-            ]
-            y_values = [
-                result.seconds_per_iteration
-                for result in matching_results
-            ]
-
-            color, marker = element_styles[element_type]
-
-            line, = ax.plot(
-                x_values,
-                y_values,
-                color=color,
-                marker=marker,
-                linewidth=2,
-                markersize=6,
-                label=element_type,
-            )
-
-            legend_entries.setdefault(element_type, line)
-            all_x_values.extend(x_values)
-            all_y_values.extend(y_values)
-
-        setup_x_axis(ax, all_x_values)
-
-        if log_y and all(value > 0 for value in all_y_values):
-            ax.set_yscale("log")
-        else:
-            ax.set_ylim(bottom=0)
-
-        ax.yaxis.set_major_formatter(
-            FuncFormatter(
-                lambda value, _: format_duration(value)
-            )
-        )
-        ax.set_title(OPERATION_LABELS[operation], fontsize=12)
-        ax.grid(True, which="both", linestyle=":", alpha=0.45)
-
-    for axis_index in range(len(operations), len(axes)):
-        axes[axis_index].set_visible(False)
-
-    fig.suptitle(
-        "Unstructured element-type comparison\n"
-        f"{format_config(config)}",
-        fontsize=17,
-        fontweight="bold",
-    )
-    fig.supxlabel("base-grid logical cells", fontsize=13)
-    fig.supylabel("average time / iteration", fontsize=13)
-
-    if legend_entries:
-        fig.legend(
-            legend_entries.values(),
-            legend_entries.keys(),
-            loc="center left",
-            bbox_to_anchor=(0.84, 0.5),
-            fontsize=10,
-        )
-
-    fig.tight_layout(rect=(0.03, 0.03, 0.82, 0.91))
-
-    path = (
-        out_dir
-        / f"unstructured_cross_type_{config_slug(config)}.png"
-    )
-    save_figure(fig, path, dpi)
-
-
-def plot_heatmaps(
-    results,
-    infos,
-    configs,
-    element_types,
-    out_dir,
-    dpi,
-    all_dimensions,
-):
-    benchmark_by_operation_and_type = {
-        (info.operation, info.element_type): info.name
-        for info in infos.values()
-        if info.family == "unstructured"
-    }
-
-    operations = [
-        operation
-        for operation, _ in UNSTRUCTURED_OPERATIONS
-        if any(
-            (operation, element_type)
-            in benchmark_by_operation_and_type
-            for element_type in element_types
-        )
-    ]
-
-    lookup = {
-        (result.benchmark, result.config, result.dim): result
-        for result in results
-    }
-
-    for config in configs:
-        dimensions = sorted({
-            result.dim
-            for result in results
-            if result.config == config
-            and infos[result.benchmark].family == "unstructured"
-        })
-
-        if not dimensions:
+    for group, nodes in (
+        ("mesh", [r["node"] for r in records if r["name"].startswith("mesh_")]),
+        ("generate", [r["node"] for r in records if not r["name"].startswith("mesh_")]),
+    ):
+        if not nodes:
             continue
+        thicket.statsframe.dataframe = full_statsframe.loc[nodes]
+        plt.figure(figsize=(8, 1.5 + 0.25 * len(nodes)))
+        ax = th.stats.display_heatmap(thicket, columns=[mean_column], annot=True, fmt=".6f")
+        ax.tick_params(axis="y", labelsize=7)
+        if ax.collections and ax.collections[0].colorbar:
+            ax.collections[0].colorbar.ax.ticklabel_format(style="plain", useOffset=False)
+        path = out_dir / f"thicket_{group}_heatmap.png"
+        ax.get_figure().savefig(path, dpi=150, bbox_inches="tight")
+        plt.close(ax.get_figure())
+        print(f"saved {path}")
+    thicket.statsframe.dataframe = full_statsframe
 
-        if not all_dimensions:
-            dimensions = [dimensions[-1]]
-
-        for dim in dimensions:
-            matrix = np.full(
-                (len(operations), len(element_types)),
-                np.nan,
-            )
-
-            for row, operation in enumerate(operations):
-                for column, element_type in enumerate(element_types):
-                    benchmark = benchmark_by_operation_and_type.get(
-                        (operation, element_type)
-                    )
-
-                    if benchmark is None:
-                        continue
-
-                    result = lookup.get(
-                        (benchmark, config, dim)
-                    )
-
-                    if result is not None:
-                        matrix[row, column] = (
-                            result.seconds_per_iteration
-                        )
-
-            positive_values = matrix[
-                np.isfinite(matrix) & (matrix > 0)
-            ]
-
-            if positive_values.size == 0:
-                continue
-
-            minimum = float(np.min(positive_values))
-            maximum = float(np.max(positive_values))
-
-            if minimum == maximum:
-                minimum *= 0.5
-                maximum *= 2.0
-
-            norm = LogNorm(vmin=minimum, vmax=maximum)
-            masked = np.ma.masked_invalid(matrix)
-            masked = np.ma.masked_less_equal(masked, 0)
-
-            cmap = copy(plt.get_cmap("viridis"))
-            cmap.set_bad("#dddddd")
-
-            fig, ax = plt.subplots(
-                figsize=(
-                    max(9, 1.4 * len(element_types)),
-                    max(6, 0.75 * len(operations)),
-                )
-            )
-
-            image = ax.imshow(
-                masked,
-                cmap=cmap,
-                norm=norm,
-                aspect="auto",
-            )
-
-            ax.set_xticks(range(len(element_types)))
-            ax.set_xticklabels(
-                element_types,
-                rotation=35,
-                ha="right",
-            )
-            ax.set_yticks(range(len(operations)))
-            ax.set_yticklabels([
-                OPERATION_LABELS[operation]
-                for operation in operations
-            ])
-
-            for row in range(len(operations)):
-                for column in range(len(element_types)):
-                    value = matrix[row, column]
-
-                    if not np.isfinite(value) or value <= 0:
-                        text = "n/a"
-                        color = "#666666"
-                    else:
-                        text = format_duration(value)
-                        color = (
-                            "white"
-                            if norm(value) > 0.55
-                            else "black"
-                        )
-
-                    ax.text(
-                        column,
-                        row,
-                        text,
-                        ha="center",
-                        va="center",
-                        fontsize=8,
-                        color=color,
-                    )
-
-            colorbar = fig.colorbar(image, ax=ax)
-            colorbar.set_label("average time / iteration")
-            colorbar.ax.yaxis.set_major_formatter(
-                FuncFormatter(
-                    lambda value, _: format_duration(value)
-                )
-            )
-
-            ax.set_title(
-                "Unstructured benchmark summary\n"
-                f"N={dim}, {format_config(config)}",
-                fontsize=15,
-                fontweight="bold",
-            )
-
-            fig.tight_layout()
-
-            path = (
-                out_dir
-                / (
-                    "unstructured_heatmap_"
-                    f"{config_slug(config)}_dim-{dim}.png"
-                )
-            )
-            save_figure(fig, path, dpi)
-
-
-def write_csv(results, infos, path):
-    fields = [
-        "benchmark",
-        "family",
-        "operation",
-        "element_type",
-        "topological_dimensions",
-        "dim",
-        "grid_points",
-        "base_grid_logical_cells",
-        "backend",
-        "source_location",
-        "execution_location",
-        "output_location",
-        "sync_strategy",
-        "threads",
-        "iterations",
-        "total_measured_seconds",
-        "seconds_per_iteration",
-        "base_grid_logical_cells_per_second",
-    ]
-
-    with path.open("w", newline="") as stream:
-        writer = csv.DictWriter(stream, fieldnames=fields)
-        writer.writeheader()
-
-        for result in sorted(
-            results,
-            key=lambda item: (
-                item.benchmark,
-                config_sort_key(item.config),
-                item.dim,
-            ),
-        ):
-            info = infos[result.benchmark]
-            points = base_grid_points(info, result.dim)
-            cells = base_grid_cells(info, result.dim)
-
-            throughput = ""
-            if (
-                cells is not None
-                and result.seconds_per_iteration > 0
-            ):
-                throughput = (
-                    cells / result.seconds_per_iteration
-                )
-
-            writer.writerow({
-                "benchmark": result.benchmark,
-                "family": info.family,
-                "operation": info.operation or "",
-                "element_type": info.element_type or "",
-                "topological_dimensions": (
-                    info.ndims if info.ndims is not None else ""
-                ),
-                "dim": result.dim,
-                "grid_points": points if points is not None else "",
-                "base_grid_logical_cells": (
-                    cells if cells is not None else ""
-                ),
-                "backend": result.config.backend or "",
-                "source_location": result.config.src,
-                "execution_location": result.config.execution,
-                "output_location": result.config.out,
-                "sync_strategy": result.config.sync or "",
-                "threads": (
-                    result.config.threads
-                    if result.config.threads is not None
-                    else ""
-                ),
-                "iterations": result.iterations,
-                "total_measured_seconds": result.total_seconds,
-                "seconds_per_iteration": (
-                    result.seconds_per_iteration
-                ),
-                "base_grid_logical_cells_per_second": throughput,
-            })
-
-    print(f"saved {path}")
+    sample_nodes = [r["node"] for r in records if r["name"].startswith("mesh_")]
+    if sample_nodes:
+        ax = th.stats.display_boxplot(thicket, nodes=sample_nodes, columns=[time_column])
+        ax.tick_params(axis="x", rotation=90, labelsize=6)
+        ax.ticklabel_format(axis="y", style="plain", useOffset=False)
+        path = out_dir / "thicket_boxplot.png"
+        ax.get_figure().savefig(path, dpi=150, bbox_inches="tight")
+        plt.close(ax.get_figure())
+        print(f"saved {path}")
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description=(
-            "Plot current Conduit mesh transform benchmark results."
-        )
-    )
-    parser.add_argument(
-        "cali_file",
-        nargs="?",
-        help="path to a current benchmark .cali file",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        help="output directory, defaults to the Caliper filename stem",
-    )
-    parser.add_argument(
-        "--dpi",
-        type=int,
-        default=160,
-        help="PNG resolution, default: 160",
-    )
-    parser.add_argument(
-        "--log-y",
-        action="store_true",
-        help="use logarithmic scaling for runtime plots",
-    )
-    parser.add_argument(
-        "--throughput",
-        action="store_true",
-        help=(
-            "also generate base-grid logical-cell throughput plots"
-        ),
-    )
-    parser.add_argument(
-        "--no-cross-type",
-        action="store_true",
-        help="skip cross-element-type comparison figures",
-    )
-    parser.add_argument(
-        "--no-heatmaps",
-        action="store_true",
-        help="skip unstructured summary heatmaps",
-    )
-    parser.add_argument(
-        "--all-heatmaps",
-        action="store_true",
-        help=(
-            "generate heatmaps for every dimension instead of only "
-            "the largest"
-        ),
-    )
-
-    args = parser.parse_args()
-
-    cali_file = (
-        Path(args.cali_file)
-        if args.cali_file
-        else find_cali_file()
-    )
-
+    cali_file = Path(sys.argv[1]) if len(sys.argv) > 1 else find_cali_file()
     if not cali_file.exists():
         sys.exit(f"no such file: {cali_file}")
 
     try:
-        thicket = th.Thicket.from_caliperreader(
-            str(cali_file)
-        )
-        results, time_column = collect_results(thicket)
+        thicket = th.Thicket.from_caliperreader(str(cali_file))
     except ReaderError as error:
         sys.exit(f"failed to read {cali_file}: {error}")
-    except RuntimeError as error:
-        sys.exit(str(error))
 
-    if not results:
-        sys.exit(
-            f"no current mesh benchmark regions found in {cali_file}"
-        )
+    records = collect(thicket)
+    if not records:
+        sys.exit(f"no benchmark regions found in {cali_file}")
 
-    benchmark_names = sorted({
-        result.benchmark for result in results
-    })
-    infos = {
-        name: classify_benchmark(name)
-        for name in benchmark_names
-    }
+    iters = sorted({r["iter"] for r in records})
+    iters_label = f"n={iters[0]}" if len(iters) == 1 else f"n={iters[0]}-{iters[-1]}"
 
-    configs = sorted(
-        {result.config for result in results},
-        key=config_sort_key,
+    out_dir = cali_file.with_suffix("")
+    out_dir.mkdir(exist_ok=True)
+
+    mesh_records = [r for r in records if r["name"].startswith("mesh_")]
+    generate_records = [r for r in records if not r["name"].startswith("mesh_")]
+
+    def generate_group(record):
+        operation, shape = split_generate_name(record["name"])
+        return (operation, shape) if shape else None
+
+    mesh_time_panels = build_line_panels(
+        mesh_records, lambda r: (r["name"], MESH_SERIES_LABEL), lambda r: r["avg_time"]
     )
-    dimensions = sorted({result.dim for result in results})
-    element_types = ordered_element_types(infos)
-
-    out_dir = (
-        args.output_dir
-        if args.output_dir is not None
-        else cali_file.with_suffix("")
+    generate_time_panels = build_line_panels(
+        generate_records, generate_group, lambda r: r["avg_time"]
     )
-    out_dir.mkdir(parents=True, exist_ok=True)
+    if mesh_time_panels:
+        plot_group(
+            mesh_time_panels, out_dir / "mesh_scaling.png",
+            suptitle=f"Mesh conversion benchmark: avg time per iteration ({iters_label})",
+            ylabel="avg time / iteration (ms)", y_scale=1e3,
+            legend_label=MESH_SERIES_LABEL,
+        )
+    if generate_time_panels:
+        plot_group(
+            generate_time_panels, out_dir / "generate_scaling.png",
+            suptitle=f"Generate-function benchmark: avg time per iteration ({iters_label})",
+            ylabel="avg time / iteration (ms)", y_scale=1e3,
+            series_order=SHAPE_ORDER,
+        )
 
-    print(f"time column: {time_column}")
-    print(f"benchmark names: {len(benchmark_names)}")
-    print(f"configurations: {len(configs)}")
-    print(f"dimension sizes: {dimensions}")
-    print(
-        "element types: "
-        + (", ".join(element_types) if element_types else "none")
+    mesh_per_elem_panels = build_line_panels(
+        mesh_records, lambda r: (r["name"], MESH_SERIES_LABEL), per_element_value
     )
-
-    if max(dimensions) <= 4:
-        print(
-            "warning: all dimensions are <= 4; these runs are useful "
-            "for CI validation but are likely dominated by fixed overhead"
-        )
-
-    write_csv(
-        results,
-        infos,
-        out_dir / "benchmark_results.csv",
+    generate_per_elem_panels = build_line_panels(
+        generate_records, generate_group, per_element_value
     )
-
-    config_styles = make_styles(configs, "tab20")
-    element_styles = make_styles(element_types, "tab10")
-
-    plotted = set()
-
-    mesh_names = [
-        name
-        for name, _ in MESH_BENCHMARKS
-        if name in infos
-    ]
-    mesh_names.extend(sorted(
-        name
-        for name, info in infos.items()
-        if info.family == "mesh"
-        and name not in mesh_names
-    ))
-
-    if mesh_names:
-        plot_benchmark_grid(
-            results,
-            infos,
-            mesh_names,
-            configs,
-            config_styles,
-            "Whole-mesh conversions",
-            out_dir / "mesh_scaling.png",
-            args.dpi,
-            x_mode="points",
-            log_y=args.log_y,
+    if mesh_per_elem_panels:
+        plot_group(
+            mesh_per_elem_panels, out_dir / "mesh_scaling_per_element.png",
+            suptitle=f"Mesh conversion benchmark: avg time per element ({iters_label})",
+            ylabel="avg time / element (ns)", y_scale=1e9, y_log=True,
+            stack_vertical=True, legend_label=MESH_SERIES_LABEL,
         )
-        plotted.update(mesh_names)
-
-    for element_type in element_types:
-        type_names = [
-            info.name
-            for info in infos.values()
-            if info.family == "unstructured"
-            and info.element_type == element_type
-        ]
-        type_names.sort(
-            key=lambda name: (
-                OPERATION_ORDER.get(
-                    infos[name].operation,
-                    len(OPERATION_ORDER),
-                ),
-                name,
-            )
+    if generate_per_elem_panels:
+        plot_group(
+            generate_per_elem_panels, out_dir / "generate_scaling_per_element.png",
+            suptitle=f"Generate-function benchmark: avg time per element ({iters_label})",
+            ylabel="avg time / element (ns)", y_scale=1e9, y_log=True,
+            series_order=SHAPE_ORDER, stack_vertical=True,
         )
 
-        if not type_names:
-            continue
-
-        use_logical_cells = all(
-            infos[name].ndims is not None
-            for name in type_names
-        )
-        x_mode = "cells" if use_logical_cells else "dim"
-
-        plot_benchmark_grid(
-            results,
-            infos,
-            type_names,
-            configs,
-            config_styles,
-            f"Unstructured {element_type} transforms",
-            out_dir
-            / f"unstructured_{safe_file_part(element_type)}_scaling.png",
-            args.dpi,
-            x_mode=x_mode,
-            log_y=args.log_y,
-        )
-
-        if args.throughput and use_logical_cells:
-            plot_benchmark_grid(
-                results,
-                infos,
-                type_names,
-                configs,
-                config_styles,
-                f"Unstructured {element_type} throughput",
-                out_dir
-                / (
-                    "unstructured_"
-                    f"{safe_file_part(element_type)}_throughput.png"
-                ),
-                args.dpi,
-                x_mode="cells",
-                log_y=args.log_y,
-                throughput=True,
-            )
-
-        plotted.update(type_names)
-
-    other_names = sorted(set(benchmark_names) - plotted)
-    if other_names:
-        print(
-            "warning: plotting unclassified benchmarks in "
-            "other_scaling.png:"
-        )
-        for name in other_names:
-            print(f"  {name}")
-
-        plot_benchmark_grid(
-            results,
-            infos,
-            other_names,
-            configs,
-            config_styles,
-            "Other discovered benchmarks",
-            out_dir / "other_scaling.png",
-            args.dpi,
-            x_mode="dim",
-            log_y=args.log_y,
-        )
-        plotted.update(other_names)
-
-    if set(benchmark_names) != plotted:
-        missing = sorted(set(benchmark_names) - plotted)
-        sys.exit(
-            "internal error: benchmarks were not plotted: "
-            + ", ".join(missing)
-        )
-
-    if not args.no_cross_type:
-        for config in configs:
-            plot_cross_type_comparison(
-                results,
-                infos,
-                config,
-                element_types,
-                element_styles,
-                out_dir,
-                args.dpi,
-                args.log_y,
-            )
-
-    if not args.no_heatmaps:
+    mesh_lookup = {}
+    for r in mesh_records:
+        convert = split_mesh_convert(r["name"])
+        if convert:
+            mesh_lookup[(convert[0], convert[1], r["dim"])] = r
+    if mesh_lookup:
+        srcs = ordered({k[0] for k in mesh_lookup}, MESH_SRC_ORDER)
+        dsts = sorted({k[1] for k in mesh_lookup})
+        dims = sorted({k[2] for k in mesh_lookup})
         plot_heatmaps(
-            results,
-            infos,
-            configs,
-            element_types,
-            out_dir,
-            args.dpi,
-            args.all_heatmaps,
+            mesh_lookup, srcs, dsts, dims,
+            value_fn=lambda r: r["avg_time"] * 1e3,
+            out_dir=out_dir, filename_prefix="mesh_conversion_heatmap",
+            suptitle=f"Mesh conversion avg time per iteration, ms ({iters_label})",
+            row_label="source representation", col_label="target representation",
+            cbar_label="avg time / iteration (ms)",
+        )
+        plot_heatmaps(
+            mesh_lookup, srcs, dsts, dims,
+            value_fn=lambda r: per_element_value(r) * 1e9 if per_element_value(r) else None,
+            out_dir=out_dir, filename_prefix="mesh_conversion_heatmap_per_element",
+            suptitle=f"Mesh conversion avg time per element, ns ({iters_label})",
+            row_label="source representation", col_label="target representation",
+            cbar_label="avg time / element (ns)", cell_fmt=format_ns_cell,
         )
 
-    print(f"wrote results to {out_dir}/")
+    shape_lookup = {}
+    for r in generate_records:
+        operation, shape = split_generate_name(r["name"])
+        if shape:
+            shape_lookup[(operation, shape, r["dim"])] = r
+    if shape_lookup:
+        operations = ordered({k[0] for k in shape_lookup}, OPERATIONS)
+        shapes = ordered({k[1] for k in shape_lookup}, SHAPE_ORDER)
+        dims = sorted({k[2] for k in shape_lookup})
+        plot_heatmaps(
+            shape_lookup, operations, shapes, dims,
+            value_fn=lambda r: r["avg_time"] * 1e3,
+            out_dir=out_dir, filename_prefix="generate_heatmap",
+            suptitle=f"Generate-function avg time per iteration, ms ({iters_label})",
+            row_label="operation", col_label="element shape",
+            cbar_label="avg time / iteration (ms)",
+        )
+        plot_heatmaps(
+            shape_lookup, operations, shapes, dims,
+            value_fn=lambda r: per_element_value(r) * 1e9 if per_element_value(r) else None,
+            out_dir=out_dir, filename_prefix="generate_heatmap_per_element",
+            suptitle=f"Generate-function avg time per element, ns ({iters_label})",
+            row_label="operation", col_label="element shape",
+            cbar_label="avg time / element (ns)", cell_fmt=format_ns_cell,
+        )
+        plot_heatmaps(
+            shape_lookup, operations, shapes, dims,
+            value_fn=growth_value,
+            out_dir=out_dir, filename_prefix="generate_growth_heatmap",
+            suptitle=f"Generate-function output/input element ratio ({iters_label})",
+            row_label="operation", col_label="element shape",
+            cbar_label="output elements / input elements", cell_fmt=format_growth_cell,
+        )
+
+    plot_thicket_views(thicket, records, find_time_column(thicket.dataframe), out_dir)
+
+    print(f"wrote plots to {out_dir}/")
 
 
 if __name__ == "__main__":

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -5,6 +5,7 @@
 import argparse
 import re
 import sys
+from collections import namedtuple
 from pathlib import Path
 
 import matplotlib
@@ -41,9 +42,10 @@ UNSTRUCTURED_GENERATE_FUNCTIONS = [
 ]
 
 UNSTRUCTURED_GENERATE_ELEM_TYPES = ["quads", "hexs"]
+UNSTRUCTURED_GENERATE_ELEM_NDIMS = {"quads": 2, "hexs": 3}
 
 UNSTRUCTURED_GENERATE_CONVERSIONS = [
-    f"{fn}_{elem}"
+    f"unstructured_{fn}_{elem}"
     for fn in UNSTRUCTURED_GENERATE_FUNCTIONS
     for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
 ]
@@ -58,7 +60,7 @@ CONVERSION_LABELS = {
     "topology_rectilinear_to_unstructured": "rect→unstruct",
     "topology_structured_to_unstructured": "struct→unstruct",
     **{
-        f"{fn}_{elem}": f"{fn} ({elem})"
+        f"unstructured_{fn}_{elem}": f"{fn} ({elem})"
         for fn in UNSTRUCTURED_GENERATE_FUNCTIONS
         for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
     },
@@ -69,7 +71,7 @@ CONVERSION_GROUPS = [
     ("topology", TOPOLOGY_CONVERSIONS),
 ] + [
     (f"unstructured_generate_{elem}",
-     [f"{fn}_{elem}" for fn in UNSTRUCTURED_GENERATE_FUNCTIONS])
+     [f"unstructured_{fn}_{elem}" for fn in UNSTRUCTURED_GENERATE_FUNCTIONS])
     for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
 ]
 
@@ -78,12 +80,7 @@ END_TO_END_GROUP_PANELS = [
     for group_name, group_conversions in CONVERSION_GROUPS
 ]
 
-COMPONENT_METRICS = [
-    ("use_with", "use_with"),
-    ("forall", "forall"),
-    ("data movement", "data_movement"),
-    ("other processing", "other_processing"),
-]
+COMPONENT_METRICS = ["use_with", "forall", "data_movement", "other_processing"]
 
 CMAP = plt.get_cmap("tab10")
 MARKERS = ["o", "s", "^", "D", "v", "P", "X", "*"]
@@ -93,18 +90,39 @@ CFG_ABBREVIATIONS = {
     "device": "dev",
 }
 
+# A benchmark execution configuration: which backend ran it, plus where the
+# source data lives, where execution happens, and where the output lives.
+Cfg = namedtuple("Cfg", ["backend", "src", "exec", "out"])
+
 
 def format_cfg_label(cfg):
-    backend, src, exec_, out = cfg
-
-    if backend is None:
+    if cfg.backend is None:
         return "serial - before device support"
 
-    backend = CFG_ABBREVIATIONS.get(backend, backend)
-    src = CFG_ABBREVIATIONS.get(src, src)
-    exec_ = CFG_ABBREVIATIONS.get(exec_, exec_)
-    out = CFG_ABBREVIATIONS.get(out, out)
+    backend = CFG_ABBREVIATIONS.get(cfg.backend, cfg.backend)
+    src = CFG_ABBREVIATIONS.get(cfg.src, cfg.src)
+    exec_ = CFG_ABBREVIATIONS.get(cfg.exec, cfg.exec)
+    out = CFG_ABBREVIATIONS.get(cfg.out, cfg.out)
     return f"{backend}: {src}→{exec_}→{out}"
+
+
+def per_entity_kind(conv_name):
+    # Coordset transform cost scales with the number of points; topology
+    # transform cost scales with the number of elements.
+    return "point" if conv_name.startswith("coordset_") else "element"
+
+
+def per_entity_count(conv_name, dim):
+    # braid takes points per axis, so a mesh with `dim` points per axis has
+    # dim**k points and (dim - 1)**k elements, where k is the topological
+    # dimension of the mesh.
+    if per_entity_kind(conv_name) == "point":
+        return dim ** 3
+    for elem, ndims in UNSTRUCTURED_GENERATE_ELEM_NDIMS.items():
+        if conv_name.endswith(f"_{elem}"):
+            return max(dim - 1, 1) ** ndims
+    # topology_* conversions run on full 3D braid meshes
+    return max(dim - 1, 1) ** 3
 
 
 def format_range_label(prefix, values):
@@ -125,12 +143,6 @@ def parse_config_name(name):
         return None
     conv_name, dim_str, rest = match.groups()
 
-    backend = None
-    conv_parts = conv_name.split("_")
-    if len(conv_parts) > 1 and conv_parts[-1] in KNOWN_BACKENDS:
-        backend = conv_parts[-1]
-        conv_name = "_".join(conv_parts[:-1])
-
     values = {}
     for field in rest.split("_"):
         if "-" not in field:
@@ -139,8 +151,10 @@ def parse_config_name(name):
         values[key] = value
 
     required = {"iter"}
-    optional = {"src", "exec", "out", "sync", "threads"}
+    optional = {"backend", "src", "exec", "out", "sync", "threads"}
     if not (required <= set(values) <= required | optional):
+        return None
+    if "backend" in values and values["backend"] not in KNOWN_BACKENDS:
         return None
     if "src" in values and values["src"] not in ("host", "device"):
         return None
@@ -158,7 +172,10 @@ def parse_config_name(name):
             return None
         threads = int(values["threads"])
 
-    cfg = (backend, values.get("src"), values.get("exec"), values.get("out"))
+    cfg = Cfg(values.get("backend"),
+              values.get("src"),
+              values.get("exec"),
+              values.get("out"))
     sync_strategy = values.get("sync")
     return conv_name, cfg, int(dim_str), int(values["iter"]), threads, sync_strategy
 
@@ -187,6 +204,9 @@ def find_cali_file():
         + (f" ({skipped} other .cali file(s) skipped)" if skipped else "")
         + ":"
     )
+    for f in cali_files:
+        print(f"  {f.name} ({parse_timestamp(f)})")
+    print(f"using most recent: {cali_files[0].name}")
     return cali_files[0]
 
 
@@ -230,12 +250,11 @@ def collect_data(thicket):
         if parsed is None:
             continue
         conv_name, cfg, dim, iters, threads, sync_strategy = parsed
-        backend, _, _, _ = cfg
 
         dims_seen.add(dim)
         syncs_seen.add(sync_strategy)
-        if backend is not None:
-            backends_seen.add(backend)
+        if cfg.backend is not None:
+            backends_seen.add(cfg.backend)
 
         totals = {name: 0.0 for name in LEAF_METRIC_NAMES}
         accumulate_leaf_metrics(thicket, profile_id, cfg_node, totals)
@@ -258,7 +277,7 @@ def collect_data(thicket):
     return data, sorted(dims_seen), backends_seen, syncs_seen
 
 
-def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_label, per_element=False):
+def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_label, per_entity=False):
     n = len(panels)
     fig_width = 10
 
@@ -274,8 +293,8 @@ def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_labe
             for d in dims:
                 v = data.get((cfg, conv_name, d), {}).get(metric, np.nan)
                 if not np.isnan(v):
-                    if per_element:
-                        v = v / (d ** 3)  # dim is per axis, so the mesh has d**3 elements
+                    if per_entity:
+                        v = v / per_entity_count(conv_name, d)
                     v = v * scale
                 ys.append(v)
             raw_ys_by_cfg.append(ys)
@@ -297,7 +316,7 @@ def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_labe
                 dims, ys,
                 label=format_cfg_label(cfg),
                 color=CMAP(j % 10), marker=MARKERS[j % len(MARKERS)],
-                linestyle="-" if cfg[2] == "device" else "--",
+                linestyle="-" if cfg.exec == "device" else "--",
                 markersize=7, linewidth=2.2, alpha=0.9,
             )
 
@@ -309,8 +328,8 @@ def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_labe
         ax.tick_params(axis="both", which="major", labelsize=13)
 
         positive_values = [v for v in panel_values if v > 0]
-        if per_element and positive_values:
-            # Per-element cost spans many orders of magnitude, so use
+        if per_entity and positive_values:
+            # Per-entity cost spans many orders of magnitude, so use
             # a log-scale y-axis
             ax.set_yscale("log")
         else:
@@ -339,65 +358,58 @@ def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_labe
     print(f"saved {path}")
 
 
-def generate_plots(data, dims, cfg_keys, iters_label, out_dir, suffix="", include_components=True):
-    ylabel = "avg time / iter"
+def generate_plots(data, dims, cfg_keys, iters_label, out_dir, suffix="",
+                   include_components=True, per_entity=False):
+    # Per-entity plots normalize each conversion by its point/element count;
+    # every group is homogeneous in kind, so label each figure accordingly.
+    file_suffix = f"_per_entity{suffix}" if per_entity else suffix
 
     for group_name, group_panels in END_TO_END_GROUP_PANELS:
+        if per_entity:
+            kind = per_entity_kind(group_panels[0][1])
+            suptitle = f"avg {group_name} conversion time per {kind} vs data size"
+            ylabel = f"avg time / {kind}"
+        else:
+            suptitle = f"avg {group_name} conversion time vs data size"
+            ylabel = "avg time / iter"
         plot_panels(
             data, dims, cfg_keys,
             group_panels,
-            f"avg {group_name} conversion time vs data size",
-            out_dir / f"end_to_end_combined_{group_name}{suffix}.png",
+            suptitle,
+            out_dir / f"end_to_end_combined_{group_name}{file_suffix}.png",
             ylabel,
             iters_label,
+            per_entity=per_entity,
         )
 
     for conv in CONVERSIONS:
+        if per_entity:
+            kind = per_entity_kind(conv)
+            suptitle = f"{CONVERSION_LABELS[conv]} avg end-to-end time per {kind} vs data size"
+            ylabel = f"avg time / {kind}"
+        else:
+            suptitle = f"{CONVERSION_LABELS[conv]} avg end-to-end conversion time vs data size"
+            ylabel = "avg time / iter"
         plot_panels(
             data, dims, cfg_keys,
             [(CONVERSION_LABELS[conv], conv, "end_to_end")],
-            f"{CONVERSION_LABELS[conv]} avg end-to-end conversion time vs data size",
-            out_dir / f"end_to_end_{conv}{suffix}.png",
+            suptitle,
+            out_dir / f"end_to_end_{conv}{file_suffix}.png",
             ylabel,
             iters_label,
+            per_entity=per_entity,
         )
 
-        if include_components:
-            component_panels = [(title, conv, metric) for title, metric in COMPONENT_METRICS]
+        if include_components and not per_entity:
+            component_panels = [(metric, conv, metric) for metric in COMPONENT_METRICS]
             plot_panels(
                 data, dims, cfg_keys,
                 component_panels,
                 f"{CONVERSION_LABELS[conv]} components vs data size",
                 out_dir / f"components_{conv}{suffix}.png",
-                ylabel,
+                "avg time / iter",
                 iters_label,
             )
-
-
-def generate_per_element_plots(data, dims, cfg_keys, iters_label, out_dir, suffix=""):
-    ylabel = "avg time / element"
-
-    for group_name, group_panels in END_TO_END_GROUP_PANELS:
-        plot_panels(
-            data, dims, cfg_keys,
-            group_panels,
-            f"avg {group_name} time per element vs data size",
-            out_dir / f"end_to_end_combined_{group_name}_per_element{suffix}.png",
-            ylabel,
-            iters_label,
-            per_element=True,
-        )
-
-    for conv in CONVERSIONS:
-        plot_panels(
-            data, dims, cfg_keys,
-            [(CONVERSION_LABELS[conv], conv, "end_to_end")],
-            f"{CONVERSION_LABELS[conv]} avg end-to-end time per element vs data size",
-            out_dir / f"end_to_end_{conv}_per_element{suffix}.png",
-            ylabel,
-            iters_label,
-            per_element=True,
-        )
 
 
 def main():
@@ -448,14 +460,16 @@ def main():
             suffix=sync_suffix,
             include_components=not serial_only,
         )
-        generate_per_element_plots(
+        generate_plots(
             sync_data, dims, cfg_keys, iters_label, out_dir,
             suffix=sync_suffix,
+            include_components=False,
+            per_entity=True,
         )
 
         if not serial_only:
             for backend in sorted(backends_seen):
-                backend_keys = [cfg for cfg in cfg_keys if cfg[0] == backend]
+                backend_keys = [cfg for cfg in cfg_keys if cfg.backend == backend]
                 if backend_keys:
                     generate_plots(
                         sync_data, dims, backend_keys, iters_label, out_dir,

--- a/src/tests/blueprint/plot_benchmark_output.py
+++ b/src/tests/blueprint/plot_benchmark_output.py
@@ -3,10 +3,14 @@
 # other details. No copyright assignment is required to contribute to Conduit.
 
 import argparse
+import csv
+import math
 import re
 import sys
-from collections import namedtuple
+from copy import copy
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import matplotlib
 
@@ -15,469 +19,1395 @@ import matplotlib.pyplot as plt
 import numpy as np
 import thicket as th
 from caliperreader.readererror import ReaderError
-from matplotlib.ticker import FormatStrFormatter
+from matplotlib.colors import LogNorm
+from matplotlib.ticker import FuncFormatter
 
-COORDSET_CONVERSIONS = [
-    "coordset_rectilinear_to_explicit",
-    "coordset_uniform_to_explicit",
-    "coordset_uniform_to_rectilinear",
+
+MESH_BENCHMARKS = [
+    ("mesh_uniform_to_rectilinear", "uniform → rectilinear"),
+    ("mesh_uniform_to_structured", "uniform → structured"),
+    ("mesh_uniform_to_unstructured", "uniform → unstructured"),
+    ("mesh_rectilinear_to_structured", "rectilinear → structured"),
+    ("mesh_rectilinear_to_unstructured", "rectilinear → unstructured"),
+    ("mesh_structured_to_unstructured", "structured → unstructured"),
 ]
 
-TOPOLOGY_CONVERSIONS = [
-    "topology_uniform_to_unstructured",
-    "topology_rectilinear_to_unstructured",
-    "topology_structured_to_unstructured",
+MESH_LABELS = dict(MESH_BENCHMARKS)
+
+UNSTRUCTURED_OPERATIONS = [
+    ("to_polytopal", "to polytopal"),
+    ("generate_points", "generate points"),
+    ("generate_lines", "generate lines"),
+    ("generate_faces", "generate faces"),
+    ("generate_centroids", "generate centroids"),
+    ("generate_sides", "generate sides"),
+    ("generate_corners", "generate corners"),
+    ("generate_offsets", "generate offsets"),
+    ("generate_offsets_inline", "generate offsets inline"),
 ]
 
-UNSTRUCTURED_GENERATE_FUNCTIONS = [
-    "to_polytopal",
-    "generate_offsets",
-    "generate_offsets_inline",
-    "generate_points",
-    "generate_lines",
-    "generate_faces",
-    "generate_centroids",
-    "generate_sides",
-    "generate_corners",
-]
-
-UNSTRUCTURED_GENERATE_ELEM_TYPES = ["quads", "hexs"]
-UNSTRUCTURED_GENERATE_ELEM_NDIMS = {"quads": 2, "hexs": 3}
-
-UNSTRUCTURED_GENERATE_CONVERSIONS = [
-    f"unstructured_{fn}_{elem}"
-    for fn in UNSTRUCTURED_GENERATE_FUNCTIONS
-    for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
-]
-
-CONVERSIONS = COORDSET_CONVERSIONS + TOPOLOGY_CONVERSIONS + UNSTRUCTURED_GENERATE_CONVERSIONS
-
-CONVERSION_LABELS = {
-    "coordset_rectilinear_to_explicit": "rect→explicit",
-    "coordset_uniform_to_explicit": "uniform→explicit",
-    "coordset_uniform_to_rectilinear": "uniform→rect",
-    "topology_uniform_to_unstructured": "uniform→unstruct",
-    "topology_rectilinear_to_unstructured": "rect→unstruct",
-    "topology_structured_to_unstructured": "struct→unstruct",
-    **{
-        f"unstructured_{fn}_{elem}": f"{fn} ({elem})"
-        for fn in UNSTRUCTURED_GENERATE_FUNCTIONS
-        for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
-    },
+OPERATION_LABELS = dict(UNSTRUCTURED_OPERATIONS)
+OPERATION_ORDER = {
+    operation: index
+    for index, (operation, _) in enumerate(UNSTRUCTURED_OPERATIONS)
 }
 
-CONVERSION_GROUPS = [
-    ("coordset", COORDSET_CONVERSIONS),
-    ("topology", TOPOLOGY_CONVERSIONS),
-] + [
-    (f"unstructured_generate_{elem}",
-     [f"unstructured_{fn}_{elem}" for fn in UNSTRUCTURED_GENERATE_FUNCTIONS])
-    for elem in UNSTRUCTURED_GENERATE_ELEM_TYPES
+PREFERRED_ELEMENT_TYPE_ORDER = [
+    "tris",
+    "quads",
+    "tets",
+    "hexs",
+    "wedges",
+    "pyramids",
+    "mixed_2d",
+    "mixed",
 ]
 
-END_TO_END_GROUP_PANELS = [
-    (group_name, [(CONVERSION_LABELS[c], c, "end_to_end") for c in group_conversions])
-    for group_name, group_conversions in CONVERSION_GROUPS
-]
+ELEMENT_TYPE_NDIMS = {
+    "tris": 2,
+    "quads": 2,
+    "polygonal": 2,
+    "mixed_2d": 2,
+    "tets": 3,
+    "hexs": 3,
+    "wedges": 3,
+    "pyramids": 3,
+    "polyhedral": 3,
+    "mixed": 3,
+}
 
-COMPONENT_METRICS = ["use_with", "forall", "data_movement", "other_processing"]
-
-CMAP = plt.get_cmap("tab10")
 MARKERS = ["o", "s", "^", "D", "v", "P", "X", "*"]
 
-CFG_ABBREVIATIONS = {
-    "openmp": "omp",
-    "device": "dev",
-}
+CONFIG_NAME_RE = re.compile(
+    r"^(?P<benchmark>(?:mesh|unstructured)_.+?)"
+    r"_dim-(?P<dim>\d+)"
+    r"_(?P<metadata>.+)$"
+)
 
-# A benchmark execution configuration: which backend ran it, plus where the
-# source data lives, where execution happens, and where the output lives.
-Cfg = namedtuple("Cfg", ["backend", "src", "exec", "out"])
+TIMESTAMP_RE = re.compile(r"^\d{8}_\d{6}$")
 
-
-def format_cfg_label(cfg):
-    if cfg.backend is None:
-        return "serial - before device support"
-
-    backend = CFG_ABBREVIATIONS.get(cfg.backend, cfg.backend)
-    src = CFG_ABBREVIATIONS.get(cfg.src, cfg.src)
-    exec_ = CFG_ABBREVIATIONS.get(cfg.exec, cfg.exec)
-    out = CFG_ABBREVIATIONS.get(cfg.out, cfg.out)
-    return f"{backend}: {src}→{exec_}→{out}"
+REQUIRED_METADATA_FIELDS = {"src", "exec", "out", "iter"}
+OPTIONAL_METADATA_FIELDS = {"backend", "sync", "threads"}
+ALLOWED_METADATA_FIELDS = (
+    REQUIRED_METADATA_FIELDS | OPTIONAL_METADATA_FIELDS
+)
 
 
-def per_entity_kind(conv_name):
-    # Coordset transform cost scales with the number of points; topology
-    # transform cost scales with the number of elements.
-    return "point" if conv_name.startswith("coordset_") else "element"
+@dataclass(frozen=True)
+class Config:
+    backend: Optional[str]
+    src: str
+    execution: str
+    out: str
+    sync: Optional[str]
+    threads: Optional[int]
 
 
-def per_entity_count(conv_name, dim):
-    # braid takes points per axis, so a mesh with `dim` points per axis has
-    # dim**k points and (dim - 1)**k elements, where k is the topological
-    # dimension of the mesh.
-    if per_entity_kind(conv_name) == "point":
-        return dim ** 3
-    for elem, ndims in UNSTRUCTURED_GENERATE_ELEM_NDIMS.items():
-        if conv_name.endswith(f"_{elem}"):
-            return max(dim - 1, 1) ** ndims
-    # topology_* conversions run on full 3D braid meshes
-    return max(dim - 1, 1) ** 3
+@dataclass(frozen=True)
+class BenchmarkInfo:
+    name: str
+    family: str
+    label: str
+    operation: Optional[str]
+    element_type: Optional[str]
+    ndims: Optional[int]
 
 
-def format_range_label(prefix, values):
-    values = sorted(values)
-    if len(values) == 1:
-        return f"{prefix}={values[0]}"
-    return f"{prefix}={values[0]}-{values[-1]}"
-
-
-KNOWN_BACKENDS = {"openmp", "cuda", "hip", "serial"}
-
-CONFIG_NAME_RE = re.compile(r"^(.+?)_dim-(\d+)_(.+)$")
+@dataclass(frozen=True)
+class BenchmarkResult:
+    benchmark: str
+    config: Config
+    dim: int
+    iterations: int
+    total_seconds: float
+    seconds_per_iteration: float
 
 
 def parse_config_name(name):
     match = CONFIG_NAME_RE.match(name)
     if match is None:
         return None
-    conv_name, dim_str, rest = match.groups()
+
+    benchmark = match.group("benchmark")
+    dim = int(match.group("dim"))
 
     values = {}
-    for field in rest.split("_"):
+    for field in match.group("metadata").split("_"):
         if "-" not in field:
             return None
+
         key, value = field.split("-", 1)
+        if not key or not value or key in values:
+            return None
+
         values[key] = value
 
-    required = {"iter"}
-    optional = {"backend", "src", "exec", "out", "sync", "threads"}
-    if not (required <= set(values) <= required | optional):
+    if not REQUIRED_METADATA_FIELDS <= values.keys():
         return None
-    if "backend" in values and values["backend"] not in KNOWN_BACKENDS:
+
+    if values.keys() - ALLOWED_METADATA_FIELDS:
         return None
-    if "src" in values and values["src"] not in ("host", "device"):
+
+    if values["src"] not in {"host", "device"}:
         return None
-    if "exec" in values and values["exec"] not in ("host", "device"):
+
+    if values["exec"] not in {"host", "device"}:
         return None
-    if "out" in values and values["out"] not in ("host", "device"):
+
+    if values["out"] not in {"host", "device"}:
         return None
-    if "sync" in values and values["sync"] not in ("sync", "assume"):
+
+    if not values["iter"].isdigit():
         return None
-    if not dim_str.isdigit() or not values["iter"].isdigit():
+
+    iterations = int(values["iter"])
+    if dim <= 1 or iterations <= 0:
         return None
+
     threads = None
     if "threads" in values:
         if not values["threads"].isdigit():
             return None
+
         threads = int(values["threads"])
+        if threads <= 0:
+            return None
 
-    cfg = Cfg(values.get("backend"),
-              values.get("src"),
-              values.get("exec"),
-              values.get("out"))
-    sync_strategy = values.get("sync")
-    return conv_name, cfg, int(dim_str), int(values["iter"]), threads, sync_strategy
+    config = Config(
+        backend=values.get("backend"),
+        src=values["src"],
+        execution=values["exec"],
+        out=values["out"],
+        sync=values.get("sync"),
+        threads=threads,
+    )
+
+    return benchmark, config, dim, iterations
 
 
-def parse_timestamp(cali_file):
-    stem = Path(cali_file).stem
-    if len(stem) == 15 and stem[:8].isdigit() and stem[8] == "_" and stem[9:].isdigit():
-        return f"{stem[0:4]}-{stem[4:6]}-{stem[6:8]} {stem[9:11]}:{stem[11:13]}:{stem[13:15]}"
+def parse_unstructured_benchmark(name):
+    # Longer operation names must be checked first so generate_offsets_inline
+    # is not interpreted as generate_offsets plus an inline element type.
+    operations = sorted(
+        OPERATION_LABELS,
+        key=len,
+        reverse=True,
+    )
+
+    for operation in operations:
+        prefix = f"unstructured_{operation}_"
+        if name.startswith(prefix):
+            element_type = name[len(prefix):]
+            if element_type:
+                return operation, element_type
+
     return None
 
 
-def find_cali_file():
-    all_cali = list(Path.cwd().glob("*.cali"))
-    cali_files = []
-    for f in all_cali:
-        if parse_timestamp(f) is not None:
-            cali_files.append(f)
-    cali_files.sort(reverse=True)
+def classify_benchmark(name):
+    if name.startswith("mesh_"):
+        return BenchmarkInfo(
+            name=name,
+            family="mesh",
+            label=MESH_LABELS.get(name, name.replace("_", " ")),
+            operation=name.removeprefix("mesh_"),
+            element_type=None,
+            ndims=3,
+        )
 
-    if not cali_files:
-        sys.exit(f"no timestamped .cali files (YYYYMMDD_HHMMSS.cali) found in {Path.cwd()}")
+    parsed = parse_unstructured_benchmark(name)
+    if parsed is not None:
+        operation, element_type = parsed
+        return BenchmarkInfo(
+            name=name,
+            family="unstructured",
+            label=OPERATION_LABELS[operation],
+            operation=operation,
+            element_type=element_type,
+            ndims=ELEMENT_TYPE_NDIMS.get(element_type),
+        )
 
-    skipped = len(all_cali) - len(cali_files)
-    print(
-        f"found {len(cali_files)} timestamped .cali file(s) in {Path.cwd()}"
-        + (f" ({skipped} other .cali file(s) skipped)" if skipped else "")
-        + ":"
+    return BenchmarkInfo(
+        name=name,
+        family="other",
+        label=name.replace("_", " "),
+        operation=None,
+        element_type=None,
+        ndims=None,
     )
-    for f in cali_files:
-        print(f"  {f.name} ({parse_timestamp(f)})")
-    print(f"using most recent: {cali_files[0].name}")
-    return cali_files[0]
 
 
-def node_time(thicket, profile_id, node):
+def config_sort_key(config):
+    return (
+        config.backend or "",
+        config.src,
+        config.execution,
+        config.out,
+        config.sync or "",
+        config.threads if config.threads is not None else -1,
+    )
+
+
+def format_config(config):
+    parts = []
+
+    if config.backend:
+        parts.append(config.backend)
+
+    parts.append(
+        f"{config.src} → {config.execution} → {config.out}"
+    )
+
+    if config.sync:
+        parts.append(f"sync={config.sync}")
+
+    if config.threads is not None:
+        parts.append(f"threads={config.threads}")
+
+    return ", ".join(parts)
+
+
+def config_slug(config):
+    parts = []
+
+    if config.backend:
+        parts.append(config.backend)
+
+    parts.extend([
+        config.src,
+        config.execution,
+        config.out,
+    ])
+
+    if config.sync:
+        parts.append(config.sync)
+
+    if config.threads is not None:
+        parts.append(f"threads-{config.threads}")
+
+    return safe_file_part("_".join(parts))
+
+
+def safe_file_part(value):
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
+
+
+def ordered_element_types(infos):
+    discovered = {
+        info.element_type
+        for info in infos.values()
+        if info.element_type is not None
+    }
+
+    ordered = [
+        element_type
+        for element_type in PREFERRED_ELEMENT_TYPE_ORDER
+        if element_type in discovered
+    ]
+
+    ordered.extend(
+        sorted(discovered - set(PREFERRED_ELEMENT_TYPE_ORDER))
+    )
+
+    return ordered
+
+
+def find_cali_file():
+    candidates = [
+        path
+        for path in Path.cwd().glob("*.cali")
+        if TIMESTAMP_RE.match(path.stem)
+    ]
+    candidates.sort(reverse=True)
+
+    if not candidates:
+        sys.exit(
+            "no timestamped .cali files "
+            f"(YYYYMMDD_HHMMSS.cali) found in {Path.cwd()}"
+        )
+
+    print(f"using most recent Caliper file: {candidates[0]}")
+    return candidates[0]
+
+
+def find_time_column(dataframe):
+    preferred = (
+        "time",
+        "sum#sum#time.duration",
+        "sum#time.duration",
+        "time.duration",
+    )
+
+    for candidate in preferred:
+        if candidate in dataframe.columns:
+            return candidate
+
+    for column in dataframe.columns:
+        if str(column).endswith("time.duration"):
+            return column
+
+    raise RuntimeError(
+        "unable to find a Caliper time column; available columns are: "
+        + ", ".join(str(column) for column in dataframe.columns)
+    )
+
+
+def iter_graph_nodes(graph):
+    stack = list(graph.roots)
+    visited = set()
+
+    while stack:
+        node = stack.pop()
+        node_id = id(node)
+
+        if node_id in visited:
+            continue
+
+        visited.add(node_id)
+        yield node
+        stack.extend(node.children)
+
+
+def node_time(thicket, profile_id, node, time_column):
     try:
-        return thicket.dataframe.loc[(node, profile_id), "time"]
+        value = thicket.dataframe.loc[
+            (node, profile_id),
+            time_column,
+        ]
     except KeyError:
         return float("nan")
 
+    try:
+        return float(np.asarray(value).reshape(-1)[0])
+    except (TypeError, ValueError, IndexError):
+        return float("nan")
 
-def subtree_time(thicket, profile_id, node):
-    # Caliper measures exclusive time, so a region's inclusive time is its
-    # own exclusive time plus the summed exclusive time of its subtree.
-    total = node_time(thicket, profile_id, node)
-    total = 0.0 if np.isnan(total) else total
+
+def inclusive_time(
+    thicket,
+    profile_id,
+    node,
+    time_column,
+    cache,
+):
+    node_id = id(node)
+    if node_id in cache:
+        return cache[node_id]
+
+    value = node_time(
+        thicket,
+        profile_id,
+        node,
+        time_column,
+    )
+    total = 0.0 if np.isnan(value) else value
+
     for child in node.children:
-        total += subtree_time(thicket, profile_id, child)
+        total += inclusive_time(
+            thicket,
+            profile_id,
+            child,
+            time_column,
+            cache,
+        )
+
+    cache[node_id] = total
     return total
 
-LEAF_METRIC_NAMES = ("use_with", "forall", "sync", "assume")
 
-def accumulate_leaf_metrics(thicket, profile_id, node, totals):
-    name = node.frame["name"]
-    if name in LEAF_METRIC_NAMES:
-        val = node_time(thicket, profile_id, node)
-        totals[name] += 0.0 if np.isnan(val) else val
-    for child in node.children:
-        accumulate_leaf_metrics(thicket, profile_id, child, totals)
+def collect_results(thicket):
+    profile_ids = list(
+        thicket.dataframe.index
+        .get_level_values("profile")
+        .unique()
+    )
 
+    if len(profile_ids) != 1:
+        raise RuntimeError(
+            "expected exactly one profile in the Caliper file, "
+            f"found {len(profile_ids)}"
+        )
 
-def collect_data(thicket):
-    profile_id = thicket.dataframe.index.get_level_values("profile")[0]
-    data = {}
-    dims_seen = set()
-    backends_seen = set()
-    syncs_seen = set()
+    profile_id = profile_ids[0]
+    time_column = find_time_column(thicket.dataframe)
+    time_cache = {}
 
-    root = list(thicket.graph.roots)[0]
-    for cfg_node in root.children:
-        parsed = parse_config_name(cfg_node.frame["name"])
+    results = []
+    seen = set()
+    malformed_names = []
+
+    for node in iter_graph_nodes(thicket.graph):
+        name = node.frame.get("name", "")
+        parsed = parse_config_name(name)
+
         if parsed is None:
+            if (
+                isinstance(name, str)
+                and name.startswith(("mesh_", "unstructured_"))
+                and "_dim-" in name
+            ):
+                malformed_names.append(name)
             continue
-        conv_name, cfg, dim, iters, threads, sync_strategy = parsed
 
-        dims_seen.add(dim)
-        syncs_seen.add(sync_strategy)
-        if cfg.backend is not None:
-            backends_seen.add(cfg.backend)
+        benchmark, config, dim, iterations = parsed
+        key = (benchmark, config, dim)
 
-        totals = {name: 0.0 for name in LEAF_METRIC_NAMES}
-        accumulate_leaf_metrics(thicket, profile_id, cfg_node, totals)
-
-        end_to_end = subtree_time(thicket, profile_id, cfg_node) / iters
-        use_with = totals["use_with"] / iters
-        forall = totals["forall"] / iters
-        data_movement = (totals["sync"] + totals["assume"]) / iters
-
-        data[(cfg, conv_name, dim, sync_strategy)] = {
-            "end_to_end": end_to_end,
-            "use_with": use_with,
-            "forall": forall,
-            "data_movement": data_movement,
-            "other_processing": max(0.0, end_to_end - (use_with + forall + data_movement)),
-            "iters": iters,
-            "threads": threads,
-        }
-
-    return data, sorted(dims_seen), backends_seen, syncs_seen
-
-
-def plot_panels(data, dims, cfg_keys, panels, suptitle, path, ylabel, iters_label, per_entity=False):
-    n = len(panels)
-    fig_width = 10
-
-    # ms is the only unit
-    scale = 1e3
-
-    panel_data = []
-    for _, conv_name, metric in panels:
-        raw_ys_by_cfg = []
-        panel_values = []
-        for cfg in cfg_keys:
-            ys = []
-            for d in dims:
-                v = data.get((cfg, conv_name, d), {}).get(metric, np.nan)
-                if not np.isnan(v):
-                    if per_entity:
-                        v = v / per_entity_count(conv_name, d)
-                    v = v * scale
-                ys.append(v)
-            raw_ys_by_cfg.append(ys)
-            panel_values.extend(v for v in ys if not np.isnan(v))
-        panel_data.append((raw_ys_by_cfg, panel_values))
-
-    fig, axes = plt.subplots(n, 1, figsize=(fig_width, 4.2 * n), squeeze=False)
-    axes = axes[:, 0]
-    suptitle_text = fig.suptitle(f"{suptitle} ({iters_label})", fontsize=20, fontweight="bold")
-
-    for i in range(n):
-        ax = axes[i]
-        title, conv_name, metric = panels[i]
-        raw_ys_by_cfg, panel_values = panel_data[i]
-
-        for j, cfg in enumerate(cfg_keys):
-            ys = raw_ys_by_cfg[j]
-            ax.plot(
-                dims, ys,
-                label=format_cfg_label(cfg),
-                color=CMAP(j % 10), marker=MARKERS[j % len(MARKERS)],
-                linestyle="-" if cfg.exec == "device" else "--",
-                markersize=7, linewidth=2.2, alpha=0.9,
+        if key in seen:
+            raise RuntimeError(
+                "duplicate benchmark configuration encountered: "
+                f"{name}"
             )
 
+        seen.add(key)
+
+        total = inclusive_time(
+            thicket,
+            profile_id,
+            node,
+            time_column,
+            time_cache,
+        )
+
+        results.append(
+            BenchmarkResult(
+                benchmark=benchmark,
+                config=config,
+                dim=dim,
+                iterations=iterations,
+                total_seconds=total,
+                seconds_per_iteration=total / iterations,
+            )
+        )
+
+    if malformed_names:
+        print(
+            "warning: ignored benchmark-like regions with unsupported "
+            "names:"
+        )
+        for name in sorted(set(malformed_names)):
+            print(f"  {name}")
+
+    return results, time_column
+
+
+def base_grid_points(info, dim):
+    if info.ndims is None:
+        return None
+    return dim ** info.ndims
+
+
+def base_grid_cells(info, dim):
+    if info.ndims is None:
+        return None
+    return (dim - 1) ** info.ndims
+
+
+def format_duration(seconds):
+    if not np.isfinite(seconds):
+        return "n/a"
+
+    seconds = abs(seconds)
+
+    if seconds == 0:
+        return "0"
+
+    if seconds < 1.0e-6:
+        return f"{seconds * 1.0e9:.3g} ns"
+
+    if seconds < 1.0e-3:
+        return f"{seconds * 1.0e6:.3g} µs"
+
+    if seconds < 1.0:
+        return f"{seconds * 1.0e3:.3g} ms"
+
+    return f"{seconds:.3g} s"
+
+
+def format_rate(rate):
+    if not np.isfinite(rate):
+        return "n/a"
+    return f"{rate:.3g}"
+
+
+def iteration_summary(results):
+    values = sorted({result.iterations for result in results})
+
+    if len(values) == 1:
+        return f"{values[0]} measured iterations"
+
+    return (
+        f"{values[0]}-{values[-1]} measured iterations"
+    )
+
+
+def setup_x_axis(ax, values):
+    values = sorted(set(values))
+    if not values:
+        return
+
+    if (
+        len(values) > 1
+        and values[0] > 0
+        and values[-1] / values[0] >= 4
+    ):
         ax.set_xscale("log", base=2)
-        ax.set_xticks(dims)
-        ax.set_xticklabels([str(d) for d in dims])
-        ax.grid(True, which="both", linestyle=":", alpha=0.4)
-        ax.set_title(title, fontsize=17)
-        ax.tick_params(axis="both", which="major", labelsize=13)
 
-        positive_values = [v for v in panel_values if v > 0]
-        if per_entity and positive_values:
-            # Per-entity cost spans many orders of magnitude, so use
-            # a log-scale y-axis
-            ax.set_yscale("log")
-        else:
-            # Fixed precision so tick labels are comparable across panels
-            ax.yaxis.set_major_formatter(FormatStrFormatter("%.3f"))
-            local_max = max(panel_values) if panel_values else 0.0
-            scaled_max = local_max * 1.05 if panel_values else 1.0
-            ax.set_ylim(bottom=-0.04 * scaled_max, top=scaled_max)
+    ax.set_xticks(values)
+    ax.set_xticklabels([f"{value:,}" for value in values])
 
-    # One shared x/y title instead of repeating it on every panel
-    fig.supxlabel("dim size per axis (mesh is N³)", fontsize=15)
-    fig.supylabel(f"{ylabel} (ms)", fontsize=15)
 
-    fig.tight_layout(rect=(0, 0, 1, 0.96))
+def make_styles(items, cmap_name):
+    cmap = plt.get_cmap(cmap_name)
 
-    # Legend to the right of the subplots, one entry per row.
-    handles, labels = axes[0].get_legend_handles_labels()
-    legend = fig.legend(handles, labels, loc="center left", bbox_to_anchor=(1.0, 0.5), fontsize=13)
+    return {
+        item: (
+            cmap(index % cmap.N),
+            MARKERS[index % len(MARKERS)],
+        )
+        for index, item in enumerate(items)
+    }
 
-    fig.canvas.draw()
-    legend_bbox_fig = legend.get_window_extent().transformed(fig.transFigure.inverted())
-    suptitle_text.set_x(legend_bbox_fig.x1 / 2)
 
-    fig.savefig(path, dpi=150, bbox_inches="tight")
+def save_figure(fig, path, dpi):
+    fig.savefig(
+        path,
+        dpi=dpi,
+        bbox_inches="tight",
+    )
     plt.close(fig)
     print(f"saved {path}")
 
 
-def generate_plots(data, dims, cfg_keys, iters_label, out_dir, suffix="",
-                   include_components=True, per_entity=False):
-    # Per-entity plots normalize each conversion by its point/element count;
-    # every group is homogeneous in kind, so label each figure accordingly.
-    file_suffix = f"_per_entity{suffix}" if per_entity else suffix
+def plot_benchmark_grid(
+    results,
+    infos,
+    benchmark_names,
+    configs,
+    config_styles,
+    title,
+    path,
+    dpi,
+    x_mode,
+    log_y=False,
+    throughput=False,
+):
+    if not benchmark_names:
+        return
 
-    for group_name, group_panels in END_TO_END_GROUP_PANELS:
-        if per_entity:
-            kind = per_entity_kind(group_panels[0][1])
-            suptitle = f"avg {group_name} conversion time per {kind} vs data size"
-            ylabel = f"avg time / {kind}"
-        else:
-            suptitle = f"avg {group_name} conversion time vs data size"
-            ylabel = "avg time / iter"
-        plot_panels(
-            data, dims, cfg_keys,
-            group_panels,
-            suptitle,
-            out_dir / f"end_to_end_combined_{group_name}{file_suffix}.png",
-            ylabel,
-            iters_label,
-            per_entity=per_entity,
-        )
+    columns = min(3, len(benchmark_names))
+    rows = math.ceil(len(benchmark_names) / columns)
 
-    for conv in CONVERSIONS:
-        if per_entity:
-            kind = per_entity_kind(conv)
-            suptitle = f"{CONVERSION_LABELS[conv]} avg end-to-end time per {kind} vs data size"
-            ylabel = f"avg time / {kind}"
-        else:
-            suptitle = f"{CONVERSION_LABELS[conv]} avg end-to-end conversion time vs data size"
-            ylabel = "avg time / iter"
-        plot_panels(
-            data, dims, cfg_keys,
-            [(CONVERSION_LABELS[conv], conv, "end_to_end")],
-            suptitle,
-            out_dir / f"end_to_end_{conv}{file_suffix}.png",
-            ylabel,
-            iters_label,
-            per_entity=per_entity,
-        )
+    fig, axes = plt.subplots(
+        rows,
+        columns,
+        figsize=(5.2 * columns, 3.8 * rows),
+        squeeze=False,
+    )
+    axes = axes.flatten()
 
-        if include_components and not per_entity:
-            component_panels = [(metric, conv, metric) for metric in COMPONENT_METRICS]
-            plot_panels(
-                data, dims, cfg_keys,
-                component_panels,
-                f"{CONVERSION_LABELS[conv]} components vs data size",
-                out_dir / f"components_{conv}{suffix}.png",
-                "avg time / iter",
-                iters_label,
+    legend_entries = {}
+
+    for axis_index, benchmark in enumerate(benchmark_names):
+        ax = axes[axis_index]
+        info = infos[benchmark]
+
+        panel_results = [
+            result
+            for result in results
+            if result.benchmark == benchmark
+        ]
+
+        all_x_values = []
+        all_y_values = []
+
+        for config in configs:
+            config_results = sorted(
+                (
+                    result
+                    for result in panel_results
+                    if result.config == config
+                ),
+                key=lambda result: result.dim,
             )
+
+            if not config_results:
+                continue
+
+            x_values = []
+            y_values = []
+
+            for result in config_results:
+                if x_mode == "points":
+                    x_value = base_grid_points(info, result.dim)
+                elif x_mode == "cells":
+                    x_value = base_grid_cells(info, result.dim)
+                else:
+                    x_value = result.dim
+
+                if x_value is None:
+                    continue
+
+                if throughput:
+                    cell_count = base_grid_cells(info, result.dim)
+                    if (
+                        cell_count is None
+                        or result.seconds_per_iteration <= 0
+                    ):
+                        continue
+
+                    y_value = (
+                        cell_count
+                        / result.seconds_per_iteration
+                        / 1.0e6
+                    )
+                else:
+                    y_value = result.seconds_per_iteration
+
+                x_values.append(x_value)
+                y_values.append(y_value)
+
+            if not x_values:
+                continue
+
+            color, marker = config_styles[config]
+            label = format_config(config)
+
+            line, = ax.plot(
+                x_values,
+                y_values,
+                color=color,
+                marker=marker,
+                linewidth=2,
+                markersize=6,
+                label=label,
+            )
+
+            legend_entries.setdefault(label, line)
+            all_x_values.extend(x_values)
+            all_y_values.extend(y_values)
+
+        setup_x_axis(ax, all_x_values)
+
+        if log_y and all(value > 0 for value in all_y_values):
+            ax.set_yscale("log")
+        else:
+            ax.set_ylim(bottom=0)
+
+        if throughput:
+            ax.yaxis.set_major_formatter(
+                FuncFormatter(
+                    lambda value, _: format_rate(value)
+                )
+            )
+        else:
+            ax.yaxis.set_major_formatter(
+                FuncFormatter(
+                    lambda value, _: format_duration(value)
+                )
+            )
+
+        ax.set_title(info.label, fontsize=12)
+        ax.grid(True, which="both", linestyle=":", alpha=0.45)
+
+    for axis_index in range(len(benchmark_names), len(axes)):
+        axes[axis_index].set_visible(False)
+
+    if x_mode == "points":
+        x_label = "input grid points"
+    elif x_mode == "cells":
+        x_label = "base-grid logical cells"
+    else:
+        x_label = "points per active axis"
+
+    y_label = (
+        "million base-grid logical cells / second"
+        if throughput
+        else "average time / iteration"
+    )
+
+    fig.suptitle(
+        f"{title} ({iteration_summary(results)})",
+        fontsize=17,
+        fontweight="bold",
+    )
+    fig.supxlabel(x_label, fontsize=13)
+    fig.supylabel(y_label, fontsize=13)
+
+    if legend_entries:
+        fig.legend(
+            legend_entries.values(),
+            legend_entries.keys(),
+            loc="center left",
+            bbox_to_anchor=(0.84, 0.5),
+            fontsize=10,
+        )
+        right = 0.82
+    else:
+        right = 0.97
+
+    fig.tight_layout(rect=(0.03, 0.03, right, 0.93))
+    save_figure(fig, path, dpi)
+
+
+def plot_cross_type_comparison(
+    results,
+    infos,
+    config,
+    element_types,
+    element_styles,
+    out_dir,
+    dpi,
+    log_y,
+):
+    operations = [
+        operation
+        for operation, _ in UNSTRUCTURED_OPERATIONS
+        if any(
+            info.operation == operation
+            and info.element_type in element_types
+            and info.ndims is not None
+            for info in infos.values()
+        )
+    ]
+
+    if not operations:
+        return
+
+    columns = 3
+    rows = math.ceil(len(operations) / columns)
+
+    fig, axes = plt.subplots(
+        rows,
+        columns,
+        figsize=(5.2 * columns, 3.8 * rows),
+        squeeze=False,
+    )
+    axes = axes.flatten()
+
+    legend_entries = {}
+
+    for axis_index, operation in enumerate(operations):
+        ax = axes[axis_index]
+        all_x_values = []
+        all_y_values = []
+
+        for element_type in element_types:
+            matching_infos = [
+                info
+                for info in infos.values()
+                if info.operation == operation
+                and info.element_type == element_type
+                and info.ndims is not None
+            ]
+
+            if not matching_infos:
+                continue
+
+            benchmark = matching_infos[0].name
+            info = matching_infos[0]
+
+            matching_results = sorted(
+                (
+                    result
+                    for result in results
+                    if result.benchmark == benchmark
+                    and result.config == config
+                ),
+                key=lambda result: result.dim,
+            )
+
+            if not matching_results:
+                continue
+
+            x_values = [
+                base_grid_cells(info, result.dim)
+                for result in matching_results
+            ]
+            y_values = [
+                result.seconds_per_iteration
+                for result in matching_results
+            ]
+
+            color, marker = element_styles[element_type]
+
+            line, = ax.plot(
+                x_values,
+                y_values,
+                color=color,
+                marker=marker,
+                linewidth=2,
+                markersize=6,
+                label=element_type,
+            )
+
+            legend_entries.setdefault(element_type, line)
+            all_x_values.extend(x_values)
+            all_y_values.extend(y_values)
+
+        setup_x_axis(ax, all_x_values)
+
+        if log_y and all(value > 0 for value in all_y_values):
+            ax.set_yscale("log")
+        else:
+            ax.set_ylim(bottom=0)
+
+        ax.yaxis.set_major_formatter(
+            FuncFormatter(
+                lambda value, _: format_duration(value)
+            )
+        )
+        ax.set_title(OPERATION_LABELS[operation], fontsize=12)
+        ax.grid(True, which="both", linestyle=":", alpha=0.45)
+
+    for axis_index in range(len(operations), len(axes)):
+        axes[axis_index].set_visible(False)
+
+    fig.suptitle(
+        "Unstructured element-type comparison\n"
+        f"{format_config(config)}",
+        fontsize=17,
+        fontweight="bold",
+    )
+    fig.supxlabel("base-grid logical cells", fontsize=13)
+    fig.supylabel("average time / iteration", fontsize=13)
+
+    if legend_entries:
+        fig.legend(
+            legend_entries.values(),
+            legend_entries.keys(),
+            loc="center left",
+            bbox_to_anchor=(0.84, 0.5),
+            fontsize=10,
+        )
+
+    fig.tight_layout(rect=(0.03, 0.03, 0.82, 0.91))
+
+    path = (
+        out_dir
+        / f"unstructured_cross_type_{config_slug(config)}.png"
+    )
+    save_figure(fig, path, dpi)
+
+
+def plot_heatmaps(
+    results,
+    infos,
+    configs,
+    element_types,
+    out_dir,
+    dpi,
+    all_dimensions,
+):
+    benchmark_by_operation_and_type = {
+        (info.operation, info.element_type): info.name
+        for info in infos.values()
+        if info.family == "unstructured"
+    }
+
+    operations = [
+        operation
+        for operation, _ in UNSTRUCTURED_OPERATIONS
+        if any(
+            (operation, element_type)
+            in benchmark_by_operation_and_type
+            for element_type in element_types
+        )
+    ]
+
+    lookup = {
+        (result.benchmark, result.config, result.dim): result
+        for result in results
+    }
+
+    for config in configs:
+        dimensions = sorted({
+            result.dim
+            for result in results
+            if result.config == config
+            and infos[result.benchmark].family == "unstructured"
+        })
+
+        if not dimensions:
+            continue
+
+        if not all_dimensions:
+            dimensions = [dimensions[-1]]
+
+        for dim in dimensions:
+            matrix = np.full(
+                (len(operations), len(element_types)),
+                np.nan,
+            )
+
+            for row, operation in enumerate(operations):
+                for column, element_type in enumerate(element_types):
+                    benchmark = benchmark_by_operation_and_type.get(
+                        (operation, element_type)
+                    )
+
+                    if benchmark is None:
+                        continue
+
+                    result = lookup.get(
+                        (benchmark, config, dim)
+                    )
+
+                    if result is not None:
+                        matrix[row, column] = (
+                            result.seconds_per_iteration
+                        )
+
+            positive_values = matrix[
+                np.isfinite(matrix) & (matrix > 0)
+            ]
+
+            if positive_values.size == 0:
+                continue
+
+            minimum = float(np.min(positive_values))
+            maximum = float(np.max(positive_values))
+
+            if minimum == maximum:
+                minimum *= 0.5
+                maximum *= 2.0
+
+            norm = LogNorm(vmin=minimum, vmax=maximum)
+            masked = np.ma.masked_invalid(matrix)
+            masked = np.ma.masked_less_equal(masked, 0)
+
+            cmap = copy(plt.get_cmap("viridis"))
+            cmap.set_bad("#dddddd")
+
+            fig, ax = plt.subplots(
+                figsize=(
+                    max(9, 1.4 * len(element_types)),
+                    max(6, 0.75 * len(operations)),
+                )
+            )
+
+            image = ax.imshow(
+                masked,
+                cmap=cmap,
+                norm=norm,
+                aspect="auto",
+            )
+
+            ax.set_xticks(range(len(element_types)))
+            ax.set_xticklabels(
+                element_types,
+                rotation=35,
+                ha="right",
+            )
+            ax.set_yticks(range(len(operations)))
+            ax.set_yticklabels([
+                OPERATION_LABELS[operation]
+                for operation in operations
+            ])
+
+            for row in range(len(operations)):
+                for column in range(len(element_types)):
+                    value = matrix[row, column]
+
+                    if not np.isfinite(value) or value <= 0:
+                        text = "n/a"
+                        color = "#666666"
+                    else:
+                        text = format_duration(value)
+                        color = (
+                            "white"
+                            if norm(value) > 0.55
+                            else "black"
+                        )
+
+                    ax.text(
+                        column,
+                        row,
+                        text,
+                        ha="center",
+                        va="center",
+                        fontsize=8,
+                        color=color,
+                    )
+
+            colorbar = fig.colorbar(image, ax=ax)
+            colorbar.set_label("average time / iteration")
+            colorbar.ax.yaxis.set_major_formatter(
+                FuncFormatter(
+                    lambda value, _: format_duration(value)
+                )
+            )
+
+            ax.set_title(
+                "Unstructured benchmark summary\n"
+                f"N={dim}, {format_config(config)}",
+                fontsize=15,
+                fontweight="bold",
+            )
+
+            fig.tight_layout()
+
+            path = (
+                out_dir
+                / (
+                    "unstructured_heatmap_"
+                    f"{config_slug(config)}_dim-{dim}.png"
+                )
+            )
+            save_figure(fig, path, dpi)
+
+
+def write_csv(results, infos, path):
+    fields = [
+        "benchmark",
+        "family",
+        "operation",
+        "element_type",
+        "topological_dimensions",
+        "dim",
+        "grid_points",
+        "base_grid_logical_cells",
+        "backend",
+        "source_location",
+        "execution_location",
+        "output_location",
+        "sync_strategy",
+        "threads",
+        "iterations",
+        "total_measured_seconds",
+        "seconds_per_iteration",
+        "base_grid_logical_cells_per_second",
+    ]
+
+    with path.open("w", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+
+        for result in sorted(
+            results,
+            key=lambda item: (
+                item.benchmark,
+                config_sort_key(item.config),
+                item.dim,
+            ),
+        ):
+            info = infos[result.benchmark]
+            points = base_grid_points(info, result.dim)
+            cells = base_grid_cells(info, result.dim)
+
+            throughput = ""
+            if (
+                cells is not None
+                and result.seconds_per_iteration > 0
+            ):
+                throughput = (
+                    cells / result.seconds_per_iteration
+                )
+
+            writer.writerow({
+                "benchmark": result.benchmark,
+                "family": info.family,
+                "operation": info.operation or "",
+                "element_type": info.element_type or "",
+                "topological_dimensions": (
+                    info.ndims if info.ndims is not None else ""
+                ),
+                "dim": result.dim,
+                "grid_points": points if points is not None else "",
+                "base_grid_logical_cells": (
+                    cells if cells is not None else ""
+                ),
+                "backend": result.config.backend or "",
+                "source_location": result.config.src,
+                "execution_location": result.config.execution,
+                "output_location": result.config.out,
+                "sync_strategy": result.config.sync or "",
+                "threads": (
+                    result.config.threads
+                    if result.config.threads is not None
+                    else ""
+                ),
+                "iterations": result.iterations,
+                "total_measured_seconds": result.total_seconds,
+                "seconds_per_iteration": (
+                    result.seconds_per_iteration
+                ),
+                "base_grid_logical_cells_per_second": throughput,
+            })
+
+    print(f"saved {path}")
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "cali_file", nargs="?",
-        help="path to a .cali file",
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plot current Conduit mesh transform benchmark results."
+        )
     )
+    parser.add_argument(
+        "cali_file",
+        nargs="?",
+        help="path to a current benchmark .cali file",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="output directory, defaults to the Caliper filename stem",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=160,
+        help="PNG resolution, default: 160",
+    )
+    parser.add_argument(
+        "--log-y",
+        action="store_true",
+        help="use logarithmic scaling for runtime plots",
+    )
+    parser.add_argument(
+        "--throughput",
+        action="store_true",
+        help=(
+            "also generate base-grid logical-cell throughput plots"
+        ),
+    )
+    parser.add_argument(
+        "--no-cross-type",
+        action="store_true",
+        help="skip cross-element-type comparison figures",
+    )
+    parser.add_argument(
+        "--no-heatmaps",
+        action="store_true",
+        help="skip unstructured summary heatmaps",
+    )
+    parser.add_argument(
+        "--all-heatmaps",
+        action="store_true",
+        help=(
+            "generate heatmaps for every dimension instead of only "
+            "the largest"
+        ),
+    )
+
     args = parser.parse_args()
 
-    cali_file = Path(args.cali_file) if args.cali_file else find_cali_file()
+    cali_file = (
+        Path(args.cali_file)
+        if args.cali_file
+        else find_cali_file()
+    )
+
     if not cali_file.exists():
         sys.exit(f"no such file: {cali_file}")
 
     try:
-        thicket = th.Thicket.from_caliperreader(str(cali_file))
-    except ReaderError as e:
-        sys.exit(f"failed to read {cali_file}: {e}")
-
-    data, dims, backends_seen, syncs_seen = collect_data(thicket)
-    if not data:
-        sys.exit(f"no benchmark config nodes found in {cali_file}")
-
-    iters_label = format_range_label("n", {entry["iters"] for entry in data.values()})
-    threads_seen = {entry["threads"] for entry in data.values() if entry["threads"] is not None}
-    if threads_seen:
-        iters_label = f"{iters_label}, {format_range_label('threads', threads_seen)}"
-
-    out_dir = Path(cali_file.stem)
-    out_dir.mkdir(exist_ok=True)
-
-    serial_only = not backends_seen
-    if serial_only:
-        print("no backend field found, treating runs as serial-only")
-
-    multi_sync = len(syncs_seen) > 1
-    for sync_strategy in sorted(syncs_seen, key=lambda s: (s is None, s)):
-        sync_data = {
-            (cfg, conv_name, dim): entry
-            for (cfg, conv_name, dim, s), entry in data.items()
-            if s == sync_strategy
-        }
-        cfg_keys = sorted({cfg for cfg, _, _ in sync_data})
-        sync_suffix = f"_{sync_strategy or 'no-sync'}" if multi_sync else ""
-
-        generate_plots(
-            sync_data, dims, cfg_keys, iters_label, out_dir,
-            suffix=sync_suffix,
-            include_components=not serial_only,
+        thicket = th.Thicket.from_caliperreader(
+            str(cali_file)
         )
-        generate_plots(
-            sync_data, dims, cfg_keys, iters_label, out_dir,
-            suffix=sync_suffix,
-            include_components=False,
-            per_entity=True,
+        results, time_column = collect_results(thicket)
+    except ReaderError as error:
+        sys.exit(f"failed to read {cali_file}: {error}")
+    except RuntimeError as error:
+        sys.exit(str(error))
+
+    if not results:
+        sys.exit(
+            f"no current mesh benchmark regions found in {cali_file}"
         )
 
-        if not serial_only:
-            for backend in sorted(backends_seen):
-                backend_keys = [cfg for cfg in cfg_keys if cfg.backend == backend]
-                if backend_keys:
-                    generate_plots(
-                        sync_data, dims, backend_keys, iters_label, out_dir,
-                        suffix=f"{sync_suffix}_{backend}",
-                        include_components=True,
-                    )
+    benchmark_names = sorted({
+        result.benchmark for result in results
+    })
+    infos = {
+        name: classify_benchmark(name)
+        for name in benchmark_names
+    }
 
-    print(f"wrote plots to {out_dir}/")
+    configs = sorted(
+        {result.config for result in results},
+        key=config_sort_key,
+    )
+    dimensions = sorted({result.dim for result in results})
+    element_types = ordered_element_types(infos)
+
+    out_dir = (
+        args.output_dir
+        if args.output_dir is not None
+        else cali_file.with_suffix("")
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"time column: {time_column}")
+    print(f"benchmark names: {len(benchmark_names)}")
+    print(f"configurations: {len(configs)}")
+    print(f"dimension sizes: {dimensions}")
+    print(
+        "element types: "
+        + (", ".join(element_types) if element_types else "none")
+    )
+
+    if max(dimensions) <= 4:
+        print(
+            "warning: all dimensions are <= 4; these runs are useful "
+            "for CI validation but are likely dominated by fixed overhead"
+        )
+
+    write_csv(
+        results,
+        infos,
+        out_dir / "benchmark_results.csv",
+    )
+
+    config_styles = make_styles(configs, "tab20")
+    element_styles = make_styles(element_types, "tab10")
+
+    plotted = set()
+
+    mesh_names = [
+        name
+        for name, _ in MESH_BENCHMARKS
+        if name in infos
+    ]
+    mesh_names.extend(sorted(
+        name
+        for name, info in infos.items()
+        if info.family == "mesh"
+        and name not in mesh_names
+    ))
+
+    if mesh_names:
+        plot_benchmark_grid(
+            results,
+            infos,
+            mesh_names,
+            configs,
+            config_styles,
+            "Whole-mesh conversions",
+            out_dir / "mesh_scaling.png",
+            args.dpi,
+            x_mode="points",
+            log_y=args.log_y,
+        )
+        plotted.update(mesh_names)
+
+    for element_type in element_types:
+        type_names = [
+            info.name
+            for info in infos.values()
+            if info.family == "unstructured"
+            and info.element_type == element_type
+        ]
+        type_names.sort(
+            key=lambda name: (
+                OPERATION_ORDER.get(
+                    infos[name].operation,
+                    len(OPERATION_ORDER),
+                ),
+                name,
+            )
+        )
+
+        if not type_names:
+            continue
+
+        use_logical_cells = all(
+            infos[name].ndims is not None
+            for name in type_names
+        )
+        x_mode = "cells" if use_logical_cells else "dim"
+
+        plot_benchmark_grid(
+            results,
+            infos,
+            type_names,
+            configs,
+            config_styles,
+            f"Unstructured {element_type} transforms",
+            out_dir
+            / f"unstructured_{safe_file_part(element_type)}_scaling.png",
+            args.dpi,
+            x_mode=x_mode,
+            log_y=args.log_y,
+        )
+
+        if args.throughput and use_logical_cells:
+            plot_benchmark_grid(
+                results,
+                infos,
+                type_names,
+                configs,
+                config_styles,
+                f"Unstructured {element_type} throughput",
+                out_dir
+                / (
+                    "unstructured_"
+                    f"{safe_file_part(element_type)}_throughput.png"
+                ),
+                args.dpi,
+                x_mode="cells",
+                log_y=args.log_y,
+                throughput=True,
+            )
+
+        plotted.update(type_names)
+
+    other_names = sorted(set(benchmark_names) - plotted)
+    if other_names:
+        print(
+            "warning: plotting unclassified benchmarks in "
+            "other_scaling.png:"
+        )
+        for name in other_names:
+            print(f"  {name}")
+
+        plot_benchmark_grid(
+            results,
+            infos,
+            other_names,
+            configs,
+            config_styles,
+            "Other discovered benchmarks",
+            out_dir / "other_scaling.png",
+            args.dpi,
+            x_mode="dim",
+            log_y=args.log_y,
+        )
+        plotted.update(other_names)
+
+    if set(benchmark_names) != plotted:
+        missing = sorted(set(benchmark_names) - plotted)
+        sys.exit(
+            "internal error: benchmarks were not plotted: "
+            + ", ".join(missing)
+        )
+
+    if not args.no_cross_type:
+        for config in configs:
+            plot_cross_type_comparison(
+                results,
+                infos,
+                config,
+                element_types,
+                element_styles,
+                out_dir,
+                args.dpi,
+                args.log_y,
+            )
+
+    if not args.no_heatmaps:
+        plot_heatmaps(
+            results,
+            infos,
+            configs,
+            element_types,
+            out_dir,
+            args.dpi,
+            args.all_heatmaps,
+        )
+
+    print(f"wrote results to {out_dir}/")
+
 
 if __name__ == "__main__":
     main()

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -25,7 +25,7 @@
 using namespace conduit;
 
 // Number of points per active axis. Braid requires at least two.
-std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4, 8, 16, 32, 64, 128, 256};
+std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4};
 
 // Intentionally small by default, to minimize CI time spent benchmarking.
 index_t BENCHMARK_NUM_WARMUP_ITERATIONS = 10;

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -217,13 +217,13 @@ benchmark_topo_generate_offsets_inline(const char *name,
 TEST(blueprint_mesh_transform_benchmark, coordset_transforms)
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
-    benchmark_coordset_transform("uniform_to_rectilinear",
+    benchmark_coordset_transform("coordset_uniform_to_rectilinear",
                                  "uniform",
                                  blueprint::mesh::coordset::uniform::to_rectilinear);
-    benchmark_coordset_transform("uniform_to_explicit",
+    benchmark_coordset_transform("coordset_uniform_to_explicit",
                                  "uniform",
                                  blueprint::mesh::coordset::uniform::to_explicit);
-    benchmark_coordset_transform("rectilinear_to_explicit",
+    benchmark_coordset_transform("coordset_rectilinear_to_explicit",
                                  "rectilinear",
                                  blueprint::mesh::coordset::rectilinear::to_explicit);
 }

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -19,37 +19,40 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
-#include <utility>
 #include <vector>
 
 using namespace conduit;
 
-// Number of points per active axis. Braid requires at least two.
-std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4};
+// Number of vertices per axis, braid requires at least two. Larger sizes
+// (e.g. 8) can be passed on the command line for deeper, one-off runs; some
+// shapes (e.g. pyramids) scale much worse than others at that size.
+std::vector<index_t> BENCHMARK_DIM_SIZES = {2};
 
-// Intentionally small by default, to minimize CI time spent benchmarking.
-index_t BENCHMARK_NUM_WARMUP_ITERATIONS = 10;
-index_t BENCHMARK_NUM_ITERATIONS = 100;
+// Small by default, to minimize CI time spent benchmarking
+index_t BENCHMARK_NUM_WARMUP_ITERATIONS = 2;
+index_t BENCHMARK_NUM_ITERATIONS = 20;
 
 //-----------------------------------------------------------------------------
-template <typename SetupFn, typename RunFn>
-void
-run_benchmark(const std::string &name,
-              SetupFn &&setup,
-              RunFn &&run)
+// Reports vertex/element counts for the input and output meshes. Some
+// operations (e.g. generate_corners) produce far more elements than they
+// started with, so it's worth recording both sides.
+std::string
+mesh_size_info(const Node &input, const Node &output)
 {
-    benchmark::exec(name,
-                    std::forward<SetupFn>(setup),
-                    std::forward<RunFn>(run),
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
+    const index_t inverts  = blueprint::mesh::coordset::length(input["coordsets"].child(0));
+    const index_t inelems  = blueprint::mesh::topology::length(input["topologies"].child(0));
+    const index_t outverts = blueprint::mesh::coordset::length(output["coordsets"].child(0));
+    const index_t outelems = blueprint::mesh::topology::length(output["topologies"].child(0));
+
+    return "inverts-"   + std::to_string(inverts)
+         + "_inelems-"  + std::to_string(inelems)
+         + "_outverts-" + std::to_string(outverts)
+         + "_outelems-" + std::to_string(outelems);
 }
 
 //-----------------------------------------------------------------------------
 void
 make_braid_dataset(const std::string &src_type,
-                   const benchmark::ExecConfig &config,
                    const index_t npts,
                    Node &src)
 {
@@ -59,6 +62,7 @@ make_braid_dataset(const std::string &src_type,
 
     const index_t npts_z = is_2d ? 0 : npts;
 
+    // Braid will reset `src` for us internally 
     blueprint::mesh::examples::braid(src_type,
                                      npts,
                                      npts,
@@ -67,171 +71,121 @@ make_braid_dataset(const std::string &src_type,
 }
 
 //-----------------------------------------------------------------------------
-void
-benchmark_mesh_convert(const std::string &name,
-                       const std::string &src_type,
-                       const std::string &target)
+// One mesh::convert() benchmark: convert a braid `src_type` mesh to `target`.
+struct ConvertConfig
 {
-    // Create the source Node once and reuse it for every iteration
-    auto setup = [&](const benchmark::ExecConfig &config,
-                               const index_t npts,
-                               Node &src) {
-        make_braid_dataset(src_type, config, npts, src);
-    };
-
-    // The type being converted to
-    Node options;
-    options["target"] = target;
-
-    // Perform the conversion
-    auto run = [&](const Node &src, Node &dst) {
-        blueprint::mesh::convert(src, options, dst);
-    };
-
-    // Launch the benchmark
-    run_benchmark(name, setup, run);
-}
+    std::string name;
+    std::string src_type;
+    std::string target;
+};
 
 //-----------------------------------------------------------------------------
-// generate_offsets has no blueprint::mesh::convert() target.
 void
-benchmark_topology_generate_offsets(const std::string &name,
-                                    const std::string &src_type)
+run_benchmarks(const std::vector<ConvertConfig> &convert_configs)
 {
-    // Create the source Node once and reuse it for every iteration
-    auto setup = [&](const benchmark::ExecConfig &config,
-                               const index_t npts,
-                               Node &src) {
-        make_braid_dataset(src_type, config, npts, src);
-    };
+    // The available execution configurations (host/device) based
+    // on what Conduit was compiled with.
+    const auto exec_configs = benchmark::get_exec_configs();
 
-    // Perform the conversion
-    auto run = [&](const Node &src, Node &dst) {
-        blueprint::mesh::topology::unstructured::generate_offsets(
-            src["topologies"].child(0),
-            dst);
-    };
+    // We create src and dst nodes once and reuse them across all benchmarks
+    Node src;
+    Node dst;
 
-    // Launch the benchmark
-    run_benchmark(name, setup, run);
-}
-
-//-----------------------------------------------------------------------------
-// generate_offsets_inline also has no blueprint::mesh::convert() target.
-void
-benchmark_topology_generate_offsets_inline(const std::string &name,
-                                           const std::string &src_type)
-{
-    // This conversion is unique in that it mutates its argument in place,
-    // and is a no-op if the offsets already exist.
-    Node topo;
-
-    // Create the source Node once, but in this case we reuse topo
-    // instead of src.
-    auto setup = [&](const benchmark::ExecConfig &config,
-                               const index_t npts,
-                               Node &src) {
-        make_braid_dataset(src_type, config, npts, src);
-        topo.set(src["topologies"].child(0));
-    };
-
-    // Perform the conversion
-    auto run = [&](const Node &, Node &) {
-        if (topo.has_path("elements/offsets"))
+    // Iterating over the dimension sizes first allows us to reuse `src`
+    // across benchmarks that use the same `src_type` and `npts`, reducing
+    // overall runtime and memory usage.
+    for (const auto npts : BENCHMARK_DIM_SIZES)
+    {
+        // Iterating over `exec_configs` second will allow us to reuse `src`
+        // across all configurations of a particular `src_location`. This
+        // allows us to create `src` once for host and once for device,
+        // per `src_type` and `npts` combination.
+        std::string built_src_type;
+        for (const auto &exec_config : exec_configs)
         {
-            // Remove the offsets before each iteration to
-            // avoid a no-op.
-            topo["elements"].remove_child("offsets");
+            // This iterates over all of the benchmark configurations
+            // themselves (i.e., which source and target types to use).
+            for (const auto &convert_config : convert_configs)
+            {
+                // Since multiple benchmarks will use the same
+                // src_type and npts, we can improve performance and
+                // limit memory utilization by only rebuilding `src`
+                // when the next entry's (src_type, npts) differs.
+                if (convert_config.src_type != built_src_type)
+                {
+                    make_braid_dataset(convert_config.src_type, npts, src);
+                    built_src_type = convert_config.src_type;
+                }
+
+                // TODO: There may be other interesting options
+                Node options;
+                options["target"] = convert_config.target;
+
+                // This lambda defines the code to be benchmarked
+                auto run = [&](const Node &input, Node &output) {
+                    blueprint::mesh::convert(input, options, output);
+                };
+
+                // This executes a benchmark of the current configuration
+                benchmark::exec(convert_config.name,
+                                src,
+                                dst,
+                                run,
+                                mesh_size_info,
+                                exec_config,
+                                npts,
+                                BENCHMARK_NUM_WARMUP_ITERATIONS,
+                                BENCHMARK_NUM_ITERATIONS);
+            }
         }
-
-        blueprint::mesh::topology::unstructured::
-            generate_offsets_inline(topo);
-    };
-
-    // Launch the benchmark
-    run_benchmark(name, setup, run);
+    }
 }
 
 //-----------------------------------------------------------------------------
+// Benchmarks that measure the performance of full mesh conversions
 TEST(blueprint_mesh_transform_benchmark, mesh_transforms)
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
 
-    // mesh::convert converts an entire mesh, including both its coordset and
-    // topology.
-    benchmark_mesh_convert("mesh_uniform_to_rectilinear",
-                           "uniform",
-                           "rectilinear");
-
-    benchmark_mesh_convert("mesh_uniform_to_structured",
-                           "uniform",
-                           "structured");
-
-    benchmark_mesh_convert("mesh_uniform_to_unstructured",
-                           "uniform",
-                           "unstructured");
-
-    benchmark_mesh_convert("mesh_rectilinear_to_structured",
-                           "rectilinear",
-                           "structured");
-
-    benchmark_mesh_convert("mesh_rectilinear_to_unstructured",
-                           "rectilinear",
-                           "unstructured");
-
-    benchmark_mesh_convert("mesh_structured_to_unstructured",
-                           "structured",
-                           "unstructured");
+    run_benchmarks({
+        {"mesh_uniform_to_rectilinear",      "uniform",     "rectilinear"},
+        {"mesh_uniform_to_structured",       "uniform",     "structured"},
+        {"mesh_uniform_to_unstructured",     "uniform",     "unstructured"},
+        {"mesh_rectilinear_to_structured",   "rectilinear", "structured"},
+        {"mesh_rectilinear_to_unstructured", "rectilinear", "unstructured"},
+        {"mesh_structured_to_unstructured",  "structured",  "unstructured"},
+    });
 }
 
 //-----------------------------------------------------------------------------
-TEST(blueprint_mesh_transform_benchmark, unstructured_generate_transforms)
+TEST(blueprint_mesh_transform_benchmark, generate_transforms)
+// Benchmarks that measure the performance of mesh generation transforms
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
-
-    // Exercise fixed-shape and mixed-shape 2D and 3D unstructured cell
-    // meshes.
-    const std::vector<std::string> source_types = {
-        "tris",
+    
+    const std::vector<std::string> shapes = {
         "quads",
-        // "mixed_2d", // segfaults
-        "tets",
         "hexs",
-        "wedges",
-        "pyramids",
-        // "mixed" // segfaults
+        "pyramids", // particularly slow pre-device execution
+        // "mixed_2d", // TODO: investigate why this segfaults
+        // "mixed" // TODO: investigate why this segfaults
     };
 
-    for (const std::string &src_type : source_types)
+    // Building this list programatically makes it easy to benchmark with
+    // different shape types.
+    std::vector<ConvertConfig> configs;
+    for (const auto &shape : shapes)
     {
-        benchmark_mesh_convert("unstructured_to_polytopal_" + src_type,
-                               src_type,
-                               "polytopal");
-        benchmark_mesh_convert("unstructured_generate_points_" + src_type,
-                               src_type,
-                               "generate_points");
-        benchmark_mesh_convert("unstructured_generate_lines_" + src_type,
-                               src_type,
-                               "generate_lines");
-        benchmark_mesh_convert("unstructured_generate_faces_" + src_type,
-                               src_type,
-                               "generate_faces");
-        benchmark_mesh_convert("unstructured_generate_centroids_" + src_type,
-                               src_type,
-                               "generate_centroids");
-        benchmark_mesh_convert("unstructured_generate_sides_" + src_type,
-                               src_type,
-                               "generate_sides");
-        benchmark_mesh_convert("unstructured_generate_corners_" + src_type,
-                               src_type,
-                               "generate_corners");
-        benchmark_topology_generate_offsets(
-            "unstructured_generate_offsets_" + src_type,
-            src_type);
-        benchmark_topology_generate_offsets_inline(
-            "unstructured_generate_offsets_inline_" + src_type,
-            src_type);
+        configs.push_back({"to_polytopal_" + shape,       shape, "polytopal"});
+        configs.push_back({"generate_points_" + shape,    shape, "generate_points"});
+        configs.push_back({"generate_lines_" + shape,     shape, "generate_lines"});
+        configs.push_back({"generate_faces_" + shape,     shape, "generate_faces"});
+        configs.push_back({"generate_centroids_" + shape, shape, "generate_centroids"});
+        configs.push_back({"generate_sides_" + shape,     shape, "generate_sides"});
+        configs.push_back({"generate_corners_" + shape,   shape, "generate_corners"});
     }
+
+    run_benchmarks(configs);
 }
 
 //-----------------------------------------------------------------------------
@@ -250,14 +204,12 @@ main(int argc, char *argv[])
 
     if (argc >= 2)
     {
-        BENCHMARK_NUM_WARMUP_ITERATIONS =
-            static_cast<index_t>(std::atoll(argv[1]));
+        BENCHMARK_NUM_WARMUP_ITERATIONS = static_cast<index_t>(std::atoll(argv[1]));
     }
 
     if (argc >= 3)
     {
-        BENCHMARK_NUM_ITERATIONS =
-            static_cast<index_t>(std::atoll(argv[2]));
+        BENCHMARK_NUM_ITERATIONS = static_cast<index_t>(std::atoll(argv[2]));
     }
 
     if (argc >= 4)
@@ -266,8 +218,7 @@ main(int argc, char *argv[])
 
         for (int i = 3; i < argc; i++)
         {
-            BENCHMARK_DIM_SIZES.push_back(
-                static_cast<index_t>(std::atoll(argv[i])));
+            BENCHMARK_DIM_SIZES.push_back(static_cast<index_t>(std::atoll(argv[i])));
         }
     }
 
@@ -275,26 +226,27 @@ main(int argc, char *argv[])
     {
         if (dim_size <= 1)
         {
-            std::cerr
-                << "ERROR: braid benchmark dimensions must be greater than "
-                   "1; received "
-                << dim_size << "."
-                << std::endl;
-
-            return EXIT_FAILURE;
+            // Braid will error if this is the case, so we may
+            // as well not go any further.
+            CONDUIT_ERROR("Mesh transform benchmark dimensions must be "
+                          "greater than 1; received " << dim_size << ".");
         }
     }
 
     // TODO: Look at Caliper options related to OpenMP/GPU profiling.
     const std::string timestamp = benchmark::get_timestamp();
 
+    // Caliper options can be configured here
     Node cali_opts;
     cali_opts["config"] = "hatchet-region-profile(output=" + timestamp + ".cali)";
 
+    // Begin timing
     annotations::initialize(cali_opts);
 
+    // Run all benchmarks
     const int result = RUN_ALL_TESTS();
 
+    // Finalize timing
     annotations::finalize();
 
     return result;

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -266,7 +266,8 @@ main(int argc, char *argv[])
 
     // Caliper options can be configured here
     Node cali_opts;
-    cali_opts["config"] = "runtime-report, hatchet-region-profile";
+    // TODO: Investigate spot vs hatchet-region-profile
+    cali_opts["config"] = "runtime-report,hatchet-region-profile(output=" + timestamp + ".cali)";
 
     // Begin timing
     annotations::initialize(cali_opts);

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -15,11 +15,30 @@
 
 #include "gtest/gtest.h"
 
+#include <iostream>
+#include <utility>
+
 using namespace conduit;
 
+// Intentionally small by default, to minimize CI time spent benchmarking
 std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4};
 index_t BENCHMARK_NUM_WARMUP_ITERATIONS  = 10;
 index_t BENCHMARK_NUM_ITERATIONS         = 100;
+
+//-----------------------------------------------------------------------------
+template <typename SetupFn, typename RunFn>
+void
+run_benchmark(const std::string &name,
+              SetupFn &&setup,
+              RunFn &&run)
+{
+    benchmark::exec(name,
+                    std::forward<SetupFn>(setup),
+                    std::forward<RunFn>(run),
+                    BENCHMARK_NUM_WARMUP_ITERATIONS,
+                    BENCHMARK_NUM_ITERATIONS,
+                    BENCHMARK_DIM_SIZES);
+}
 
 //-----------------------------------------------------------------------------
 void
@@ -35,11 +54,17 @@ make_braid_dataset(const std::string &src_type,
 }
 
 //-----------------------------------------------------------------------------
-// 2D braid element types error out if given a non-zero z dimension
+// 2D braid element types error out if given a non-zero z dimension,
+// so clamp npts_z to zero for them.
 index_t
-braid_bound_npts_z(const std::string &mesh_type, index_t npts_z)
+braid_npts_z(const std::string &mesh_type,
+             index_t npts_z)
 {
-    return (mesh_type == "tris" || mesh_type == "quads") ? 0 : npts_z;
+    if (mesh_type == "tris" || mesh_type == "quads")
+    {
+        return 0;
+    }
+    return npts_z;
 }
 
 //-----------------------------------------------------------------------------
@@ -51,13 +76,13 @@ make_unstructured_braid_dataset(const std::string &src_type,
     blueprint::mesh::examples::braid(src_type,
                                      config.dim_size,
                                      config.dim_size,
-                                     braid_bound_npts_z(src_type, config.dim_size),
+                                     braid_npts_z(src_type, config.dim_size),
                                      src);
 }
 
 //-----------------------------------------------------------------------------
 void
-benchmark_coordset_transform(const char *name,
+benchmark_coordset_transform(const std::string &name,
                              const std::string &src_type,
                              void (*transform)(const Node &, Node &))
 {
@@ -67,51 +92,43 @@ benchmark_coordset_transform(const char *name,
     };
 
     // Perform a transform on the source Node
-    auto run = [=](const Node &src) {
-        Node dst;
+    auto run = [&](const Node &src, Node &dst) {
         transform(src["coordsets"].child(0), dst);
     };
 
-    // Execute the benchmark
-    benchmark::exec(name,
-                    setup,
-                    run,
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
+    run_benchmark(name, setup, run);
 }
 
 //-----------------------------------------------------------------------------
+// Benchmarks blueprint::mesh::convert(), which covers every topology and
+// unstructured-generate transform below.
 void
-benchmark_topology_transform(const char *name,
-                             const std::string &src_type,
-                             void (*transform)(const Node &, Node &, Node &))
+benchmark_mesh_convert(const std::string &name,
+                       void (*make_dataset)(const std::string &, const benchmark::ExecConfig &, Node &),
+                       const std::string &src_type,
+                       const std::string &target)
 {
     // Create the source Node once and reuse it for each iteration
     auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_braid_dataset(src_type, config, src);
+        make_dataset(src_type, config, src);
     };
+
+    Node options;
+    options["target"] = target;
 
     // Perform a transform on the source Node
-    auto run = [=](const Node &src) {
-        Node topo_dst, coords_dst;
-        transform(src["topologies"].child(0), topo_dst, coords_dst);
+    auto run = [&](const Node &src, Node &dst) {
+        blueprint::mesh::convert(src, options, dst);
     };
 
-    // Execute the benchmark
-    benchmark::exec(name,
-                    setup,
-                    run,
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
+    run_benchmark(name, setup, run);
 }
 
 //-----------------------------------------------------------------------------
+// generate_offsets has no blueprint::mesh::convert() target.
 void
-benchmark_topo_generate_single(const char *name,
-                               const std::string &src_type,
-                               void (*transform)(const Node &, Node &))
+benchmark_topology_generate_offsets(const std::string &name,
+                                    const std::string &src_type)
 {
     // Create the source Node once and reuse it for each iteration
     auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
@@ -119,103 +136,51 @@ benchmark_topo_generate_single(const char *name,
     };
 
     // Perform a transform on the source Node
-    auto run = [=](const Node &src) {
-        Node dst;
-        transform(src["topologies"].child(0), dst);
+    auto run = [&](const Node &src, Node &dst) {
+        blueprint::mesh::topology::unstructured::generate_offsets(src["topologies"].child(0),
+                                                                  dst);
     };
 
-    // Execute the benchmark
-    benchmark::exec(name,
-                    setup,
-                    run,
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
+    run_benchmark(name, setup, run);
 }
 
 //-----------------------------------------------------------------------------
+// generate_offsets_inline also has no blueprint::mesh::convert() target.
 void
-benchmark_topo_generate_maps(const char *name,
-                             const std::string &src_type,
-                             void (*transform)(const Node &, Node &, Node &, Node &))
+benchmark_topology_generate_offsets_inline(const std::string &name,
+                                           const std::string &src_type)
 {
-    // Create the source Node once and reuse it for each iteration
+    // generate_offsets_inline mutates its argument in place and is a no-op
+    // if offsets are already present, so keep a working copy of the source
+    // topology alive across iterations and strip its offsets before each
+    // run.
+    Node topo;
+
+    // Create the working topology once and reuse it for each iteration
     auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
         make_unstructured_braid_dataset(src_type, config, src);
+        topo.set(src["topologies"].child(0));
     };
 
-    // Perform a transform on the source Node
-    auto run = [=](const Node &src) {
-        Node dst, s2dmap, d2smap;
-        transform(src["topologies"].child(0), dst, s2dmap, d2smap);
+    // Perform the transform on the working topology
+    auto run = [&](const Node &, Node &) {
+        if (topo.has_path("elements/offsets"))
+        {
+            topo["elements"].remove_child("offsets");
+        }
+        blueprint::mesh::topology::unstructured::generate_offsets_inline(topo);
     };
 
-    // Execute the benchmark
-    benchmark::exec(name,
-                    setup,
-                    run,
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
-}
-
-//-----------------------------------------------------------------------------
-void
-benchmark_topo_generate_topo_coords_maps(const char *name,
-                                         const std::string &src_type,
-                                         void (*transform)(const Node &, Node &, Node &, Node &, Node &))
-{
-    // Create the source Node once and reuse it for each iteration
-    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_unstructured_braid_dataset(src_type, config, src);
-    };
-
-    // Perform a transform on the source Node
-    auto run = [=](const Node &src) {
-        Node topo_dst, coords_dst, s2dmap, d2smap;
-        transform(src["topologies"].child(0), topo_dst, coords_dst, s2dmap, d2smap);
-    };
-
-    // Execute the benchmark
-    benchmark::exec(name,
-                    setup,
-                    run,
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
-}
-
-//-----------------------------------------------------------------------------
-void
-benchmark_topo_generate_offsets_inline(const char *name,
-                                       const std::string &src_type)
-{
-    // Create the source Node once and reuse it for each iteration
-    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_unstructured_braid_dataset(src_type, config, src);
-    };
-
-    // generate_offsets_inline mutates its argument in place and is a no-op if
-    // offsets are already present, so each iteration needs its own copy of
-    // the source topology to do real work.
-    auto run = [=](const Node &src) {
-        Node topo_copy;
-        topo_copy.set(src["topologies"].child(0));
-        blueprint::mesh::topology::unstructured::generate_offsets_inline(topo_copy);
-    };
-
-    // Execute the benchmark
-    benchmark::exec(name,
-                    setup,
-                    run,
-                    BENCHMARK_NUM_WARMUP_ITERATIONS,
-                    BENCHMARK_NUM_ITERATIONS,
-                    BENCHMARK_DIM_SIZES);
+    run_benchmark(name, setup, run);
 }
 
 //-----------------------------------------------------------------------------
 TEST(blueprint_mesh_transform_benchmark, coordset_transforms)
 {
+    // This is not an exhaustive benchmark of the coordset transforms;
+    // it only includes the ones that made sense to port to the device
+    // execution model.
+
     CONDUIT_ANNOTATE_MARK_FUNCTION;
     benchmark_coordset_transform("coordset_uniform_to_rectilinear",
                                  "uniform",
@@ -231,52 +196,67 @@ TEST(blueprint_mesh_transform_benchmark, coordset_transforms)
 //-----------------------------------------------------------------------------
 TEST(blueprint_mesh_transform_benchmark, topology_transforms)
 {
+    // This is not an exhaustive benchmark of the topology transforms;
+    // it only includes 'to_unstructured' since that is the only transform
+    // that made sense to port to the device execution model.
+
     CONDUIT_ANNOTATE_MARK_FUNCTION;
-    benchmark_topology_transform("topology_uniform_to_unstructured",
-                                 "uniform",
-                                 blueprint::mesh::topology::uniform::to_unstructured);
-    benchmark_topology_transform("topology_rectilinear_to_unstructured",
-                                 "rectilinear",
-                                 blueprint::mesh::topology::rectilinear::to_unstructured);
-    benchmark_topology_transform("topology_structured_to_unstructured",
-                                 "structured",
-                                 blueprint::mesh::topology::structured::to_unstructured);
+    benchmark_mesh_convert("topology_uniform_to_unstructured",
+                           make_braid_dataset,
+                           "uniform",
+                           "unstructured");
+    benchmark_mesh_convert("topology_rectilinear_to_unstructured",
+                           make_braid_dataset,
+                           "rectilinear",
+                           "unstructured");
+    benchmark_mesh_convert("topology_structured_to_unstructured",
+                           make_braid_dataset,
+                           "structured",
+                           "unstructured");
 }
 
 //-----------------------------------------------------------------------------
 TEST(blueprint_mesh_transform_benchmark, unstructured_generate_transforms)
 {
+    // This is not an exhaustive benchmark of the unstructured generate
+    // transforms; it only includes the ones that made sense to port to the
+    // device execution model.
+
     CONDUIT_ANNOTATE_MARK_FUNCTION;
     for (const std::string &src_type : {"quads", "hexs"})
     {
-        benchmark_topo_generate_single(("to_polytopal_" + src_type).c_str(),
-            src_type,
-            blueprint::mesh::topology::unstructured::to_polytopal);
-        benchmark_topo_generate_single(("generate_offsets_" + src_type).c_str(),
-            src_type,
-            static_cast<void (*)(const Node &, Node &)>(
-                blueprint::mesh::topology::unstructured::generate_offsets));
-        benchmark_topo_generate_maps(("generate_points_" + src_type).c_str(),
-            src_type,
-            blueprint::mesh::topology::unstructured::generate_points);
-        benchmark_topo_generate_maps(("generate_lines_" + src_type).c_str(),
-            src_type,
-            blueprint::mesh::topology::unstructured::generate_lines);
-        benchmark_topo_generate_maps(("generate_faces_" + src_type).c_str(),
-            src_type,
-            blueprint::mesh::topology::unstructured::generate_faces);
-        benchmark_topo_generate_topo_coords_maps(("generate_centroids_" + src_type).c_str(),
-            src_type,
-            blueprint::mesh::topology::unstructured::generate_centroids);
-        benchmark_topo_generate_topo_coords_maps(("generate_sides_" + src_type).c_str(),
-            src_type,
-            static_cast<void (*)(const Node &, Node &, Node &, Node &, Node &)>(
-                blueprint::mesh::topology::unstructured::generate_sides));
-        benchmark_topo_generate_topo_coords_maps(("generate_corners_" + src_type).c_str(),
-            src_type,
-            blueprint::mesh::topology::unstructured::generate_corners);
-        benchmark_topo_generate_offsets_inline(("generate_offsets_inline_" + src_type).c_str(),
-            src_type);
+        benchmark_mesh_convert("unstructured_to_polytopal_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "polytopal");
+        benchmark_mesh_convert("unstructured_generate_points_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "generate_points");
+        benchmark_mesh_convert("unstructured_generate_lines_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "generate_lines");
+        benchmark_mesh_convert("unstructured_generate_faces_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "generate_faces");
+        benchmark_mesh_convert("unstructured_generate_centroids_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "generate_centroids");
+        benchmark_mesh_convert("unstructured_generate_sides_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "generate_sides");
+        benchmark_mesh_convert("unstructured_generate_corners_" + src_type,
+                               make_unstructured_braid_dataset,
+                               src_type,
+                               "generate_corners");
+        benchmark_topology_generate_offsets("unstructured_generate_offsets_" + src_type,
+                                            src_type);
+        benchmark_topology_generate_offsets_inline("unstructured_generate_offsets_inline_" + src_type,
+                                                   src_type);
     }
 }
 
@@ -284,6 +264,13 @@ TEST(blueprint_mesh_transform_benchmark, unstructured_generate_transforms)
 int main(int argc, char *argv[])
 {
     ::testing::InitGoogleTest(&argc, argv);
+
+    if (!annotations::supported())
+    {
+        std::cout << "WARNING: conduit was built without Caliper support, "
+                     "so this benchmark will run but will not produce any "
+                     "timing output (.cali file)." << std::endl;
+    }
 
     if (argc >= 2)
     {

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -17,7 +17,7 @@
 
 using namespace conduit;
 
-std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4, 8, 16, 32, 64};
+std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4};
 index_t BENCHMARK_NUM_WARMUP_ITERATIONS  = 10;
 index_t BENCHMARK_NUM_ITERATIONS         = 100;
 
@@ -31,6 +31,27 @@ make_braid_dataset(const std::string &src_type,
                                      config.dim_size,
                                      config.dim_size,
                                      config.dim_size,
+                                     src);
+}
+
+//-----------------------------------------------------------------------------
+// 2D braid element types error out if given a non-zero z dimension
+index_t
+braid_bound_npts_z(const std::string &mesh_type, index_t npts_z)
+{
+    return (mesh_type == "tris" || mesh_type == "quads") ? 0 : npts_z;
+}
+
+//-----------------------------------------------------------------------------
+void
+make_unstructured_braid_dataset(const std::string &src_type,
+                                const benchmark::ExecConfig &config,
+                                Node &src)
+{
+    blueprint::mesh::examples::braid(src_type,
+                                     config.dim_size,
+                                     config.dim_size,
+                                     braid_bound_npts_z(src_type, config.dim_size),
                                      src);
 }
 
@@ -87,6 +108,112 @@ benchmark_topology_transform(const char *name,
 }
 
 //-----------------------------------------------------------------------------
+void
+benchmark_topo_generate_single(const char *name,
+                               const std::string &src_type,
+                               void (*transform)(const Node &, Node &))
+{
+    // Create the source Node once and reuse it for each iteration
+    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
+        make_unstructured_braid_dataset(src_type, config, src);
+    };
+
+    // Perform a transform on the source Node
+    auto run = [=](const Node &src) {
+        Node dst;
+        transform(src["topologies"].child(0), dst);
+    };
+
+    // Execute the benchmark
+    benchmark::exec(name,
+                    setup,
+                    run,
+                    BENCHMARK_NUM_WARMUP_ITERATIONS,
+                    BENCHMARK_NUM_ITERATIONS,
+                    BENCHMARK_DIM_SIZES);
+}
+
+//-----------------------------------------------------------------------------
+void
+benchmark_topo_generate_maps(const char *name,
+                             const std::string &src_type,
+                             void (*transform)(const Node &, Node &, Node &, Node &))
+{
+    // Create the source Node once and reuse it for each iteration
+    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
+        make_unstructured_braid_dataset(src_type, config, src);
+    };
+
+    // Perform a transform on the source Node
+    auto run = [=](const Node &src) {
+        Node dst, s2dmap, d2smap;
+        transform(src["topologies"].child(0), dst, s2dmap, d2smap);
+    };
+
+    // Execute the benchmark
+    benchmark::exec(name,
+                    setup,
+                    run,
+                    BENCHMARK_NUM_WARMUP_ITERATIONS,
+                    BENCHMARK_NUM_ITERATIONS,
+                    BENCHMARK_DIM_SIZES);
+}
+
+//-----------------------------------------------------------------------------
+void
+benchmark_topo_generate_topo_coords_maps(const char *name,
+                                         const std::string &src_type,
+                                         void (*transform)(const Node &, Node &, Node &, Node &, Node &))
+{
+    // Create the source Node once and reuse it for each iteration
+    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
+        make_unstructured_braid_dataset(src_type, config, src);
+    };
+
+    // Perform a transform on the source Node
+    auto run = [=](const Node &src) {
+        Node topo_dst, coords_dst, s2dmap, d2smap;
+        transform(src["topologies"].child(0), topo_dst, coords_dst, s2dmap, d2smap);
+    };
+
+    // Execute the benchmark
+    benchmark::exec(name,
+                    setup,
+                    run,
+                    BENCHMARK_NUM_WARMUP_ITERATIONS,
+                    BENCHMARK_NUM_ITERATIONS,
+                    BENCHMARK_DIM_SIZES);
+}
+
+//-----------------------------------------------------------------------------
+void
+benchmark_topo_generate_offsets_inline(const char *name,
+                                       const std::string &src_type)
+{
+    // Create the source Node once and reuse it for each iteration
+    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
+        make_unstructured_braid_dataset(src_type, config, src);
+    };
+
+    // generate_offsets_inline mutates its argument in place and is a no-op if
+    // offsets are already present, so each iteration needs its own copy of
+    // the source topology to do real work.
+    auto run = [=](const Node &src) {
+        Node topo_copy;
+        topo_copy.set(src["topologies"].child(0));
+        blueprint::mesh::topology::unstructured::generate_offsets_inline(topo_copy);
+    };
+
+    // Execute the benchmark
+    benchmark::exec(name,
+                    setup,
+                    run,
+                    BENCHMARK_NUM_WARMUP_ITERATIONS,
+                    BENCHMARK_NUM_ITERATIONS,
+                    BENCHMARK_DIM_SIZES);
+}
+
+//-----------------------------------------------------------------------------
 TEST(blueprint_mesh_transform_benchmark, coordset_transforms)
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
@@ -105,24 +232,52 @@ TEST(blueprint_mesh_transform_benchmark, coordset_transforms)
 TEST(blueprint_mesh_transform_benchmark, topology_transforms)
 {
     CONDUIT_ANNOTATE_MARK_FUNCTION;
-    benchmark_topology_transform("topology_uniform_to_rectilinear",
-                                 "uniform",
-                                 blueprint::mesh::topology::uniform::to_rectilinear);
-    benchmark_topology_transform("topology_uniform_to_structured",
-                                 "uniform",
-                                 blueprint::mesh::topology::uniform::to_structured);
     benchmark_topology_transform("topology_uniform_to_unstructured",
                                  "uniform",
                                  blueprint::mesh::topology::uniform::to_unstructured);
-    benchmark_topology_transform("topology_rectilinear_to_structured",
-                                 "rectilinear",
-                                 blueprint::mesh::topology::rectilinear::to_structured);
     benchmark_topology_transform("topology_rectilinear_to_unstructured",
                                  "rectilinear",
                                  blueprint::mesh::topology::rectilinear::to_unstructured);
     benchmark_topology_transform("topology_structured_to_unstructured",
                                  "structured",
                                  blueprint::mesh::topology::structured::to_unstructured);
+}
+
+//-----------------------------------------------------------------------------
+TEST(blueprint_mesh_transform_benchmark, unstructured_generate_transforms)
+{
+    CONDUIT_ANNOTATE_MARK_FUNCTION;
+    for (const std::string &src_type : {"quads", "hexs"})
+    {
+        benchmark_topo_generate_single(("to_polytopal_" + src_type).c_str(),
+            src_type,
+            blueprint::mesh::topology::unstructured::to_polytopal);
+        benchmark_topo_generate_single(("generate_offsets_" + src_type).c_str(),
+            src_type,
+            static_cast<void (*)(const Node &, Node &)>(
+                blueprint::mesh::topology::unstructured::generate_offsets));
+        benchmark_topo_generate_maps(("generate_points_" + src_type).c_str(),
+            src_type,
+            blueprint::mesh::topology::unstructured::generate_points);
+        benchmark_topo_generate_maps(("generate_lines_" + src_type).c_str(),
+            src_type,
+            blueprint::mesh::topology::unstructured::generate_lines);
+        benchmark_topo_generate_maps(("generate_faces_" + src_type).c_str(),
+            src_type,
+            blueprint::mesh::topology::unstructured::generate_faces);
+        benchmark_topo_generate_topo_coords_maps(("generate_centroids_" + src_type).c_str(),
+            src_type,
+            blueprint::mesh::topology::unstructured::generate_centroids);
+        benchmark_topo_generate_topo_coords_maps(("generate_sides_" + src_type).c_str(),
+            src_type,
+            static_cast<void (*)(const Node &, Node &, Node &, Node &, Node &)>(
+                blueprint::mesh::topology::unstructured::generate_sides));
+        benchmark_topo_generate_topo_coords_maps(("generate_corners_" + src_type).c_str(),
+            src_type,
+            blueprint::mesh::topology::unstructured::generate_corners);
+        benchmark_topo_generate_offsets_inline(("generate_offsets_inline_" + src_type).c_str(),
+            src_type);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -23,9 +23,7 @@
 
 using namespace conduit;
 
-// Number of vertices per axis, braid requires at least two. Larger sizes
-// (e.g. 8) can be passed on the command line for deeper, one-off runs; some
-// shapes (e.g. pyramids) scale much worse than others at that size.
+// Number of vertices per axis, braid requires at least two
 std::vector<index_t> BENCHMARK_DIM_SIZES = {2};
 
 // Small by default, to minimize CI time spent benchmarking
@@ -35,7 +33,7 @@ index_t BENCHMARK_NUM_ITERATIONS = 20;
 //-----------------------------------------------------------------------------
 // Reports vertex/element counts for the input and output meshes. Some
 // operations (e.g. generate_corners) produce far more elements than they
-// started with, so it's worth recording both sides.
+// started with, so it's worth recording both.
 std::string
 mesh_size_info(const Node &input, const Node &output)
 {

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -118,6 +118,7 @@ run_benchmarks(const std::vector<ConvertConfig> &convert_configs)
                 // TODO: There may be other interesting options
                 Node options;
                 options["target"] = convert_config.target;
+                options["copy"]   = 0;
 
                 // This lambda defines the code to be benchmarked
                 auto run = [&](const Node &input, Node &output) {

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -170,7 +170,7 @@ TEST(blueprint_mesh_transform_benchmark, generate_transforms)
         // "mixed"     // TODO: investigate why this segfaults
     };
 
-    // Building this list programatically makes it easy to benchmark with
+    // Building this list programmatically makes it easy to benchmark with
     // different shape types.
     std::vector<ConvertConfig> configs;
     for (const auto &shape : shapes)

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -266,7 +266,7 @@ main(int argc, char *argv[])
 
     // Caliper options can be configured here
     Node cali_opts;
-    cali_opts["config"] = "hatchet-region-profile(output=" + timestamp + ".cali)";
+    cali_opts["config"] = "runtime-report, hatchet-region-profile";
 
     // Begin timing
     annotations::initialize(cali_opts);

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -166,9 +166,9 @@ TEST(blueprint_mesh_transform_benchmark, generate_transforms)
     const std::vector<std::string> shapes = {
         "quads",
         "hexs",
-        "pyramids", // particularly slow pre-device execution
+        "pyramids",    // particularly slow pre-device execution
         // "mixed_2d", // TODO: investigate why this segfaults
-        // "mixed" // TODO: investigate why this segfaults
+        // "mixed"     // TODO: investigate why this segfaults
     };
 
     // Building this list programatically makes it easy to benchmark with
@@ -233,7 +233,7 @@ main(int argc, char *argv[])
         }
     }
 
-    // TODO: Look at Caliper options related to OpenMP/GPU profiling.
+    // TODO: Look at Caliper options related to OpenMP/GPU profiling
     const std::string timestamp = benchmark::get_timestamp();
 
     // Caliper options can be configured here

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -12,18 +12,24 @@
 #include "conduit_annotations.hpp"
 #include "conduit_benchmark.hpp"
 #include "conduit_blueprint.hpp"
+#include "conduit_core.hpp"
 
 #include "gtest/gtest.h"
 
+#include <cstdlib>
 #include <iostream>
+#include <string>
 #include <utility>
+#include <vector>
 
 using namespace conduit;
 
-// Intentionally small by default, to minimize CI time spent benchmarking
-std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4};
-index_t BENCHMARK_NUM_WARMUP_ITERATIONS  = 10;
-index_t BENCHMARK_NUM_ITERATIONS         = 100;
+// Number of points per active axis. Braid requires at least two.
+std::vector<index_t> BENCHMARK_DIM_SIZES = {2, 4, 8, 16, 32, 64, 128, 256};
+
+// Intentionally small by default, to minimize CI time spent benchmarking.
+index_t BENCHMARK_NUM_WARMUP_ITERATIONS = 10;
+index_t BENCHMARK_NUM_ITERATIONS = 100;
 
 //-----------------------------------------------------------------------------
 template <typename SetupFn, typename RunFn>
@@ -44,83 +50,45 @@ run_benchmark(const std::string &name,
 void
 make_braid_dataset(const std::string &src_type,
                    const benchmark::ExecConfig &config,
+                   const index_t npts,
                    Node &src)
 {
+    const bool is_2d = src_type == "tris" ||
+                       src_type == "quads" ||
+                       src_type == "mixed_2d";
+
+    const index_t npts_z = is_2d ? 0 : npts;
+
     blueprint::mesh::examples::braid(src_type,
-                                     config.dim_size,
-                                     config.dim_size,
-                                     config.dim_size,
+                                     npts,
+                                     npts,
+                                     npts_z,
                                      src);
 }
 
 //-----------------------------------------------------------------------------
-// 2D braid element types error out if given a non-zero z dimension,
-// so clamp npts_z to zero for them.
-index_t
-braid_npts_z(const std::string &mesh_type,
-             index_t npts_z)
-{
-    if (mesh_type == "tris" || mesh_type == "quads")
-    {
-        return 0;
-    }
-    return npts_z;
-}
-
-//-----------------------------------------------------------------------------
-void
-make_unstructured_braid_dataset(const std::string &src_type,
-                                const benchmark::ExecConfig &config,
-                                Node &src)
-{
-    blueprint::mesh::examples::braid(src_type,
-                                     config.dim_size,
-                                     config.dim_size,
-                                     braid_npts_z(src_type, config.dim_size),
-                                     src);
-}
-
-//-----------------------------------------------------------------------------
-void
-benchmark_coordset_transform(const std::string &name,
-                             const std::string &src_type,
-                             void (*transform)(const Node &, Node &))
-{
-    // Create the source Node once and reuse it for each iteration
-    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_braid_dataset(src_type, config, src);
-    };
-
-    // Perform a transform on the source Node
-    auto run = [&](const Node &src, Node &dst) {
-        transform(src["coordsets"].child(0), dst);
-    };
-
-    run_benchmark(name, setup, run);
-}
-
-//-----------------------------------------------------------------------------
-// Benchmarks blueprint::mesh::convert(), which covers every topology and
-// unstructured-generate transform below.
 void
 benchmark_mesh_convert(const std::string &name,
-                       void (*make_dataset)(const std::string &, const benchmark::ExecConfig &, Node &),
                        const std::string &src_type,
                        const std::string &target)
 {
-    // Create the source Node once and reuse it for each iteration
-    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_dataset(src_type, config, src);
+    // Create the source Node once and reuse it for every iteration
+    auto setup = [&](const benchmark::ExecConfig &config,
+                               const index_t npts,
+                               Node &src) {
+        make_braid_dataset(src_type, config, npts, src);
     };
 
+    // The type being converted to
     Node options;
     options["target"] = target;
 
-    // Perform a transform on the source Node
+    // Perform the conversion
     auto run = [&](const Node &src, Node &dst) {
         blueprint::mesh::convert(src, options, dst);
     };
 
+    // Launch the benchmark
     run_benchmark(name, setup, run);
 }
 
@@ -130,17 +98,21 @@ void
 benchmark_topology_generate_offsets(const std::string &name,
                                     const std::string &src_type)
 {
-    // Create the source Node once and reuse it for each iteration
-    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_unstructured_braid_dataset(src_type, config, src);
+    // Create the source Node once and reuse it for every iteration
+    auto setup = [&](const benchmark::ExecConfig &config,
+                               const index_t npts,
+                               Node &src) {
+        make_braid_dataset(src_type, config, npts, src);
     };
 
-    // Perform a transform on the source Node
+    // Perform the conversion
     auto run = [&](const Node &src, Node &dst) {
-        blueprint::mesh::topology::unstructured::generate_offsets(src["topologies"].child(0),
-                                                                  dst);
+        blueprint::mesh::topology::unstructured::generate_offsets(
+            src["topologies"].child(0),
+            dst);
     };
 
+    // Launch the benchmark
     run_benchmark(name, setup, run);
 }
 
@@ -150,67 +122,64 @@ void
 benchmark_topology_generate_offsets_inline(const std::string &name,
                                            const std::string &src_type)
 {
-    // generate_offsets_inline mutates its argument in place and is a no-op
-    // if offsets are already present, so keep a working copy of the source
-    // topology alive across iterations and strip its offsets before each
-    // run.
+    // This conversion is unique in that it mutates its argument in place,
+    // and is a no-op if the offsets already exist.
     Node topo;
 
-    // Create the working topology once and reuse it for each iteration
-    auto setup = [&](const benchmark::ExecConfig &config, Node &src) {
-        make_unstructured_braid_dataset(src_type, config, src);
+    // Create the source Node once, but in this case we reuse topo
+    // instead of src.
+    auto setup = [&](const benchmark::ExecConfig &config,
+                               const index_t npts,
+                               Node &src) {
+        make_braid_dataset(src_type, config, npts, src);
         topo.set(src["topologies"].child(0));
     };
 
-    // Perform the transform on the working topology
+    // Perform the conversion
     auto run = [&](const Node &, Node &) {
         if (topo.has_path("elements/offsets"))
         {
+            // Remove the offsets before each iteration to
+            // avoid a no-op.
             topo["elements"].remove_child("offsets");
         }
-        blueprint::mesh::topology::unstructured::generate_offsets_inline(topo);
+
+        blueprint::mesh::topology::unstructured::
+            generate_offsets_inline(topo);
     };
 
+    // Launch the benchmark
     run_benchmark(name, setup, run);
 }
 
 //-----------------------------------------------------------------------------
-TEST(blueprint_mesh_transform_benchmark, coordset_transforms)
+TEST(blueprint_mesh_transform_benchmark, mesh_transforms)
 {
-    // This is not an exhaustive benchmark of the coordset transforms;
-    // it only includes the ones that made sense to port to the device
-    // execution model.
-
     CONDUIT_ANNOTATE_MARK_FUNCTION;
-    benchmark_coordset_transform("coordset_uniform_to_rectilinear",
-                                 "uniform",
-                                 blueprint::mesh::coordset::uniform::to_rectilinear);
-    benchmark_coordset_transform("coordset_uniform_to_explicit",
-                                 "uniform",
-                                 blueprint::mesh::coordset::uniform::to_explicit);
-    benchmark_coordset_transform("coordset_rectilinear_to_explicit",
-                                 "rectilinear",
-                                 blueprint::mesh::coordset::rectilinear::to_explicit);
-}
 
-//-----------------------------------------------------------------------------
-TEST(blueprint_mesh_transform_benchmark, topology_transforms)
-{
-    // This is not an exhaustive benchmark of the topology transforms;
-    // it only includes 'to_unstructured' since that is the only transform
-    // that made sense to port to the device execution model.
+    // mesh::convert converts an entire mesh, including both its coordset and
+    // topology.
+    benchmark_mesh_convert("mesh_uniform_to_rectilinear",
+                           "uniform",
+                           "rectilinear");
 
-    CONDUIT_ANNOTATE_MARK_FUNCTION;
-    benchmark_mesh_convert("topology_uniform_to_unstructured",
-                           make_braid_dataset,
+    benchmark_mesh_convert("mesh_uniform_to_structured",
+                           "uniform",
+                           "structured");
+
+    benchmark_mesh_convert("mesh_uniform_to_unstructured",
                            "uniform",
                            "unstructured");
-    benchmark_mesh_convert("topology_rectilinear_to_unstructured",
-                           make_braid_dataset,
+
+    benchmark_mesh_convert("mesh_rectilinear_to_structured",
+                           "rectilinear",
+                           "structured");
+
+    benchmark_mesh_convert("mesh_rectilinear_to_unstructured",
                            "rectilinear",
                            "unstructured");
-    benchmark_mesh_convert("topology_structured_to_unstructured",
-                           make_braid_dataset,
+
+    benchmark_mesh_convert("mesh_structured_to_unstructured",
                            "structured",
                            "unstructured");
 }
@@ -218,50 +187,56 @@ TEST(blueprint_mesh_transform_benchmark, topology_transforms)
 //-----------------------------------------------------------------------------
 TEST(blueprint_mesh_transform_benchmark, unstructured_generate_transforms)
 {
-    // This is not an exhaustive benchmark of the unstructured generate
-    // transforms; it only includes the ones that made sense to port to the
-    // device execution model.
-
     CONDUIT_ANNOTATE_MARK_FUNCTION;
-    for (const std::string &src_type : {"quads", "hexs"})
+
+    // Exercise fixed-shape and mixed-shape 2D and 3D unstructured cell
+    // meshes.
+    const std::vector<std::string> source_types = {
+        "tris",
+        "quads",
+        // "mixed_2d", // segfaults
+        "tets",
+        "hexs",
+        "wedges",
+        "pyramids",
+        // "mixed" // segfaults
+    };
+
+    for (const std::string &src_type : source_types)
     {
         benchmark_mesh_convert("unstructured_to_polytopal_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "polytopal");
         benchmark_mesh_convert("unstructured_generate_points_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "generate_points");
         benchmark_mesh_convert("unstructured_generate_lines_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "generate_lines");
         benchmark_mesh_convert("unstructured_generate_faces_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "generate_faces");
         benchmark_mesh_convert("unstructured_generate_centroids_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "generate_centroids");
         benchmark_mesh_convert("unstructured_generate_sides_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "generate_sides");
         benchmark_mesh_convert("unstructured_generate_corners_" + src_type,
-                               make_unstructured_braid_dataset,
                                src_type,
                                "generate_corners");
-        benchmark_topology_generate_offsets("unstructured_generate_offsets_" + src_type,
-                                            src_type);
-        benchmark_topology_generate_offsets_inline("unstructured_generate_offsets_inline_" + src_type,
-                                                   src_type);
+        benchmark_topology_generate_offsets(
+            "unstructured_generate_offsets_" + src_type,
+            src_type);
+        benchmark_topology_generate_offsets_inline(
+            "unstructured_generate_offsets_inline_" + src_type,
+            src_type);
     }
 }
 
 //-----------------------------------------------------------------------------
-int main(int argc, char *argv[])
+int
+main(int argc, char *argv[])
 {
     ::testing::InitGoogleTest(&argc, argv);
 
@@ -269,38 +244,57 @@ int main(int argc, char *argv[])
     {
         std::cout << "WARNING: conduit was built without Caliper support, "
                      "so this benchmark will run but will not produce any "
-                     "timing output (.cali file)." << std::endl;
+                     "timing output (.cali file)."
+                  << std::endl;
     }
 
     if (argc >= 2)
     {
-        BENCHMARK_NUM_WARMUP_ITERATIONS = static_cast<index_t>(atoll(argv[1]));
+        BENCHMARK_NUM_WARMUP_ITERATIONS =
+            static_cast<index_t>(std::atoll(argv[1]));
     }
+
     if (argc >= 3)
     {
-        BENCHMARK_NUM_ITERATIONS = static_cast<index_t>(atoll(argv[2]));
+        BENCHMARK_NUM_ITERATIONS =
+            static_cast<index_t>(std::atoll(argv[2]));
     }
+
     if (argc >= 4)
     {
         BENCHMARK_DIM_SIZES.clear();
+
         for (int i = 3; i < argc; i++)
         {
-            BENCHMARK_DIM_SIZES.push_back(static_cast<index_t>(atoll(argv[i])));
+            BENCHMARK_DIM_SIZES.push_back(
+                static_cast<index_t>(std::atoll(argv[i])));
         }
     }
 
-    // TODO: Look at Caliper options related to OpenMP/GPU profiling
+    for (const index_t dim_size : BENCHMARK_DIM_SIZES)
+    {
+        if (dim_size <= 1)
+        {
+            std::cerr
+                << "ERROR: braid benchmark dimensions must be greater than "
+                   "1; received "
+                << dim_size << "."
+                << std::endl;
+
+            return EXIT_FAILURE;
+        }
+    }
+
+    // TODO: Look at Caliper options related to OpenMP/GPU profiling.
     const std::string timestamp = benchmark::get_timestamp();
+
     Node cali_opts;
     cali_opts["config"] = "hatchet-region-profile(output=" + timestamp + ".cali)";
 
-    // Begin profiling
     annotations::initialize(cali_opts);
 
-    // Begin benchmarking
     const int result = RUN_ALL_TESTS();
 
-    // End profiling
     annotations::finalize();
 
     return result;

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -28,7 +28,7 @@ std::vector<index_t> BENCHMARK_DIM_SIZES = {2};
 
 // Small by default, to minimize CI time spent benchmarking
 index_t BENCHMARK_NUM_WARMUP_ITERATIONS = 2;
-index_t BENCHMARK_NUM_ITERATIONS = 20;
+index_t BENCHMARK_NUM_ITERATIONS = 2;
 
 //-----------------------------------------------------------------------------
 // Reports vertex/element counts for the input and output meshes. Some

--- a/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_transform_benchmark.cpp
@@ -8,6 +8,35 @@
 ///
 //-----------------------------------------------------------------------------
 
+/*
+Usage:
+    t_blueprint_mesh_transform_benchmark [num_warmup_iterations]
+                                         [num_iterations]
+                                         [dim_size ...]
+
+    All arguments are optional and positional:
+      num_warmup_iterations  untimed iterations per benchmark (default: 2)
+      num_iterations         timed iterations per benchmark (default: 2)
+      dim_size ...           one or more mesh sizes, given as the number of
+                             vertices per axis. Each must be > 1 and every
+                             benchmark is run at every size (default: [2])
+
+Examples:
+    # Defaults: 2 warmups, 2 timed iterations, dim size 2
+    ./t_blueprint_mesh_transform_benchmark
+
+    # 5 warmups, 20 timed iterations, dim size 2
+    ./t_blueprint_mesh_transform_benchmark 5 20
+
+    # 5 warmups, 20 timed iterations, at dim sizes 10, 20, and 40
+    ./t_blueprint_mesh_transform_benchmark 5 20 10 20 40
+
+If conduit was built with Caliper support, timing results are written to
+<YYYYmmdd_HHMMSS>.cali in the current directory, which can be plotted
+with src/tests/blueprint/plot_benchmark_output.py (cmake automatically
+copies it to the tests/blueprint folder for convenience).
+*/
+
 #include "conduit.hpp"
 #include "conduit_annotations.hpp"
 #include "conduit_benchmark.hpp"


### PR DESCRIPTION
This PR adds benchmarks for the rest of the APIs mentioned in #1637. It also makes improvements to the benchmarking infrastructure itself, backporting changes from the device-execution side as well as implementing new ideas I've been meaning to explore. This PR targets the `develop` branch so that its changes can be later merged into the device-support branch too.

Output nodes are now only created once and are `.reset()` instead of getting re-allocated many times. This seems to be a big performance improvement, as the overall benchmark time with all of the new benchmarks is now about the same as what it took to perform just the coordset and topology benchmarks before.

Everything (that can) is now using the `mesh::convert` API. AI helped me find other simplifications + improvements with respect to naming and reducing boilerplate.

I still need to review the plotting script changes, as they are purely AI-generated without me making sure they are sensible.