### PR TITLE
Fix memory leak in assume()

### DIFF
--- a/src/libs/conduit/conduit_data_accessor.cpp
+++ b/src/libs/conduit/conduit_data_accessor.cpp
@@ -597,6 +597,29 @@ DataAccessor<T>::sync()
                                                m_node_ptr->dtype().stride(),
                                                m_data,
                                                m_stride);
+
+        // By this point, m_data has been copied into m_node_ptr->data_ptr().
+        // We need to free our local copy of m_data, lest we leak memory.
+        if (m_do_i_own_it)
+        {
+            if (execution::DeviceMemory::is_device_ptr(m_data))
+            {
+                execution::DeviceMemory::deallocate(m_data);
+            }
+            else // if (!execution::DeviceMemory::is_device_ptr(m_data))
+            {
+                execution::HostMemory::deallocate(m_data);
+            }
+
+            m_do_i_own_it = false;
+            m_other_ptr = nullptr;
+            m_other_dtype = DataType::empty();
+        }
+
+        // Set m_data to the node's data and update offset and stride
+        m_data = m_node_ptr->data_ptr();
+        m_offset = dtype().offset();
+        m_stride = dtype().stride();
     }
 }
 
@@ -622,7 +645,16 @@ DataAccessor<T>::assume()
         // reset will deallocate the data the node points to
         m_node_ptr->reset();
         m_node_ptr->schema_ptr()->set(dtype());
-        m_node_ptr->set_data_ptr(m_data);
+
+        // Allow m_node_ptr to take ownership of m_data so that future
+        // release()/reset() calls will free it, lest we leak memory.
+        const index_t owning_allocator_id =
+            execution::DeviceMemory::is_device_ptr(m_data)
+                ? execution::get_device_allocator_id()
+                : execution::get_host_allocator_id();
+        m_node_ptr->take_data_ptr(m_data,
+                                  dtype().element_bytes() * number_of_elements(),
+                                  owning_allocator_id);
 
         // the assumed data is now the accessor's new original backing storage
         m_orig_data_ptr = m_data;

--- a/src/libs/conduit/conduit_data_accessor.cpp
+++ b/src/libs/conduit/conduit_data_accessor.cpp
@@ -597,29 +597,6 @@ DataAccessor<T>::sync()
                                                m_node_ptr->dtype().stride(),
                                                m_data,
                                                m_stride);
-
-        // By this point, m_data has been copied into m_node_ptr->data_ptr().
-        // We need to free our local copy of m_data, lest we leak memory.
-        if (m_do_i_own_it)
-        {
-            if (execution::DeviceMemory::is_device_ptr(m_data))
-            {
-                execution::DeviceMemory::deallocate(m_data);
-            }
-            else // if (!execution::DeviceMemory::is_device_ptr(m_data))
-            {
-                execution::HostMemory::deallocate(m_data);
-            }
-
-            m_do_i_own_it = false;
-            m_other_ptr = nullptr;
-            m_other_dtype = DataType::empty();
-        }
-
-        // Set m_data to the node's data and update offset and stride
-        m_data = m_node_ptr->data_ptr();
-        m_offset = dtype().offset();
-        m_stride = dtype().stride();
     }
 }
 

--- a/src/libs/conduit/conduit_data_accessor.cpp
+++ b/src/libs/conduit/conduit_data_accessor.cpp
@@ -629,9 +629,9 @@ DataAccessor<T>::assume()
             execution::DeviceMemory::is_device_ptr(m_data)
                 ? execution::get_device_allocator_id()
                 : execution::get_host_allocator_id();
-        m_node_ptr->take_data_ptr(m_data,
-                                  dtype().element_bytes() * number_of_elements(),
-                                  owning_allocator_id);
+        m_node_ptr->assume_data_ptr(m_data,
+                                    dtype().element_bytes() * number_of_elements(),
+                                    owning_allocator_id);
 
         // the assumed data is now the accessor's new original backing storage
         m_orig_data_ptr = m_data;

