### PR TITLE
Shape map verify tests for int64 and int32 case

### DIFF
--- a/src/tests/blueprint/python/t_python_blueprint_mesh.py
+++ b/src/tests/blueprint/python/t_python_blueprint_mesh.py
@@ -346,6 +346,51 @@ class Test_Blueprint_Mesh(unittest.TestCase):
                     conduit.blueprint.mesh.convert(n, options, output)
                     conduit.blueprint.mesh.convert(n, options, output, maps)
 
+    def test_shape_map_int64_verify(self):
+        mesh = conduit.Node()
+        conduit.blueprint.mesh.examples.braid("mixed_2d", 2, 2, 0, mesh)
+        # state: 
+        #   ...
+        # coordsets: 
+        #   ...
+        # topologies: 
+        #   mesh: 
+        #     type: "unstructured"
+        #     coordset: "coords"
+        #     elements: 
+        #       shape: "mixed"
+        #       shape_map: 
+        #         quad: 9
+        #         tri: 5
+        #       shapes: ...
+        #       sizes: ...
+        #       offsets: ...
+        #       connectivity: ...
+        # fields: 
+        #   ...
+
+        info = conduit.Node()
+
+        quadnode = mesh.fetch("topologies/mesh/elements/shape_map/quad")
+        self.assertTrue(conduit.DataType.is_int32(quadnode.dtype()))
+        trinode = mesh.fetch("topologies/mesh/elements/shape_map/tri")
+        self.assertTrue(conduit.DataType.is_int32(trinode.dtype()))
+
+        self.assertTrue(conduit.blueprint.mesh.verify(mesh, info))
+
+        mesh["topologies/mesh/elements/shape_map"].remove_child("quad")
+        mesh["topologies/mesh/elements/shape_map"].remove_child("tri")
+        mesh["topologies/mesh/elements/shape_map/quad"].set(conduit.DataType.int64(1))
+        mesh["topologies/mesh/elements/shape_map/quad"] = 9
+        mesh["topologies/mesh/elements/shape_map/tri"].set(conduit.DataType.int64(1))
+        mesh["topologies/mesh/elements/shape_map/tri"] = 5
+
+        quadnode = mesh.fetch("topologies/mesh/elements/shape_map/quad")
+        self.assertTrue(conduit.DataType.is_int64(quadnode.dtype()))
+        trinode = mesh.fetch("topologies/mesh/elements/shape_map/tri")
+        self.assertTrue(conduit.DataType.is_int64(trinode.dtype()))
+
+        self.assertTrue(conduit.blueprint.mesh.verify(mesh, info))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/tests/blueprint/python/t_python_blueprint_mesh.py
+++ b/src/tests/blueprint/python/t_python_blueprint_mesh.py
@@ -9,6 +9,7 @@
 
 import sys
 import unittest
+import numpy as np
 
 import conduit.blueprint as blueprint
 
@@ -380,10 +381,8 @@ class Test_Blueprint_Mesh(unittest.TestCase):
 
         mesh["topologies/mesh/elements/shape_map"].remove_child("quad")
         mesh["topologies/mesh/elements/shape_map"].remove_child("tri")
-        mesh["topologies/mesh/elements/shape_map/quad"].set(conduit.DataType.int64(1))
-        mesh["topologies/mesh/elements/shape_map/quad"] = 9
-        mesh["topologies/mesh/elements/shape_map/tri"].set(conduit.DataType.int64(1))
-        mesh["topologies/mesh/elements/shape_map/tri"] = 5
+        mesh["topologies/mesh/elements/shape_map/quad"].set(np.int64(9))
+        mesh["topologies/mesh/elements/shape_map/tri"].set(np.int64(5))
 
         quadnode = mesh.fetch("topologies/mesh/elements/shape_map/quad")
         self.assertTrue(conduit.DataType.is_int64(quadnode.dtype()))

--- a/src/tests/blueprint/t_blueprint_mesh_verify.cpp
+++ b/src/tests/blueprint/t_blueprint_mesh_verify.cpp
@@ -2734,3 +2734,45 @@ TEST(conduit_blueprint_mesh_verify, empty_mesh_vs_gen_index)
     
 }
 
+//-----------------------------------------------------------------------------
+TEST(conduit_blueprint_mesh_verify, shape_map_int64_entries)
+{
+    Node mesh, info;
+    blueprint::mesh::examples::braid("mixed_2d", 2, 2, 0, mesh);
+
+    // state: 
+    //   ...
+    // coordsets: 
+    //   ...
+    // topologies: 
+    //   mesh: 
+    //     type: "unstructured"
+    //     coordset: "coords"
+    //     elements: 
+    //       shape: "mixed"
+    //       shape_map: 
+    //         quad: 9
+    //         tri: 5
+    //       shapes: [5, 5]
+    //       sizes: [3, 3]
+    //       offsets: [0, 3]
+    //       connectivity: [0, 1, 3, ..., 3, 2]
+    // fields: 
+    //   ...
+
+    EXPECT_EQ(mesh["topologies/mesh/elements/shape_map/quad"].dtype().id(), CONDUIT_INT32_ID);
+    EXPECT_EQ(mesh["topologies/mesh/elements/shape_map/tri"].dtype().id(), CONDUIT_INT32_ID);
+
+    EXPECT_TRUE(blueprint::mesh::verify(mesh, info));
+
+    mesh["topologies/mesh/elements/shape_map"].remove_child("quad");
+    mesh["topologies/mesh/elements/shape_map"].remove_child("tri");
+
+    mesh["topologies/mesh/elements/shape_map/quad"].set(static_cast<int64>(9));
+    EXPECT_EQ(mesh["topologies/mesh/elements/shape_map/quad"].dtype().id(), CONDUIT_INT64_ID);
+    mesh["topologies/mesh/elements/shape_map/tri"].set(static_cast<int64>(5));
+    EXPECT_EQ(mesh["topologies/mesh/elements/shape_map/tri"].dtype().id(), CONDUIT_INT64_ID);
+
+    EXPECT_TRUE(blueprint::mesh::verify(mesh, info));
+}
+


### PR DESCRIPTION
I did these while investigating #1660

It is unlikely to be broken again but it doesn't hurt to test just in case something is changed in the future.