### PR TITLE
Add a build option to control compilation of typed dispatch kernels

### DIFF
--- a/scripts/build_conduit/build_conduit.sh
+++ b/scripts/build_conduit/build_conduit.sh
@@ -51,6 +51,7 @@ build_zfp="${build_zfp:=false}"
 
 # conduit options
 build_conduit="${build_conduit:=true}"
+enable_typed_dispatch="${enable_typed_dispatch:=ON}"
 
 # see if we are building on windows
 build_windows="${build_windows:=OFF}"
@@ -869,6 +870,7 @@ echo 'set(ENABLE_TESTS ' ${enable_tests} ' CACHE BOOL "")' >> ${cmake_host_confi
 echo 'set(ENABLE_MPI ' ${enable_mpi} ' CACHE BOOL "")' >> ${cmake_host_config}
 echo 'set(ENABLE_FIND_MPI ' ${enable_find_mpi} ' CACHE BOOL "")' >> ${cmake_host_config}
 echo 'set(ENABLE_OPENMP ' ${enable_openmp} ' CACHE BOOL "")' >> ${cmake_host_config}
+echo 'set(ENABLE_TYPED_DISPATCH ' ${enable_typed_dispatch} ' CACHE BOOL "")' >> ${cmake_host_config}
 echo 'set(ENABLE_FORTRAN ' ${enable_fortran} ' CACHE BOOL "")' >> ${cmake_host_config}
 echo 'set(ENABLE_PYTHON ' ${enable_python} ' CACHE BOOL "")' >> ${cmake_host_config}
 if ${build_pyvenv}; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ option(ENABLE_MPI         "Build MPI Support"           OFF)
 option(ENABLE_OPENMP      "Build OpenMP Support"        OFF)
 option(ENABLE_CUDA        "Build CUDA Support"          OFF)
 option(ENABLE_HIP         "Build HIP Support"           OFF)
+option(ENABLE_TYPED_DISPATCH "Build typed dispatch kernels" OFF)
 
 option(ENABLE_YYJSON      "Use yyjson for JSON Parsing" ON)
 

--- a/src/cmake/CMakeBasics.cmake
+++ b/src/cmake/CMakeBasics.cmake
@@ -96,6 +96,11 @@ if(ENABLE_OPENMP)
     message(STATUS "OpenMP support enabled (CONDUIT_USE_OPENMP == TRUE)")
 endif()
 
+if(ENABLE_TYPED_DISPATCH)
+    set(CONDUIT_USE_TYPED_DISPATCH TRUE)
+    message(STATUS "Typed dispatch enabled (CONDUIT_USE_TYPED_DISPATCH == TRUE)")
+endif()
+
 ################################
 # Device Support
 ################################

--- a/src/docs/sphinx/building.rst
+++ b/src/docs/sphinx/building.rst
@@ -103,6 +103,10 @@ Main CMake Options
      - Controls if Conduit OpenMP features are built.
      - *(default = OFF)*
 
+   * - ``ENABLE_TYPED_DISPATCH``
+     - Controls if ``execution::dispatch`` compiles typed kernel instantiations. Signifantly improves the performance of data-parallel kernels, at the cost of longer compile times and larger libraries.
+     - *(default = OFF)*
+
    * - ``ENABLE_TESTS``
      - Controls if unit tests are built.
      - *(default = ON)*

--- a/src/docs/sphinx/data_parallel_execution_model.rst
+++ b/src/docs/sphinx/data_parallel_execution_model.rst
@@ -334,8 +334,9 @@ Improve DataView Performance with Dispatch
 
 Because the kernel's view parameters are ``auto``, the compiler instantiates the kernel once per possible underlying dtype + one fallback (11 instantiations per ``DataAccessor`` or 2 per ``DataArray``). Three overloads cover the existing use cases in the codebase: a single view, a pair of views whose dtypes may differ (each side dispatched independently), and a group of three views of the same accessor type, which upgrades only when all three share one dtype. More overloads may be added as new use cases arise.
 
+The typed view instantiations are only compiled when Conduit is configured with ``ENABLE_TYPED_DISPATCH=ON``. Otherwise, ``dispatch()`` always invokes the kernel with the original DataView, so kernels stay correct but don't get the typed view speedup.
+
 Blueprint Port Status
 ---------------------
 
 The :ref:`Mesh Blueprint <mesh_blueprint>` ``mesh::convert`` API is in the process of being ported to the execution model. Currently, the mesh-to-mesh conversions (coordset and topology conversions) are supported. Additional transforms and internal operations are being ported over time. Until a transform is ported, it will continue to execute on the host exactly as before.
-

--- a/src/libs/conduit/conduit_config.h.in
+++ b/src/libs/conduit/conduit_config.h.in
@@ -63,6 +63,8 @@
 
 #cmakedefine CONDUIT_USE_OPENMP
 
+#cmakedefine CONDUIT_USE_TYPED_DISPATCH
+
 #cmakedefine CONDUIT_USE_PARMETIS
 
 #cmakedefine CONDUIT_USE_TOTALVIEW

--- a/src/libs/conduit/conduit_execution_dispatch.hpp
+++ b/src/libs/conduit/conduit_execution_dispatch.hpp
@@ -433,12 +433,14 @@ template <template <typename> class DataView,
 void
 dispatch(const DataView<T> &view, Kernel &&kernel)
 {
+#if defined(CONDUIT_USE_TYPED_DISPATCH)
     if (detail::is_upgradeable(view) &&
         detail::try_typed_view(view, kernel))
     {
         // The conditions were met to invoke the kernel with a typed view
         return;
     }
+#endif
     // The conditions were not met to invoke the kernel with a typed view,
     // so we directly invoke it with the provided DataView instead.
     kernel(view);
@@ -479,12 +481,14 @@ dispatch(const DataView<T> &view0,
          const DataView<T> &view2,
          Kernel &&kernel)
 {
+#if defined(CONDUIT_USE_TYPED_DISPATCH)
     if (detail::is_upgradeable_group(view0, view1, view2) &&
         detail::try_typed_view(view0, view1, view2, kernel))
     {
         // The conditions were met to invoke the kernel with typed views
         return;
     }
+#endif
     // The conditions were not met to invoke the kernel with typed views,
     // so we directly invoke it with the provided DataViews instead.
     kernel(view0, view1, view2);
@@ -502,12 +506,14 @@ dispatch(const DataView<T> &view0,
          const DataView<T> &view3,
          Kernel &&kernel)
 {
+#if defined(CONDUIT_USE_TYPED_DISPATCH)
     if (detail::is_upgradeable_group(view0, view1, view2, view3) &&
         detail::try_typed_view(view0, view1, view2, view3, kernel))
     {
         // The conditions were met to invoke the kernel with typed views
         return;
     }
+#endif
     // The conditions were not met to invoke the kernel with typed views,
     // so we directly invoke it with the provided DataViews instead.
     kernel(view0, view1, view2, view3);

--- a/src/tests/conduit/execution_test_utils.hpp
+++ b/src/tests/conduit/execution_test_utils.hpp
@@ -492,6 +492,14 @@ expect_no_leak(void (*run_fn)(Node &, ExecutionPolicy),
 //
 
 //-----------------------------------------------------------------------------
+// Whether dispatch() upgrades compact views to typed views in this build
+#if defined(CONDUIT_USE_TYPED_DISPATCH)
+const bool TYPED_DISPATCH_ENABLED = true;
+#else
+const bool TYPED_DISPATCH_ENABLED = false;
+#endif
+
+//-----------------------------------------------------------------------------
 // Verifies that the input is a typed view (not a DataAccessor or DataArray)
 template <typename TypedView>
 bool
@@ -756,14 +764,14 @@ check_single_dtype_dispatch(const std::vector<T> &vals,
     float64_accessor acc(node["vals"]);
 
     std::vector<float64> read_vals(static_cast<size_t>(size), 0.0);
-    EXPECT_TRUE(run_copy_out(policy, acc, read_vals.data()));
+    EXPECT_EQ(run_copy_out(policy, acc, read_vals.data()), TYPED_DISPATCH_ENABLED);
     for (index_t i = 0; i < size; i++)
     {
         const size_t idx = static_cast<size_t>(i);
         EXPECT_EQ(read_vals[idx], static_cast<float64>(vals[idx]));
     }
 
-    EXPECT_TRUE(run_inplace_scale(policy, acc));
+    EXPECT_EQ(run_inplace_scale(policy, acc), TYPED_DISPATCH_ENABLED);
 
     conduit::DataArray<T> res(node["vals"]);
     for (index_t i = 0; i < size; i++)

--- a/src/tests/conduit/t_conduit_execution_dispatch.cpp
+++ b/src/tests/conduit/t_conduit_execution_dispatch.cpp
@@ -34,7 +34,7 @@ TEST(conduit_execution_dispatch, single_accessor)
         std::vector<float64> buffer(static_cast<size_t>(size), 1.5);
         float64_accessor acc(buffer.data(), DataType::float64(size));
 
-        EXPECT_TRUE(run_inplace_scale(policy, acc));
+        EXPECT_EQ(run_inplace_scale(policy, acc), TYPED_DISPATCH_ENABLED);
 
         for (index_t i = 0; i < size; i++)
         {
@@ -48,7 +48,7 @@ TEST(conduit_execution_dispatch, single_accessor)
         buffer[0] = -1.0;
         float64_accessor acc(buffer.data(), DataType::float64(size, sizeof(float64)));
 
-        EXPECT_TRUE(run_inplace_scale(policy, acc));
+        EXPECT_EQ(run_inplace_scale(policy, acc), TYPED_DISPATCH_ENABLED);
 
         // The first element was not part of the DataAccessor, so it should not
         // have been modified.
@@ -73,7 +73,7 @@ TEST(conduit_execution_dispatch, single_accessor)
         float64_accessor typed_acc(node["typed"]);
         float64_accessor acc(node["acc"]);
 
-        EXPECT_TRUE(run_inplace_scale(policy, typed_acc));
+        EXPECT_EQ(run_inplace_scale(policy, typed_acc), TYPED_DISPATCH_ENABLED);
         run_scale_kernel(policy, size, acc, acc);
 
         float32_array typed_res(node["typed"]);
@@ -115,7 +115,7 @@ TEST(conduit_execution_dispatch, single_array)
         std::vector<float64> buffer(static_cast<size_t>(size), 1.5);
         float64_array view(buffer.data(), DataType::float64(size));
 
-        EXPECT_TRUE(run_inplace_scale(policy, view));
+        EXPECT_EQ(run_inplace_scale(policy, view), TYPED_DISPATCH_ENABLED);
 
         for (index_t i = 0; i < size; i++)
         {
@@ -129,7 +129,7 @@ TEST(conduit_execution_dispatch, single_array)
         buffer[0] = -1.0;
         float64_array view(buffer.data(), DataType::float64(size, sizeof(float64)));
 
-        EXPECT_TRUE(run_inplace_scale(policy, view));
+        EXPECT_EQ(run_inplace_scale(policy, view), TYPED_DISPATCH_ENABLED);
 
         // The first element was not part of the DataArray, so it should not
         // have been modified.
@@ -154,7 +154,7 @@ TEST(conduit_execution_dispatch, single_array)
         float32_array typed_view(node["typed"]);
         float32_array view(node["view"]);
 
-        EXPECT_TRUE(run_inplace_scale(policy, typed_view));
+        EXPECT_EQ(run_inplace_scale(policy, typed_view), TYPED_DISPATCH_ENABLED);
         run_scale_kernel(policy, size, view, view);
 
         float32_array typed_res(node["typed"]);
@@ -243,8 +243,8 @@ TEST(conduit_execution_dispatch, accessor_pair)
                        src_is_direct,
                        dst_is_direct);
 
-        EXPECT_TRUE(src_is_direct);
-        EXPECT_TRUE(dst_is_direct);
+        EXPECT_EQ(src_is_direct, TYPED_DISPATCH_ENABLED);
+        EXPECT_EQ(dst_is_direct, TYPED_DISPATCH_ENABLED);
 
         float64_array res(node["des"]);
         for (index_t i = 0; i < size; i++)
@@ -271,7 +271,7 @@ TEST(conduit_execution_dispatch, accessor_pair)
                        dst_is_direct);
 
         EXPECT_FALSE(src_is_direct);
-        EXPECT_TRUE(dst_is_direct);
+        EXPECT_EQ(dst_is_direct, TYPED_DISPATCH_ENABLED);
 
         for (index_t i = 0; i < size; i++)
         {
@@ -308,8 +308,8 @@ TEST(conduit_execution_dispatch, array_pair)
                        src_is_direct,
                        dst_is_direct);
 
-        EXPECT_TRUE(src_is_direct);
-        EXPECT_TRUE(dst_is_direct);
+        EXPECT_EQ(src_is_direct, TYPED_DISPATCH_ENABLED);
+        EXPECT_EQ(dst_is_direct, TYPED_DISPATCH_ENABLED);
 
         float64_array res(node["des"]);
         for (index_t i = 0; i < size; i++)
@@ -335,7 +335,7 @@ TEST(conduit_execution_dispatch, array_pair)
                        dst_is_direct);
 
         EXPECT_FALSE(src_is_direct);
-        EXPECT_TRUE(dst_is_direct);
+        EXPECT_EQ(dst_is_direct, TYPED_DISPATCH_ENABLED);
 
         for (index_t i = 0; i < size; i++)
         {
@@ -366,7 +366,7 @@ TEST(conduit_execution_dispatch, accessor_group)
     // The group shares one compact dtype, so it is upgraded. Swapping in
     // a member of another dtype causes the whole group to use plain
     // DataAccessors.
-    check_group_sum(policy, x_acc, y_acc, z_acc, true);
+    check_group_sum(policy, x_acc, y_acc, z_acc, TYPED_DISPATCH_ENABLED);
 
     // Compact, but not the dtype the other members share, so this doesn't get
     // upgraded.
@@ -395,7 +395,7 @@ TEST(conduit_execution_dispatch, array_group)
     const float64_array z_view(node["z"]);
 
     // The group shares one compact dtype, so it is upgraded
-    check_group_sum(policy, x_view, y_view, z_view, true);
+    check_group_sum(policy, x_view, y_view, z_view, TYPED_DISPATCH_ENABLED);
 
     // Swapping in a strided member causes the whole group to use plain
     // DataArrays.
@@ -422,7 +422,7 @@ run_test_single_policies()
 
         acc.use_with(policy);
 
-        EXPECT_TRUE(run_inplace_scale(policy, acc));
+        EXPECT_EQ(run_inplace_scale(policy, acc), TYPED_DISPATCH_ENABLED);
 
         acc.sync();
 
@@ -460,8 +460,8 @@ run_test_pair_policies()
         run_pair_scale(policy,
                        src_view, dst_acc, src_is_direct, dst_is_direct);
 
-        EXPECT_TRUE(src_is_direct);
-        EXPECT_TRUE(dst_is_direct);
+        EXPECT_EQ(src_is_direct, TYPED_DISPATCH_ENABLED);
+        EXPECT_EQ(dst_is_direct, TYPED_DISPATCH_ENABLED);
 
         dst_acc.sync();
 
@@ -502,11 +502,11 @@ run_test_group_policies()
         z_acc.use_with(policy);
         dst_acc.use_with(policy);
 
-        EXPECT_TRUE(run_group_sum(policy,
-                                  x_acc,
-                                  y_acc,
-                                  z_acc,
-                                  dst_acc));
+        EXPECT_EQ(run_group_sum(policy,
+                                x_acc,
+                                y_acc,
+                                z_acc,
+                                dst_acc), TYPED_DISPATCH_ENABLED);
 
         dst_acc.sync();
 


### PR DESCRIPTION
This PR makes typed dispatches a build option, meaning that the extra typed kernel instantiations it generates will not be compiled if the option is turned off. The fallback kernels are always generated, so this option will never break functionality. For static builds, I saw local compile times improve by ~25% and the total build directory size reduce by ~33%.

I've defaulted it to off within cmake to fix our CI woes, but have left it defaulted to on within `build_conduit.sh` as I see that there is precedent for splitting the decision like this (python off in cmake but on in build_conduit, tests on in cmake but off in build_conduit, etc).

Closes #1691.