--- a/src/libs/conduit/conduit_data_array.cpp
+++ b/src/libs/conduit/conduit_data_array.cpp
@@ -739,29 +739,6 @@ DataArray<T>::sync()
                                                m_node_ptr->dtype().stride(),
                                                m_data,
                                                m_stride);
-
-        // By this point, m_data has been copied into m_node_ptr->data_ptr().
-        // We need to free our local copy of m_data, lest we leak memory.
-        if (m_do_i_own_it)
-        {
-            if (execution::DeviceMemory::is_device_ptr(m_data))
-            {
-                execution::DeviceMemory::deallocate(m_data);
-            }
-            else // if (!execution::DeviceMemory::is_device_ptr(m_data))
-            {
-                execution::HostMemory::deallocate(m_data);
-            }
-
-            m_do_i_own_it = false;
-            m_other_ptr = nullptr;
-            m_other_dtype = DataType::empty();
-        }
-
-        // Set m_data to the node's data and update offset and stride
-        m_data = m_node_ptr->data_ptr();
-        m_offset = dtype().offset();
-        m_stride = dtype().stride();
     }
 }
 

--- a/src/libs/conduit/conduit_data_array.cpp
+++ b/src/libs/conduit/conduit_data_array.cpp
@@ -771,9 +771,9 @@ DataArray<T>::assume()
             execution::DeviceMemory::is_device_ptr(m_data)
                 ? execution::get_device_allocator_id()
                 : execution::get_host_allocator_id();
-        m_node_ptr->take_data_ptr(m_data,
-                                  dtype().element_bytes() * number_of_elements(),
-                                  owning_allocator_id);
+        m_node_ptr->assume_data_ptr(m_data,
+                                    dtype().element_bytes() * number_of_elements(),
+                                    owning_allocator_id);
 
         // the assumed data is now the array's new original backing storage
         m_orig_data_ptr = m_data;

--- a/src/libs/conduit/conduit_data_array.cpp
+++ b/src/libs/conduit/conduit_data_array.cpp
@@ -739,6 +739,29 @@ DataArray<T>::sync()
                                                m_node_ptr->dtype().stride(),
                                                m_data,
                                                m_stride);
+
+        // By this point, m_data has been copied into m_node_ptr->data_ptr().
+        // We need to free our local copy of m_data, lest we leak memory.
+        if (m_do_i_own_it)
+        {
+            if (execution::DeviceMemory::is_device_ptr(m_data))
+            {
+                execution::DeviceMemory::deallocate(m_data);
+            }
+            else // if (!execution::DeviceMemory::is_device_ptr(m_data))
+            {
+                execution::HostMemory::deallocate(m_data);
+            }
+
+            m_do_i_own_it = false;
+            m_other_ptr = nullptr;
+            m_other_dtype = DataType::empty();
+        }
+
+        // Set m_data to the node's data and update offset and stride
+        m_data = m_node_ptr->data_ptr();
+        m_offset = dtype().offset();
+        m_stride = dtype().stride();
     }
 }
 
@@ -764,7 +787,16 @@ DataArray<T>::assume()
         // reset will deallocate the data the node points to
         m_node_ptr->reset();
         m_node_ptr->schema_ptr()->set(dtype());
-        m_node_ptr->set_data_ptr(m_data);
+
+        // Allow m_node_ptr to take ownership of m_data so that future
+        // release()/reset() calls will free it, lest we leak memory.
+        const index_t owning_allocator_id =
+            execution::DeviceMemory::is_device_ptr(m_data)
+                ? execution::get_device_allocator_id()
+                : execution::get_host_allocator_id();
+        m_node_ptr->take_data_ptr(m_data,
+                                  dtype().element_bytes() * number_of_elements(),
+                                  owning_allocator_id);
 
         // the assumed data is now the array's new original backing storage
         m_orig_data_ptr = m_data;

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -17595,6 +17595,19 @@ Node::set_data_ptr(void *data)
     m_data    = data;
 }
 
+//---------------------------------------------------------------------------//
+void
+Node::take_data_ptr(void *data_ptr,
+                    index_t data_size,
+                    index_t allocator_id)
+{
+    m_data         = data_ptr;
+    m_data_size    = data_size;
+    m_allocator_id = allocator_id;
+    m_alloced      = true;
+    m_mmaped       = false;
+}
+
 //-----------------------------------------------------------------------------
 //
 // -- end definition of Interface Warts --

