### PR TITLE
Simplify Windows CI fix

### DIFF
--- a/src/libs/conduit/conduit_data_accessor.hpp
+++ b/src/libs/conduit/conduit_data_accessor.hpp
@@ -471,7 +471,7 @@ private:
 // -- conduit::DataAccessor explicit instantiation declarations --
 //
 //-----------------------------------------------------------------------------
-#if defined(_WIN32) && defined(CONDUIT_WINDOWS_DLL_EXPORTS) && \
+#if defined(CONDUIT_WINDOWS_DLL_EXPORTS) && \
     !defined(CONDUIT_EXPORTS_DEFINED) && \
     !defined(CONDUIT_TU_IS_CUDA) && !defined(CONDUIT_TU_IS_HIP)
 

--- a/src/libs/conduit/conduit_data_array.hpp
+++ b/src/libs/conduit/conduit_data_array.hpp
@@ -555,7 +555,7 @@ private:
 // -- conduit::DataArray explicit instantiation declarations --
 //
 //-----------------------------------------------------------------------------
-#if defined(_WIN32) && defined(CONDUIT_WINDOWS_DLL_EXPORTS) && \
+#if defined(CONDUIT_WINDOWS_DLL_EXPORTS) && \
     !defined(CONDUIT_EXPORTS_DEFINED) && \
     !defined(CONDUIT_TU_IS_CUDA) && !defined(CONDUIT_TU_IS_HIP)
 


### PR DESCRIPTION
The latest fix to CI can be simplified. However, I couldn't make it more simple than this without creating new defines (which is an option).