### PR TITLE
Add python build directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ install-*/
 .DS_Store
 src/examples/using-with-cmake/build
 src/examples/using-with-make/example
+src/libs/conduit/python/build/
+src/libs/conduit/python/conduit.egg-info/
 *.pyc
 .ipynb_checkpoints
 visitlog.py


### PR DESCRIPTION
`build_conduit.sh` enables python by default now, which generates its build directories under `src/libs/conduit/python/`.

I've been extra careful to avoid committing them, but it's only a matter of time...