--- a/src/libs/conduit/conduit_node.cpp
+++ b/src/libs/conduit/conduit_node.cpp
@@ -17597,9 +17597,9 @@ Node::set_data_ptr(void *data)
 
 //---------------------------------------------------------------------------//
 void
-Node::take_data_ptr(void *data_ptr,
-                    index_t data_size,
-                    index_t allocator_id)
+Node::assume_data_ptr(void *data_ptr,
+                      index_t data_size,
+                      index_t allocator_id)
 {
     m_data         = data_ptr;
     m_data_size    = data_size;

--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -4449,9 +4449,9 @@ private:
     /// Unlike set_data_ptr(), this lets the node take ownership of data_ptr, so
     /// that a later release()/reset() will free it.
     ///
-    void             take_data_ptr(void *data_ptr,
-                                   index_t data_size,
-                                   index_t allocator_id);
+    void             assume_data_ptr(void *data_ptr,
+                                     index_t data_size,
+                                     index_t allocator_id);
     ///
     /// Note: set_schema_ptr is *only* used in the case were we have
     /// a schema pointer that is owned by a parent schema. Using it to set a

--- a/src/libs/conduit/conduit_node.hpp
+++ b/src/libs/conduit/conduit_node.hpp
@@ -4446,6 +4446,13 @@ private:
 //-----------------------------------------------------------------------------
     void             set_data_ptr(void *data_ptr);
     ///
+    /// Unlike set_data_ptr(), this lets the node take ownership of data_ptr, so
+    /// that a later release()/reset() will free it.
+    ///
+    void             take_data_ptr(void *data_ptr,
+                                   index_t data_size,
+                                   index_t allocator_id);
+    ///
     /// Note: set_schema_ptr is *only* used in the case were we have
     /// a schema pointer that is owned by a parent schema. Using it to set a
     /// pointer that should be owned by a node unleashes chaos.

--- a/src/tests/conduit/execution_test_utils.hpp
+++ b/src/tests/conduit/execution_test_utils.hpp
@@ -16,6 +16,13 @@
 #include "conduit_execution.hpp"
 #include "conduit_memory_manager.hpp"
 
+#include <vector>
+#include "gtest/gtest.h"
+
+#if defined(CONDUIT_USE_DEVICE)
+#include <umpire/ResourceManager.hpp>
+#endif // defined(CONDUIT_USE_DEVICE)
+
 using namespace conduit;
 using conduit::execution::ExecutionPolicy;
 
@@ -390,5 +397,68 @@ run_data_array_reduction_and_sync(Node &node,
     // space as the requested execution policy.
     arr_des.sync();
 }
+
+#if defined(CONDUIT_USE_DEVICE)
+//-----------------------------------------------------------------------------
+inline size_t
+umpire_bytes_allocated(const char *pool_name)
+{
+    return umpire::ResourceManager::getInstance()
+               .getAllocator(pool_name)
+               .getCurrentSize();
+}
+
+//-----------------------------------------------------------------------------
+inline void
+expect_no_leak(void (*run_fn)(Node &, ExecutionPolicy),
+               index_t node_alloc_id,
+               ExecutionPolicy policy)
+{
+    const index_t n = 1024;
+    const std::vector<float64> src_vals(n, 1.0);
+    const std::vector<float64> des_vals(n, 0.0);
+
+    // Warm up run to make sure that both the host/device memory pools are
+    // created before we query their baseline sizes.
+    {
+        Node node;
+        node["src"].set_allocator(node_alloc_id);
+        node["des"].set_allocator(node_alloc_id);
+        node["src"].set(src_vals);
+        node["des"].set(des_vals);
+
+        // Calls sync/assume for us
+        run_fn(node, policy);
+
+        // This should free the memory allocated by sync/assume
+        node.reset();
+    }
+
+    // Record the baseline sizes of both the host/device memory pools
+    const size_t host_baseline = umpire_bytes_allocated("CONDUIT_HOST_POOL");
+    const size_t device_baseline = umpire_bytes_allocated("CONDUIT_DEVICE_POOL");
+
+    const int iterations = 4;
+    for (int i = 0; i < iterations; i++)
+    {
+        Node node;
+        node["src"].set_allocator(node_alloc_id);
+        node["des"].set_allocator(node_alloc_id);
+        node["src"].set(src_vals);
+        node["des"].set(des_vals);
+
+        // Calls sync/assume for us
+        run_fn(node, policy);
+
+        // This should free the memory allocated by sync/assume
+        node.reset();
+    }
+
+    // The memory allocated above should have been freed, so we expect both
+    // the host/device memory pools to be back to where they started.
+    EXPECT_EQ(umpire_bytes_allocated("CONDUIT_HOST_POOL"), host_baseline);
+    EXPECT_EQ(umpire_bytes_allocated("CONDUIT_DEVICE_POOL"), device_baseline);
+}
+#endif // defined(CONDUIT_USE_DEVICE)
 
 #endif

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -19,11 +19,9 @@
 #include <vector>
 #include "gtest/gtest.h"
 
-#if defined(CONDUIT_USE_CUDA)
-#include <cuda_runtime.h>
-#elif defined(CONDUIT_USE_HIP)
-#include <hip/hip_runtime.h>
-#endif // defined(CONDUIT_USE_HIP)
+#if defined(CONDUIT_USE_DEVICE)
+#include <umpire/ResourceManager.hpp>
+#endif // defined(CONDUIT_USE_DEVICE)
 
 using namespace conduit;
 using conduit::execution::ExecutionPolicy;
@@ -1430,95 +1428,127 @@ TEST(conduit_execution, strawman_data_array)
 #if defined(CONDUIT_USE_DEVICE)
 //-----------------------------------------------------------------------------
 static size_t
-used_device_bytes()
+umpire_bytes_allocated(const char *pool_name)
 {
-#if defined(CONDUIT_USE_CUDA)
-    size_t free_b = 0;
-    size_t total_b = 0;
-    cudaMemGetInfo(&free_b, &total_b);
-    return total_b - free_b;
-#elif defined(CONDUIT_USE_HIP)
-    size_t free_b = 0;
-    size_t total_b = 0;
-    hipMemGetInfo(&free_b, &total_b);
-    return total_b - free_b;
-#else // !defined(CONDUIT_USE_DEVICE)
-    return 0;
-#endif // !defined(CONDUIT_USE_DEVICE)
+    return umpire::ResourceManager::getInstance()
+               .getAllocator(pool_name)
+               .getCurrentSize();
 }
 
 //-----------------------------------------------------------------------------
 static void
 expect_no_leak(void (*run_fn)(Node &, ExecutionPolicy),
-              const char *label)
+               index_t node_alloc_id,
+               ExecutionPolicy policy)
 {
-    // The allocator pool reserves ~1GB on first use and never releases it.
-    // To check for a memory leak, we can do many small allocations in excess
-    // of 1GB and expect the allocator pool to never grow beyond 1GB. If it does,
-    // we are probably leaking memory.
-
-    // 2MB = 250 * 1000 float64 values
-    const index_t n = 250 * 1000;
+    const index_t n = 1024;
     const std::vector<float64> src_vals(n, 1.0);
-    const std::vector<float64> dst_vals(n, 0.0);
-    const ExecutionPolicy policy = ExecutionPolicy::device();
+    const std::vector<float64> des_vals(n, 0.0);
 
-    auto test_case = [&]()
+    // Warm up run to make sure that both the host/device memory pools are
+    // created before we query their baseline sizes.
     {
         Node node;
+        node["src"].set_allocator(node_alloc_id);
+        node["des"].set_allocator(node_alloc_id);
         node["src"].set(src_vals);
-        node["des"].set(dst_vals);
+        node["des"].set(des_vals);
 
-        // Calls sync or assume
+        // Calls sync/assume for us
         run_fn(node, policy);
 
-        // This should free the device memory allocated
-        // by sync/assume.
+        // This should free the memory allocated by sync/assume
         node.reset();
-    };
+    }
 
