### PR TITLE
python: Export variable giving install python modules path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 #### General
 - Turned python on by default in `build_conduit`.
+- Added `CONDUIT_PYTHONPATH`, the absolute path of Conduit's installed Python module, to Conduit's CMake config.
 
 ### Fixed
 

--- a/src/config/conduit_setup_targets.cmake
+++ b/src/config/conduit_setup_targets.cmake
@@ -84,18 +84,20 @@ if(CONDUIT_PYTHON_ENABLED)
     # Python Capsule API for conduit
     add_library(conduit::conduit_python INTERFACE IMPORTED)
 
-    # custom prefix allows the module to be installed outside of the
-    # conduit install, when given we use that exact path
+    # Build the absolute path to installed python modules here, since we know
+    # whether a custom prefix was used, as well as the install root
     if(CONDUIT_PYTHON_MODULE_CUSTOM_PREFIX)
-        set_property(TARGET conduit::conduit_python
-                     APPEND PROPERTY
-                     INTERFACE_INCLUDE_DIRECTORIES "${CONDUIT_PYTHON_MODULE_DIR}/conduit/")
-     else()
-         # default case, find the python headers relative to the install root
-         set_property(TARGET conduit::conduit_python
-                      APPEND PROPERTY
-                      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_ROOT}/${CONDUIT_PYTHON_MODULE_DIR}/conduit/")
-     endif()
+        # custom prefix allows the module to be installed outside of the
+        # conduit install, when given we use that exact path
+        set(CONDUIT_PYTHONPATH "${CONDUIT_PYTHON_MODULE_DIR}")
+    else()
+        set(CONDUIT_PYTHONPATH "${_IMPORT_ROOT}/${CONDUIT_PYTHON_MODULE_DIR}")
+    endif()
+
+    # Consumer convenience variable: export the python modules install path
+    set_property(TARGET conduit::conduit_python
+                 APPEND PROPERTY
+                 INTERFACE_INCLUDE_DIRECTORIES "${CONDUIT_PYTHONPATH}/conduit/")
 endif()
 
 # and if mpi enabled, a convenience target for remaining mpi deps (conduit::conduit_mpi)
@@ -128,6 +130,7 @@ if(NOT Conduit_FIND_QUIETLY)
     message(STATUS "CONDUIT_PYTHON_EXECUTABLE   = ${CONDUIT_PYTHON_EXECUTABLE}")
     message(STATUS "CONDUIT_PYTHON_MODULE_DIR   = ${CONDUIT_PYTHON_MODULE_DIR}")
     message(STATUS "CONDUIT_PYTHON_MODULE_CUSTOM_PREFIX = ${CONDUIT_PYTHON_MODULE_CUSTOM_PREFIX}")
+    message(STATUS "CONDUIT_PYTHONPATH          = ${CONDUIT_PYTHONPATH}")
 
     message(STATUS "CONDUIT_USE_FMT             = ${CONDUIT_USE_FMT}")
     message(STATUS "CONDUIT_USE_MPI             = ${CONDUIT_USE_MPI}")

--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -184,7 +184,7 @@ Conduit's build system provides an **install** target that installs the Conduit 
 Additional Build Notes
 ^^^^^^^^^^^^^^^^^^^^^^
 
-* **Python** - The Conduit Python module builds for both Python 2 and Python 3. To select a specific Python, set the CMake variable PYTHON_EXECUTABLE to path of the desired python binary. When ``PYTHON_MODULE_INSTALL_PREFIX`` is set and ``ENABLE_PYTHON=ON``, Conduit's Python modules will be installed to ``${PYTHON_MODULE_INSTALL_PREFIX}`` directory instead of ``${CMAKE_INSTALL_PREFIX}/python-modules``.
+* **Python** - The Conduit Python module builds for both Python 2 and Python 3. To select a specific Python, set the CMake variable PYTHON_EXECUTABLE to path of the desired python binary. When ``PYTHON_MODULE_INSTALL_PREFIX`` is set and ``ENABLE_PYTHON=ON``, Conduit's Python modules will be installed to ``${PYTHON_MODULE_INSTALL_PREFIX}`` directory instead of ``${CMAKE_INSTALL_PREFIX}/python-modules``. Either way, projects that find Conduit with CMake can use ``CONDUIT_PYTHONPATH`` to locate the installed module, for example to add it to ``PYTHONPATH``.
 
 * **MPI** - We use CMake's standard FindMPI logic. To select a specific MPI set the CMake variables ``MPI_C_COMPILER`` and ``MPI_CXX_COMPILER``, or the other FindMPI options for MPI include paths and MPI libraries. To run the mpi unit tests, you may also need change the CMake variables ``MPIEXEC_EXECUTABLE`` and ``MPIEXEC_NUMPROC_FLAG``, so you can use a different launcher, such as srun and set number of MPI tasks used.
 

--- a/src/examples/cpp_fort_and_py/CMakeLists.txt
+++ b/src/examples/cpp_fort_and_py/CMakeLists.txt
@@ -12,11 +12,15 @@
 # Note: The python instance must have the conduit python module installed
 # or it must be in your PYTHONPATH.
 #
+# CMake projects that find conduit can use CONDUIT_PYTHONPATH, which holds
+# the directory containing the conduit python module of the conduit that
+# was found.
+#
 # > mkdir build
 # > cd build
 # 
 # # if conduit python module is not installed in your python instance
-# # > export PYTHONPATH=/path/to/conduit-install/python-modules
+# # > export PYTHONPATH=${CONDUIT_PYTHONPATH}
 #
 # > cmake  \
 #    -DCONDUIT_DIR=/path/to/conduit/install
@@ -30,6 +34,7 @@
 # > ./conduit_fort_and_py_ex
 #
 # # if conduit python module is not installed in your python instance
+# # (the path reported as CONDUIT_PYTHONPATH when conduit was found)
 # > env PYTHONPATH=/path/to/conduit-install/python-modules  ./conduit_cpp_and_py_ex
 # > env PYTHONPATH=/path/to/conduit-install/python-modules  ./conduit_fort_and_py_ex
 ###############################################################################

--- a/src/examples/using-with-cmake/CMakeLists.txt
+++ b/src/examples/using-with-cmake/CMakeLists.txt
@@ -60,6 +60,18 @@ find_package(Conduit REQUIRED
              NO_DEFAULT_PATH 
              PATHS ${CONDUIT_DIR}/lib/cmake/conduit)
 
+#
+# If conduit was built with python support, CONDUIT_PYTHONPATH holds the
+# directory containing conduit's python module. Add it to PYTHONPATH to
+# import conduit from python.
+#
+if(CONDUIT_PYTHON_ENABLED)
+    message(STATUS "Conduit python module dir: ${CONDUIT_PYTHONPATH}")
+    if(NOT EXISTS ${CONDUIT_PYTHONPATH})
+        message(FATAL_ERROR "Conduit python module dir does not exist (${CONDUIT_PYTHONPATH})")
+    endif()
+endif()
+
 
 ################################################################
 # Option 2: import conduit using find_package search


### PR DESCRIPTION
Export a new variable, `CONDUIT_PYTHON_DIR`, giving the absolute installed location of Conduit's Python modules, regardless of whether a custom prefix was used, or the build was relocated.

Update install test to validate the module can be found in the advertised location, even if the install is relocated.