### PR TITLE
Silence cmake policy warning for zlib, hdf5

### DIFF
--- a/src/config/conduit_setup_deps.cmake
+++ b/src/config/conduit_setup_deps.cmake
@@ -2,6 +2,12 @@
 # Project developers. See top-level LICENSE AND COPYRIGHT files for dates and
 # other details. No copyright assignment is required to contribute to Conduit.
 
+if(POLICY CMP0074)
+    #policy for <PackageName>_ROOT variables
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 include(CMakeFindDependencyMacro)
 
 # calc the proper relative install root
@@ -15,12 +21,6 @@ endif()
 
 # we want the import root, which is right above the "lib" prefix
 get_filename_component(_IMPORT_ROOT "${_IMPORT_PREFIX}" PATH)
-
-if(POLICY CMP0074)
-    #policy for <PackageName>_ROOT variables
-    cmake_policy(PUSH)
-    cmake_policy(SET CMP0074 NEW)
-endif()
 
 ###############################################################################
 # Setup Threads


### PR DESCRIPTION
This PR:
- Resolves a CMake warning issue seen inside axom related to finding zlib, hdf5 through conduit. Fix might be useful for other conduit users.

Axom issue: https://github.com/llnl/axom/issues/1954
Axom workaround to this: https://github.com/llnl/axom/pull/1955

Snippet of the warnings during axom CMake configuration:
```
-- Conduit was built with Zlib Support
-- Looking for Zlib at: /usr
CMake Warning (dev) at /usr/tce/backend/installations/linux-rhel8-x86_64/gcc-10.3.1/cmake-3.26.3-nz532rvfpaf5lf74zxmplgiobuhol7lu/share/cmake-3.26/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
 
  CMake variable ZLIB_ROOT is set to:
 
    /usr
 
  For compatibility, CMake is ignoring the variable.
Call Stack (most recent call first):
  /usr/WS1/han12/axom_codex/toss_4_x86_64_ib/2026_08_10_15_49_45/gcc-13.3.1/conduit-0.9.7-3ethi5hq6cf3c4m3a3wiryoxzjcmvqxy/lib/cmake/conduit/conduit_setup_deps.cmake:259 (find_dependency)
  /usr/WS1/han12/axom_codex/toss_4_x86_64_ib/2026_08_10_15_49_45/gcc-13.3.1/conduit-0.9.7-3ethi5hq6cf3c4m3a3wiryoxzjcmvqxy/lib/cmake/conduit/ConduitConfig.cmake:107 (include)
  /usr/tce/backend/installations/linux-rhel8-x86_64/gcc-10.3.1/cmake-3.26.3-nz532rvfpaf5lf74zxmplgiobuhol7lu/share/cmake-3.26/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  cmake/thirdparty/SetupAxomThirdParty.cmake:128 (find_dependency)
  cmake/CMakeBasics.cmake:21 (include)
  CMakeLists.txt:128 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
 
-- Found ZLIB: /usr/lib64/libz.so (found version "1.2.11") 
-- Conduit was built with HDF5 Support
-- Looking for HDF5 at: /usr/WS1/han12/axom_codex/toss_4_x86_64_ib/2026_08_10_15_49_45/gcc-13.3.1/hdf5-1.8.23-76p5uviz3qeuti4kluwdkiwpwtzhb7iv
CMake Warning (dev) at /usr/tce/backend/installations/linux-rhel8-x86_64/gcc-10.3.1/cmake-3.26.3-nz532rvfpaf5lf74zxmplgiobuhol7lu/share/cmake-3.26/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
 
  CMake variable HDF5_ROOT is set to:
 
    /usr/WS1/han12/axom_codex/toss_4_x86_64_ib/2026_08_10_15_49_45/gcc-13.3.1/hdf5-1.8.23-76p5uviz3qeuti4kluwdkiwpwtzhb7iv
 
  For compatibility, CMake is ignoring the variable.
Call Stack (most recent call first):
  /usr/WS1/han12/axom_codex/toss_4_x86_64_ib/2026_08_10_15_49_45/gcc-13.3.1/conduit-0.9.7-3ethi5hq6cf3c4m3a3wiryoxzjcmvqxy/lib/cmake/conduit/conduit_setup_deps.cmake:297 (find_dependency)
  /usr/WS1/han12/axom_codex/toss_4_x86_64_ib/2026_08_10_15_49_45/gcc-13.3.1/conduit-0.9.7-3ethi5hq6cf3c4m3a3wiryoxzjcmvqxy/lib/cmake/conduit/ConduitConfig.cmake:107 (include)
  /usr/tce/backend/installations/linux-rhel8-x86_64/gcc-10.3.1/cmake-3.26.3-nz532rvfpaf5lf74zxmplgiobuhol7lu/share/cmake-3.26/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  cmake/thirdparty/SetupAxomThirdParty.cmake:128 (find_dependency)
  cmake/CMakeBasics.cmake:21 (include)
  CMakeLists.txt:128 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```