-    // Warm up run to ensure that the initial pool of memory is allocated.
-    test_case();
+    // Record the baseline sizes of both the host/device memory pools
+    const size_t host_baseline = umpire_bytes_allocated("CONDUIT_HOST_POOL");
+    const size_t device_baseline = umpire_bytes_allocated("CONDUIT_DEVICE_POOL");
 
-    const size_t baseline = used_device_bytes();
-
-    // 600 iterations * 2MB = ~1.2GB
-    const int iterations = 600;
+    const int iterations = 4;
     for (int i = 0; i < iterations; i++)
     {
-        test_case();
+        Node node;
+        node["src"].set_allocator(node_alloc_id);
+        node["des"].set_allocator(node_alloc_id);
+        node["src"].set(src_vals);
+        node["des"].set(des_vals);
+
+        // Calls sync/assume for us
+        run_fn(node, policy);
+
+        // This should free the memory allocated by sync/assume
+        node.reset();
     }
 
-    const size_t after = used_device_bytes();
-
-    size_t growth = 0;
-    if (after > baseline)
-    {
-        growth = after - baseline;
-    }
-
-    // All of the allocations were in 2MB increments. Despite allocating
-    // ~1.2GB in total, as long as we were deallocating correctly, we should
-    // expect growth to be zero.
-    EXPECT_LE(growth, 0);
+    // The memory allocated above should have been freed, so we expect both
+    // the host/device memory pools to be back to where they started.
+    EXPECT_EQ(umpire_bytes_allocated("CONDUIT_HOST_POOL"), host_baseline);
+    EXPECT_EQ(umpire_bytes_allocated("CONDUIT_DEVICE_POOL"), device_baseline);
 }
 
 //-----------------------------------------------------------------------------
