### PR TITLE
cmake: register python tests with Python3_EXECUTABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project aspires to adhere to [Semantic Versioning](https://semver.org/s
 
 ### Fixed
 
+#### General
+- Fixed Python unit test registration to use `Python3_EXECUTABLE` instead of `PYTHON_EXECUTABLE`. Configuring with `-DPython3_EXECUTABLE` left the old variable empty, which registered every Python test with an empty program name (`ctest` reported `Could not find executable -B`) and made those tests unrunnable.
+
 #### Blueprint
 - Fixed more C++20 issues with runtime fmt params in Silo support implementation and tests.
 - Fixed an issue where the `conduit::blueprint::mesh::examples::venn()` example would produce incorrect output for large radii.

--- a/src/cmake/SetupTests.cmake
+++ b/src/cmake/SetupTests.cmake
@@ -130,7 +130,7 @@ function(add_python_test )
 
     message(STATUS " [*] Adding Python-based Unit Test: ${args_TEST}")
     add_test(NAME ${args_TEST} COMMAND
-             ${PYTHON_EXECUTABLE} -B -m unittest -v ${args_TEST})
+             ${Python3_EXECUTABLE} -B -m unittest -v ${args_TEST})
 
     # use proper env var path sep for current platform
     if(WIN32)
@@ -183,7 +183,7 @@ function(add_python_mpi_test)
                          "${multiValueArgs}" ${ARGN} )
 
     message(STATUS " [*] Adding Python-based MPI Unit Test: ${args_TEST}")
-    set(test_command ${PYTHON_EXECUTABLE} -B -m unittest -v ${args_TEST})
+    set(test_command ${Python3_EXECUTABLE} -B -m unittest -v ${args_TEST})
 
     # Handle mpi
     if ( ${args_NUM_MPI_TASKS} )


### PR DESCRIPTION
`SetupPython.cmake` sets `Python3_EXECUTABLE` from `PYTHON_EXECUTABLE`, but not the other way around, so configuring with `-DPython3_EXECUTABLE` leaves `PYTHON_EXECUTABLE` empty. At the same time, `add_python_test()` and `add_python_mpi_test()` still used the old name, which registered every python test with an empty program name, i.e.:

```
add_test(NAME t_python_conduit_smoke COMMAND "" -B -m unittest ...)
```

ctest then treated "-B" as the executable, reporting "Could not find executable -B" for each one, and the tests could not run.

Make the tests use `Python3_EXECUTABLE`, so that regardless of which cache variable is chosen by users, the tests can be run.