-TEST(conduit_execution, no_memory_leak_on_sync_and_assume)
+TEST(conduit_execution, no_memory_leak_on_data_accessor_sync)
 {
     conduit_device_prepare();
 
-    // Data accessor tests
+    // Data originates on the host but is executed on the device
     expect_no_leak(run_data_accessor_policy_and_sync,
-                   "DataAccessor::sync()");
-    expect_no_leak(run_data_accessor_policy_and_assume,
-                   "DataAccessor::assume()");
+                   conduit::execution::get_host_allocator_id(),
+                   ExecutionPolicy::device());
 
-    // Data array tests
+    // Data originates on the device but is executed on the host
+    expect_no_leak(run_data_accessor_policy_and_sync,
+                   conduit::execution::get_device_allocator_id(),
+                   ExecutionPolicy::host());
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, no_memory_leak_on_data_accessor_assume)
+{
+    conduit_device_prepare();
+
+    // Data originates on the host but is executed on the device
+    expect_no_leak(run_data_accessor_policy_and_assume,
+                   conduit::execution::get_host_allocator_id(),
+                   ExecutionPolicy::device());
+
+    // Data originates on the device but is executed on the host
+    expect_no_leak(run_data_accessor_policy_and_assume,
+                   conduit::execution::get_device_allocator_id(),
+                   ExecutionPolicy::host());
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, no_memory_leak_on_data_array_sync)
+{
+    conduit_device_prepare();
+
+    // Data originates on the host but is executed on the device
     expect_no_leak(run_data_array_policy_and_sync,
-                   "DataArray::sync()");
+                   conduit::execution::get_host_allocator_id(),
+                   ExecutionPolicy::device());
+
+    // Data originates on the device but is executed on the host
+    expect_no_leak(run_data_array_policy_and_sync,
+                   conduit::execution::get_device_allocator_id(),
+                   ExecutionPolicy::host());
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, no_memory_leak_on_data_array_assume)
+{
+    conduit_device_prepare();
+
+    // Data originates on the host but is executed on the device
     expect_no_leak(run_data_array_policy_and_assume,
-                   "DataArray::assume()");
+                   conduit::execution::get_host_allocator_id(),
+                   ExecutionPolicy::device());
+
+    // Data originates on the device but is executed on the host
+    expect_no_leak(run_data_array_policy_and_assume,
+                   conduit::execution::get_device_allocator_id(),
+                   ExecutionPolicy::host());
 }
 #endif // defined(CONDUIT_USE_DEVICE)
 

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -19,10 +19,6 @@
 #include <vector>
 #include "gtest/gtest.h"
 
-#if defined(CONDUIT_USE_DEVICE)
-#include <umpire/ResourceManager.hpp>
-#endif // defined(CONDUIT_USE_DEVICE)
-
 using namespace conduit;
 using conduit::execution::ExecutionPolicy;
 
@@ -1426,67 +1422,6 @@ TEST(conduit_execution, strawman_data_array)
 }
 
 #if defined(CONDUIT_USE_DEVICE)
-//-----------------------------------------------------------------------------
-static size_t
-umpire_bytes_allocated(const char *pool_name)
-{
-    return umpire::ResourceManager::getInstance()
-               .getAllocator(pool_name)
-               .getCurrentSize();
-}
-
-//-----------------------------------------------------------------------------
-static void
-expect_no_leak(void (*run_fn)(Node &, ExecutionPolicy),
-               index_t node_alloc_id,
-               ExecutionPolicy policy)
-{
-    const index_t n = 1024;
-    const std::vector<float64> src_vals(n, 1.0);
-    const std::vector<float64> des_vals(n, 0.0);
-
-    // Warm up run to make sure that both the host/device memory pools are
-    // created before we query their baseline sizes.
-    {
-        Node node;
-        node["src"].set_allocator(node_alloc_id);
-        node["des"].set_allocator(node_alloc_id);
-        node["src"].set(src_vals);
-        node["des"].set(des_vals);
-
-        // Calls sync/assume for us
-        run_fn(node, policy);
-
-        // This should free the memory allocated by sync/assume
-        node.reset();
-    }
-
-    // Record the baseline sizes of both the host/device memory pools
-    const size_t host_baseline = umpire_bytes_allocated("CONDUIT_HOST_POOL");
-    const size_t device_baseline = umpire_bytes_allocated("CONDUIT_DEVICE_POOL");
-
-    const int iterations = 4;
-    for (int i = 0; i < iterations; i++)
-    {
-        Node node;
-        node["src"].set_allocator(node_alloc_id);
-        node["des"].set_allocator(node_alloc_id);
-        node["src"].set(src_vals);
-        node["des"].set(des_vals);
-
-        // Calls sync/assume for us
-        run_fn(node, policy);
-
-        // This should free the memory allocated by sync/assume
-        node.reset();
-    }
-
-    // The memory allocated above should have been freed, so we expect both
-    // the host/device memory pools to be back to where they started.
-    EXPECT_EQ(umpire_bytes_allocated("CONDUIT_HOST_POOL"), host_baseline);
-    EXPECT_EQ(umpire_bytes_allocated("CONDUIT_DEVICE_POOL"), device_baseline);
-}
-
 //-----------------------------------------------------------------------------
 TEST(conduit_execution, no_memory_leak_on_data_accessor_sync)
 {

--- a/src/tests/conduit/t_conduit_execution.cpp
+++ b/src/tests/conduit/t_conduit_execution.cpp
@@ -19,6 +19,12 @@
 #include <vector>
 #include "gtest/gtest.h"
 
+#if defined(CONDUIT_USE_CUDA)
+#include <cuda_runtime.h>
+#elif defined(CONDUIT_USE_HIP)
+#include <hip/hip_runtime.h>
+#endif // defined(CONDUIT_USE_HIP)
+
 using namespace conduit;
 using conduit::execution::ExecutionPolicy;
 
@@ -1420,6 +1426,101 @@ TEST(conduit_execution, strawman_data_array)
         }
     }
 }
+
+#if defined(CONDUIT_USE_DEVICE)
+//-----------------------------------------------------------------------------
+static size_t
+used_device_bytes()
+{
+#if defined(CONDUIT_USE_CUDA)
+    size_t free_b = 0;
+    size_t total_b = 0;
+    cudaMemGetInfo(&free_b, &total_b);
+    return total_b - free_b;
+#elif defined(CONDUIT_USE_HIP)
+    size_t free_b = 0;
+    size_t total_b = 0;
+    hipMemGetInfo(&free_b, &total_b);
+    return total_b - free_b;
+#else // !defined(CONDUIT_USE_DEVICE)
+    return 0;
+#endif // !defined(CONDUIT_USE_DEVICE)
+}
+
+//-----------------------------------------------------------------------------
+static void
+expect_no_leak(void (*run_fn)(Node &, ExecutionPolicy),
+              const char *label)
+{
+    // The allocator pool reserves ~1GB on first use and never releases it.
+    // To check for a memory leak, we can do many small allocations in excess
+    // of 1GB and expect the allocator pool to never grow beyond 1GB. If it does,
+    // we are probably leaking memory.
+
+    // 2MB = 250 * 1000 float64 values
+    const index_t n = 250 * 1000;
+    const std::vector<float64> src_vals(n, 1.0);
+    const std::vector<float64> dst_vals(n, 0.0);
+    const ExecutionPolicy policy = ExecutionPolicy::device();
+
+    auto test_case = [&]()
+    {
+        Node node;
+        node["src"].set(src_vals);
+        node["des"].set(dst_vals);
+
+        // Calls sync or assume
+        run_fn(node, policy);
+
+        // This should free the device memory allocated
+        // by sync/assume.
+        node.reset();
+    };
+
+    // Warm up run to ensure that the initial pool of memory is allocated.
+    test_case();
+
+    const size_t baseline = used_device_bytes();
+
+    // 600 iterations * 2MB = ~1.2GB
+    const int iterations = 600;
+    for (int i = 0; i < iterations; i++)
+    {
+        test_case();
+    }
+
+    const size_t after = used_device_bytes();
+
+    size_t growth = 0;
+    if (after > baseline)
+    {
+        growth = after - baseline;
+    }
+
+    // All of the allocations were in 2MB increments. Despite allocating
+    // ~1.2GB in total, as long as we were deallocating correctly, we should
+    // expect growth to be zero.
+    EXPECT_LE(growth, 0);
+}
+
+//-----------------------------------------------------------------------------
+TEST(conduit_execution, no_memory_leak_on_sync_and_assume)
+{
+    conduit_device_prepare();
+
+    // Data accessor tests
+    expect_no_leak(run_data_accessor_policy_and_sync,
+                   "DataAccessor::sync()");
+    expect_no_leak(run_data_accessor_policy_and_assume,
+                   "DataAccessor::assume()");
+
+    // Data array tests
+    expect_no_leak(run_data_array_policy_and_sync,
+                   "DataArray::sync()");
+    expect_no_leak(run_data_array_policy_and_assume,
+                   "DataArray::assume()");
+}
+#endif // defined(CONDUIT_USE_DEVICE)
 
 //-----------------------------------------------------------------------------
 void


### PR DESCRIPTION
This PR fixes a memory leak within the `assume()` implementation for both `DataAccessor` and `DataArray`.

After creating #1656, I was performing device-based test runs on my local PC to see how quick the new implementation was running relative to the old implementation. I noticed that I wasn't able to go above 256 dim test meshes on my GPU due to CUDA trying to allocate too much memory.

Maybe a 256 dim braid mesh is just too much for my 12GB of VRAM to handle, I thought. But by random chance, I simultaneously scaled the dim sizes down but increased the iteration count, and to my surprise, this also caused CUDA to ask for too much memory and crash. I did some digging to try to understand why device memory wasn't getting freed and believe I found the issue:

Previously, `assume()` was handing off a pointer to its execution location buffer without handing off ownership (i.e. letting the receiving node know that it was now holding allocated memory). This resulted in `.reset()` never actually freeing that memory. The fix is to set the necessary fields in the receiving node (in addition to the `data_ptr` itself) so that ownership of the buffer is effectively transferred.

I included a test that demonstrates the memory leak, which fails if the changes in this PR are reverted. I initially believed that `sync()` was leaking memory as well (which is why those tests are here), but splitting them into 4 separate tests proved that `sync()` was correctly cleaning up after itself.

I can now do hundreds of large mesh conversion tests without running out of device memory.